### PR TITLE
Specify uint8_t as enum class size

### DIFF
--- a/deep_gemm/include/deep_gemm/fp8_gemm.cuh
+++ b/deep_gemm/include/deep_gemm/fp8_gemm.cuh
@@ -16,7 +16,7 @@
 
 namespace deep_gemm {
 
-enum class Layout {
+enum class Layout : uint8_t {
     RowMajor,
     ColMajor
 };

--- a/deep_gemm/include/deep_gemm/scheduler.cuh
+++ b/deep_gemm/include/deep_gemm/scheduler.cuh
@@ -2,7 +2,7 @@
 
 namespace deep_gemm {
 
-enum class GemmType {
+enum class GemmType : uint8_t {
     Normal,
     GroupedContiguous,
     GroupedMasked


### PR DESCRIPTION
utilizing the smallest possible underlying type for the enum class: `Layout` and `GemmType`