### PR TITLE
fix setup build error when setuptools version is lower

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ if __name__ == '__main__':
         packages=['deep_gemm', 'deep_gemm/jit', 'deep_gemm/jit_kernels'],
         package_data={
             'deep_gemm': [
-                'include/deep_gemm/**/*',
+                'include/deep_gemm/*',
                 'include/cute/**/*',
                 'include/cutlass/**/*',
             ]


### PR DESCRIPTION
When setuptools==59.6.0,  `include/deep_gemm/**/*`, It will not copy .cuh file from the include directory。
If use new version, such as 75.8.2, it work ok。
I suggest use `include/deep_gemm/*`, will have better compatibility.