### PR TITLE
setup.py: fix wheel building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ build
 dist
 *.egg-info
 *.pyc
+# Third-party links created by `setup.py develop`
+deep_gemm/include/cute
+deep_gemm/include/cutlass


### PR DESCRIPTION
Existing PostInstallCommand works for `setup.py install` but not for `setup.py bdist_wheel` which is useful for prebuilding packages.