### PR TITLE
pytest Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,11 @@ git clone --recursive git@github.com:deepseek-ai/DeepGEMM.git
 python setup.py develop
 
 # Test JIT compilation
-python tests/test_jit.py
+pip install pytest
+pytest tests/test_jit.py -v -s
 
 # Test all GEMM implements (normal, contiguous-grouped and masked-grouped)
-python tests/test_core.py
+pytest tests/test_core.py -v -s
 ```
 
 ### Installation

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,10 +1,16 @@
+import pytest
 import random
 import torch
 from typing import Tuple
 
 import deep_gemm
-from deep_gemm import bench_kineto, calc_diff, cell_div, get_col_major_tma_aligned_tensor
+from deep_gemm import bench_kineto, calc_diff, ceil_div, get_col_major_tma_aligned_tensor
 
+# Set seeds and TF32 flags up front
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.manual_seed(0)
+random.seed(0)
 
 def per_token_cast_to_fp8(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     assert x.dim() == 2 and x.size(1) % 128 == 0
@@ -13,17 +19,15 @@ def per_token_cast_to_fp8(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     x_amax = x_view.abs().float().amax(dim=2).view(m, -1).clamp(1e-4)
     return (x_view * (448.0 / x_amax.unsqueeze(2))).to(torch.float8_e4m3fn).view(m, n), (x_amax / 448.0).view(m, -1)
 
-
 def per_block_cast_to_fp8(x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     assert x.dim() == 2
     m, n = x.shape
-    x_padded = torch.zeros((cell_div(m, 128) * 128, cell_div(n, 128) * 128), dtype=x.dtype, device=x.device)
+    x_padded = torch.zeros((ceil_div(m, 128) * 128, ceil_div(n, 128) * 128), dtype=x.dtype, device=x.device)
     x_padded[:m, :n] = x
     x_view = x_padded.view(-1, 128, x_padded.size(1) // 128, 128)
     x_amax = x_view.abs().float().amax(dim=(1, 3), keepdim=True).clamp(1e-4)
     x_scaled = (x_view * (448.0 / x_amax)).to(torch.float8_e4m3fn)
     return x_scaled.view_as(x_padded)[:m, :n].contiguous(), (x_amax / 448.0).view(x_view.size(0), x_view.size(2))
-
 
 def construct(m: int, k: int, n: int) -> \
         Tuple[Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor], torch.Tensor, torch.Tensor]:
@@ -37,7 +41,6 @@ def construct(m: int, k: int, n: int) -> \
     x_fp8 = (x_fp8[0], get_col_major_tma_aligned_tensor(x_fp8[1]))
     return x_fp8, y_fp8, out, ref_out
 
-
 def construct_grouped(num_groups: int, m: int, k: int, n: int, is_masked: bool) -> \
         Tuple[Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor], torch.Tensor, torch.Tensor]:
     x = torch.randn((num_groups, m, k), device='cuda', dtype=torch.bfloat16)
@@ -46,8 +49,14 @@ def construct_grouped(num_groups: int, m: int, k: int, n: int, is_masked: bool) 
     ref_out = torch.einsum('gmk,gnk->gmn', x, y)
 
     assert m % 4 == 0, f'TMA alignment error: {m}'
-    x_fp8 = (torch.empty_like(x, dtype=torch.float8_e4m3fn), torch.empty((num_groups, m, k // 128), device='cuda', dtype=torch.float))
-    y_fp8 = (torch.empty_like(y, dtype=torch.float8_e4m3fn), torch.empty((num_groups, (n + 127) // 128, k // 128), device='cuda', dtype=torch.float))
+    x_fp8 = (
+        torch.empty_like(x, dtype=torch.float8_e4m3fn),
+        torch.empty((num_groups, m, k // 128), device='cuda', dtype=torch.float)
+    )
+    y_fp8 = (
+        torch.empty_like(y, dtype=torch.float8_e4m3fn),
+        torch.empty((num_groups, (n + 127) // 128, k // 128), device='cuda', dtype=torch.float)
+    )
     for i in range(num_groups):
         x_fp8[0][i], x_fp8[1][i] = per_token_cast_to_fp8(x[i])
         y_fp8[0][i], y_fp8[1][i] = per_block_cast_to_fp8(y[i])
@@ -61,98 +70,86 @@ def construct_grouped(num_groups: int, m: int, k: int, n: int, is_masked: bool) 
     x_fp8 = (x_fp8[0], get_col_major_tma_aligned_tensor(x_fp8[1]))
     return x_fp8, y_fp8, out, ref_out
 
+@pytest.mark.parametrize("m", [64, 128, 4096])
+@pytest.mark.parametrize("k,n", [(7168, 2112), (1536, 24576), (512, 32768), (16384, 7168), (7168, 4096), (2048, 7168)])
+def test_gemm(m, k, n):
+    """Test single GEMM with various dimensions."""
+    x_fp8, y_fp8, out, ref_out = construct(m, k, n)
+    deep_gemm.gemm_fp8_fp8_bf16_nt(x_fp8, y_fp8, out)
+    diff = calc_diff(out, ref_out)
+    assert diff < 0.001, f'GEMM mismatch: m={m}, k={k}, n={n}, diff={diff:.5f}'
 
-def test_gemm() -> None:
-    print('Testing GEMM:')
-    for m in (64, 128, 4096):
-        for k, n in [(7168, 2112), (1536, 24576), (512, 32768), (16384, 7168), (7168, 4096), (2048, 7168)]:
-            x_fp8, y_fp8, out, ref_out = construct(m, k, n)
-            deep_gemm.gemm_fp8_fp8_bf16_nt(x_fp8, y_fp8, out)
-            diff = calc_diff(out, ref_out)
-            assert diff < 0.001, f'{m=}, {k=}, {n=}, {diff:.5f}'
+    # (Optional) performance timing
+    def test_func():
+        # Construct new tensors every time to avoid L2 cache effects
+        x_fp8_local, y_fp8_local, out_local, _ = construct(m, k, n)
+        deep_gemm.gemm_fp8_fp8_bf16_nt(x_fp8_local, y_fp8_local, out_local)
 
-            # noinspection PyShadowingNames
-            def test_func():
-                # Construct new tensors every time to avoid L2 cache acceleration
-                x_fp8, y_fp8, out, ref_out = construct(m, k, n)
-                deep_gemm.gemm_fp8_fp8_bf16_nt(x_fp8, y_fp8, out)
+    t = bench_kineto(test_func, 'fp8_gemm', suppress_kineto_output=True)
+    print(f'[test_gemm] (m={m:5}, n={n:5}, k={k:5}): {t * 1e6:6.0f} us | '
+          f'{2 * m * n * k / t / 1e12:5.2f} TFLOPS')
 
-            t = bench_kineto(test_func, 'fp8_gemm', suppress_kineto_output=True)
-            print(f' > Performance (m={m:5}, n={n:5}, k={k:5}): {t * 1e6:4.0f} us | '
-                  f'throughput: {2 * m * n * k / t / 1e12:4.0f} TFLOPS, '
-                  f'{(m * k + k * n + m * n * 2) / 1e9 / t:4.0f} GB/s')
-    print()
+@pytest.mark.parametrize("num_groups,m,k,n", [
+    (4, 8192, 7168, 4096),
+    (4, 8192, 2048, 7168),
+    (8, 4096, 7168, 4096),
+    (8, 4096, 2048, 7168)
+])
+def test_m_grouped_gemm_contiguous(num_groups, m, k, n):
+    """Test grouped GEMM with merged group+M dimension."""
+    x_fp8, y_fp8, out, ref_out = construct_grouped(num_groups, m, k, n, is_masked=False)
+    m_indices = torch.arange(0, num_groups, device='cuda', dtype=torch.int)
+    m_indices = m_indices.unsqueeze(-1).expand(num_groups, m).contiguous().view(-1)
+    deep_gemm.m_grouped_gemm_fp8_fp8_bf16_nt_contiguous(x_fp8, y_fp8, out, m_indices)
+    diff = calc_diff(out, ref_out)
+    assert diff < 0.001, f'Grouped GEMM mismatch: m={m*num_groups}, k={k}, n={n}, diff={diff:.5f}'
 
+    # (Optional) performance timing
+    def test_func():
+        x_fp8_local, y_fp8_local, out_local, _ = construct_grouped(num_groups, m, k, n, is_masked=False)
+        m_indices_local = torch.arange(0, num_groups, device='cuda', dtype=torch.int)
+        m_indices_local = m_indices_local.unsqueeze(-1).expand(num_groups, m).contiguous().view(-1)
+        deep_gemm.m_grouped_gemm_fp8_fp8_bf16_nt_contiguous(x_fp8_local, y_fp8_local, out_local, m_indices_local)
 
-def test_m_grouped_gemm_contiguous() -> None:
-    print('Testing grouped contiguous GEMM:')
+    t = bench_kineto(test_func, 'fp8_gemm', suppress_kineto_output=True)
+    print(f'[test_m_grouped_gemm_contiguous] (groups={num_groups}, m={m}, n={n}, k={k}): '
+          f'{t * 1e6:6.0f} us | {2 * num_groups * m * n * k / t / 1e12:5.2f} TFLOPS')
 
-    for num_groups, m, k, n in ((4, 8192, 7168, 4096), (4, 8192, 2048, 7168), (8, 4096, 7168, 4096), (8, 4096, 2048, 7168)):
-        # TODO: make a stronger test
-        x_fp8, y_fp8, out, ref_out = construct_grouped(num_groups, m, k, n, is_masked=False)
-        m_indices = torch.arange(0, num_groups, device='cuda', dtype=torch.int)
-        m_indices = m_indices.unsqueeze(-1).expand(num_groups, m).contiguous().view(-1)
-        deep_gemm.m_grouped_gemm_fp8_fp8_bf16_nt_contiguous(x_fp8, y_fp8, out, m_indices)
-        diff = calc_diff(out, ref_out)
-        assert diff < 0.001, f'm={m * num_groups}, {k=}, {n=}, {diff:.5f}'
+@pytest.mark.parametrize("num_groups,m", [
+    (1, 1024),
+    (2, 512),
+    (4, 256),
+])
+@pytest.mark.parametrize("k,n", [
+    (7168, 4096),
+    (2048, 7168),
+])
+def test_m_grouped_gemm_masked(num_groups, m, k, n):
+    """Test grouped GEMM where each group can have a different 'masked' M dimension."""
+    # Test correctness with random partial masks
+    masked_m_candidates = list(filter(lambda candidate: candidate <= m, (64, 128, 192, 256, 320, 384)))
+    for _ in range(10):
+        x_fp8, y_fp8, out, ref_out = construct_grouped(num_groups, m, k, n, is_masked=True)
+        masked_m = torch.empty((num_groups,), device='cuda', dtype=torch.int)
+        for j in range(num_groups):
+            masked_m[j] = random.choice(masked_m_candidates)
+        # We pick an expected M that covers the average usage
+        expected_m = min(int(masked_m.float().mean()) + 1, m)
+        deep_gemm.m_grouped_gemm_fp8_fp8_bf16_nt_masked(x_fp8, y_fp8, out, masked_m, expected_m)
 
-        # noinspection PyShadowingNames
-        def test_func():
-            # Construct new tensors every time to avoid L2 cache acceleration
-            x_fp8, y_fp8, out, ref_out = construct_grouped(num_groups, m, k, n, is_masked=False)
-            m_indices = torch.arange(0, num_groups, device='cuda', dtype=torch.int)
-            m_indices = m_indices.unsqueeze(-1).expand(num_groups, m).contiguous().view(-1)
-            deep_gemm.m_grouped_gemm_fp8_fp8_bf16_nt_contiguous(x_fp8, y_fp8, out, m_indices)
+        for j in range(num_groups):
+            diff = calc_diff(out[j, :masked_m[j].item()], ref_out[j, :masked_m[j].item()])
+            assert diff < 0.001, (
+                f'Grouped Masked GEMM mismatch: m={m}, k={k}, n={n}, group={j}, '
+                f'masked_m={masked_m[j]}, groups={num_groups}, diff={diff:.5f}'
+            )
 
-        t = bench_kineto(test_func, 'fp8_gemm', suppress_kineto_output=True)
-        print(f' > Performance ({num_groups=}, m_per_group={m:4}, n={n:4}, k={k:4}): {t * 1e6:4.0f} us | '
-              f'throughput: {2 * num_groups * m * n * k / t / 1e12:4.0f} TFLOPS, '
-              f'{(num_groups * (m * k + k * n + m * n * 2)) / 1e9 / t:4.0f} GB/s')
-    print()
+    # Test performance with full dimension (no actual mask)
+    def test_func():
+        x_fp8_local, y_fp8_local, out_local, _ = construct_grouped(num_groups, m, k, n, is_masked=True)
+        masked_m = torch.ones((num_groups,), device='cuda', dtype=torch.int) * m
+        deep_gemm.m_grouped_gemm_fp8_fp8_bf16_nt_masked(x_fp8_local, y_fp8_local, out_local, masked_m, m)
 
-
-def test_m_grouped_gemm_masked() -> None:
-    print('Testing grouped masked GEMM:')
-
-    for num_groups, m in ((1, 1024), (2, 512), (4, 256)):
-        for k, n in ((7168, 4096), (2048, 7168), ):
-            # Test correctness
-            masked_m_candidates = list(filter(lambda candidate: candidate <= m, (64, 128, 192, 256, 320, 384)))
-            for i in range(10):
-                x_fp8, y_fp8, out, ref_out = construct_grouped(num_groups, m, k, n, is_masked=True)
-                masked_m = torch.empty((num_groups, ), device='cuda', dtype=torch.int)
-                for j in range(num_groups):
-                    masked_m[j] = random.choice(masked_m_candidates)
-                expected_m = int(masked_m.float().mean()) + 1
-                deep_gemm.m_grouped_gemm_fp8_fp8_bf16_nt_masked(x_fp8, y_fp8, out, masked_m, expected_m)
-                for j in range(num_groups):
-                    diff = calc_diff(out[j, :masked_m[j].item()], ref_out[j, :masked_m[j].item()])
-                    assert diff < 0.001, f'{m=}, {k=}, {n=}, {j=}, masked_m={masked_m[j]}, {num_groups=}, {diff:.5f}'
-
-            # noinspection PyShadowingNames
-            def test_func():
-                # Construct new tensors every time to avoid L2 cache acceleration
-                x_fp8, y_fp8, out, ref_out = construct_grouped(num_groups, m, k, n, is_masked=True)
-                masked_m = torch.ones((num_groups, ), device='cuda', dtype=torch.int) * m
-                deep_gemm.m_grouped_gemm_fp8_fp8_bf16_nt_masked(x_fp8, y_fp8, out, masked_m, m)
-
-            # Test performance with fixed shapes
-            t = bench_kineto(test_func, 'fp8_gemm', suppress_kineto_output=True)
-            print(f' > Performance ({num_groups=}, m_per_group={m:4}, n={n:4}, k={k:4}): {t * 1e6:4.0f} us | '
-                  f'throughput: {2 * num_groups * m * n * k / t / 1e12:4.0f} TFLOPS, '
-                  f'{(num_groups * (m * k + k * n + m * n * 2)) / 1e9 / t:4.0f} GB/s')
-    print()
-
-
-if __name__ == '__main__':
-    torch.backends.cuda.matmul.allow_tf32 = True
-    torch.backends.cudnn.allow_tf32 = True
-    torch.manual_seed(0)
-    random.seed(0)
-
-    print('Library path:')
-    print(f' > {deep_gemm.__path__}\n')
-
-    test_gemm()
-    test_m_grouped_gemm_contiguous()
-    test_m_grouped_gemm_masked()
+    t = bench_kineto(test_func, 'fp8_gemm', suppress_kineto_output=True)
+    print(f'[test_m_grouped_gemm_masked] (groups={num_groups}, m={m}, n={n}, k={k}): '
+          f'{t * 1e6:6.0f} us | {2 * num_groups * m * n * k / t / 1e12:5.2f} TFLOPS')

--- a/tests/test_jit.py
+++ b/tests/test_jit.py
@@ -1,4 +1,5 @@
 import os
+import pytest
 import torch
 from typing import Any
 
@@ -6,6 +7,10 @@ from deep_gemm import jit
 
 
 class Capture:
+    """
+    Context manager to capture stdout via OS pipes.
+    """
+
     def __init__(self) -> None:
         self.read_fd = None
         self.write_fd = None
@@ -28,37 +33,66 @@ class Capture:
         return self.captured
 
 
-if __name__ == '__main__':
-    # Runtime
+@pytest.mark.skipif(not torch.cuda.is_available(), reason='CUDA is required for this test.')
+def test_jit():
+    # Print NVCC compiler
     print(f'NVCC compiler: {jit.get_nvcc_compiler()}\n')
 
-    # Templates
+    # Define function arguments and code body
     print('Generated code:')
-    args = (('lhs', torch.float8_e4m3fn), ('rhs', torch.float8_e4m3fn), ('scale', torch.float), ('out', torch.bfloat16),
-            ('enable_double_streams', bool), ('stream', torch.cuda.Stream))
-    body = "\n"
+    args = (
+        ('lhs', torch.float8_e4m3fn),
+        ('rhs', torch.float8_e4m3fn),
+        ('scale', torch.float),
+        ('out', torch.bfloat16),
+        ('enable_double_streams', bool),
+        ('stream', torch.cuda.Stream),
+    )
+
+    body = ''
     body += 'std::cout << reinterpret_cast<uint64_t>(lhs) << std::endl;\n'
     body += 'std::cout << reinterpret_cast<uint64_t>(rhs) << std::endl;\n'
     body += 'std::cout << reinterpret_cast<uint64_t>(scale) << std::endl;\n'
     body += 'std::cout << reinterpret_cast<uint64_t>(out) << std::endl;\n'
     body += 'std::cout << enable_double_streams << std::endl;\n'
     body += 'std::cout << reinterpret_cast<uint64_t>(stream) << std::endl;\n'
+
     code = jit.generate((), args, body)
     print(code)
 
-    # Build
+    # Build the function
     print('Building ...')
     func = jit.build('test_func', args, code)
 
     # Test correctness
     print('Running ...')
-    fp8_tensor = torch.empty((1, ), dtype=torch.float8_e4m3fn, device='cuda')
-    fp32_tensor = torch.empty((1, ), dtype=torch.float, device='cuda')
-    bf16_tensor = torch.empty((1, ), dtype=torch.bfloat16, device='cuda')
+    fp8_tensor = torch.empty((1,), dtype=torch.float8_e4m3fn, device='cuda')
+    fp32_tensor = torch.empty((1,), dtype=torch.float, device='cuda')
+    bf16_tensor = torch.empty((1,), dtype=torch.bfloat16, device='cuda')
+
     with Capture() as capture:
-        assert func(fp8_tensor, fp8_tensor, fp32_tensor, bf16_tensor, True, torch.cuda.current_stream()) == 0
+        ret = func(
+            fp8_tensor,
+            fp8_tensor,
+            fp32_tensor,
+            bf16_tensor,
+            True,
+            torch.cuda.current_stream(),
+        )
+        # If your JIT returns an error code, test it here
+        assert ret == 0, f'JIT function returned error code: {ret}'
+
     output = capture.capture()
-    ref_output = f'{fp8_tensor.data_ptr()}\n{fp8_tensor.data_ptr()}\n{fp32_tensor.data_ptr()}\n{bf16_tensor.data_ptr()}\n1\n{torch.cuda.current_stream().cuda_stream}\n'
-    assert output == ref_output, f'{output=}, {ref_output=}'
+    ref_output = (
+        f'{fp8_tensor.data_ptr()}\n'
+        f'{fp8_tensor.data_ptr()}\n'
+        f'{fp32_tensor.data_ptr()}\n'
+        f'{bf16_tensor.data_ptr()}\n'
+        f'1\n'
+        f'{torch.cuda.current_stream().cuda_stream}\n'
+    )
+
+    # Compare the captured output to the reference
+    assert output == ref_output, f'Mismatch!\nGot:\n{output}\nExpected:\n{ref_output}'
 
     print('JIT test passed')


### PR DESCRIPTION
Decorate the test function with @pytest.mark.skipif(...) so the test is skipped if CUDA is unavailable. Move all testing logic into a function named test_jit() so it’s automatically discoverable by pytest.

**CUTLASS Configuration**
Ensure that the CUTLASS_ROOT environment variable is set. For example:
export CUTLASS_ROOT=/root/DeepGEMM/third-party/cutlass
export CPATH="$CUTLASS_ROOT/include:$CPATH"
export CPLUS_INCLUDE_PATH="$CUTLASS_ROOT/include:$CPLUS_INCLUDE_PATH"

**Running the Tests:**
pip install pytest
pytest tests/test_jit.py -v -s


===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.11.11, pytest-8.3.4, pluggy-1.5.0 -- /root/miniconda3/envs/gemm/bin/python
cachedir: .pytest_cache
rootdir: /root/autodl-tmp/DeepGEMM
collected 1 item

tests/test_jit.py::test_jit NVCC compiler: ('/usr/local/cuda/bin/nvcc', '12.4')

Generated code:
// DeepGEMM auto-generated JIT CUDA source file

#include <cuda.h>
#include <cuda_fp8.h>
#include <cuda_runtime.h>
#include <iostream>

#include "cutlass/cutlass.h"

extern "C" void launch(void* __raw_lhs, void* __raw_rhs, void* __raw_scale, void* __raw_out, bool enable_double_streams, void* __raw_stream, int& __return_code) {
    // Cast raw types (if needed)
    auto lhs = reinterpret_cast<__nv_fp8_e4m3*>(__raw_lhs);
    auto rhs = reinterpret_cast<__nv_fp8_e4m3*>(__raw_rhs);
    auto scale = reinterpret_cast<float*>(__raw_scale);
    auto out = reinterpret_cast<__nv_bfloat16*>(__raw_out);
    auto stream = reinterpret_cast<cudaStream_t>(__raw_stream);
    std::cout << reinterpret_cast<uint64_t>(lhs) << std::endl;
    std::cout << reinterpret_cast<uint64_t>(rhs) << std::endl;
    std::cout << reinterpret_cast<uint64_t>(scale) << std::endl;
    std::cout << reinterpret_cast<uint64_t>(out) << std::endl;
    std::cout << enable_double_streams << std::endl;
    std::cout << reinterpret_cast<uint64_t>(stream) << std::endl;
}


Building ...
Running ...
JIT test passed
PASSED

====================================================================================== 1 passed in 6.18s ======================================================================================

![image](https://github.com/user-attachments/assets/11e4cc04-4038-4db2-8631-853f7c7d0c97)


Test environment on H800 ,cuda 12.7 ,  Python 3.11.11, pytest-8.3.4, pluggy-1.5.0 

Thu Feb 27 14:13:11 2025
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 565.57.01              Driver Version: 565.57.01      CUDA Version: 12.7     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA H800 PCIe               On  |   00000000:39:00.0 Off |                  Off |
| N/A   31C    P0             49W /  350W |       1MiB /  81559MiB |      0%      Default |
|                                         |                        |             Disabled |
+-----------------------------------------+------------------------+----------------------+

+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|  No running processes found                                                             |
+-----------------------------------------------------------------------------------------+
