### PR TITLE
Performance: reducing the percentage of FFMA interleaving yields a sight performance gain, roughly 0.5%

### DIFF
--- a/deep_gemm/jit/interleave_ffma.py
+++ b/deep_gemm/jit/interleave_ffma.py
@@ -73,7 +73,7 @@ def parse_registers(line):
 
 
 def modify_segment(m, name, ffma_lines):
-    num_lines = len(ffma_lines)
+    num_lines = (len(ffma_lines) * 9 // 16) // 2 * 2
     assert num_lines % 2 == 0
 
     le_bytes, new_le_bytes = [], []


### PR DESCRIPTION
**Reducing** the percentage of FFMA interleaving yields a **sight performance gain**, roughly **0.5%**。

<img width="795" alt="image" src="https://github.com/user-attachments/assets/b8863a7d-34b1-439a-a7fe-fe2161daa530" />

Test on H100-SXM && CUDA 12.8.


















































































































