### PR TITLE
Performance: Configuration algorithms tuned to minimize the impact of tail effects, now up to 1402 TFLOPS

### DIFF
--- a/deep_gemm/jit_kernels/gemm.py
+++ b/deep_gemm/jit_kernels/gemm.py
@@ -6,7 +6,6 @@ from .utils import get_num_sms, ceil_div, get_col_major_tma_aligned_tensor, get_
 
 # C++ code templates
 includes = ('"deep_gemm/fp8_gemm.cuh"', )
-# includes = ('"deep_gemm/fp8_gemm_inter_wg.cuh"', )
 template = """
 using namespace deep_gemm;
 
@@ -28,7 +27,7 @@ auto tma_d_desc = GemmType::make_2d_tma_d_desc(out, m);
 GemmType::run(out, rhs_scales, nullptr,
               m,
               tma_a_desc, tma_b_desc, tma_scales_a_desc, tma_d_desc,
-              stream, n_block, smem_size);
+              stream, num_sms, smem_size);
 """
 
 
@@ -64,30 +63,28 @@ def get_best_configs(m: int, n: int, k: int, num_groups: int, num_sms: int,
     else:
         block_ms = (get_m_alignment_for_contiguous_layout(), )
     block_ns = tuple(range(16, 129, 8))
-    n_blocks = tuple(range(124, num_sms+1, 2))
 
-    fix_wave_saturate = lambda x, nb: nb if x == 0 else x
-    get_num_waves = lambda bm, bn, nb: (ceil_div(ceil_div(m, bm) * ceil_div(n, bn) * num_groups, nb) if bm else None)
-    get_last_wave_util = lambda bm, bn, nb: fix_wave_saturate((ceil_div(m, bm) * ceil_div(n, bn) * num_groups) % nb, nb)
+    fix_wave_saturate = lambda x: num_sms if x == 0 else x
+    get_num_waves = lambda bm, bn: (ceil_div(ceil_div(m, bm) * ceil_div(n, bn) * num_groups, num_sms) if bm else None)
+    get_last_wave_util = lambda bm, bn: fix_wave_saturate((ceil_div(m, bm) * ceil_div(n, bn) * num_groups) % num_sms)
 
     # Decide block sizes by waves
-    best_block_m, best_block_n, best_n_block = None, None, None
+    best_block_m, best_block_n = None, None
     for block_m in block_ms:
         for block_n in block_ns:
-            for n_block in n_blocks:
-                success = False
-                num_waves, best_num_waves = get_num_waves(block_m, block_n, n_block), get_num_waves(best_block_m, best_block_n, best_n_block)
-                if best_block_m is None or best_block_n is None or best_n_block is None:
-                    success = True
-                elif num_waves < best_num_waves:
-                    success = True
-                elif num_waves == best_num_waves:
-                    # Check last wave utilization
-                    util = get_last_wave_util(block_m, block_n, n_block) + num_waves * n_block / num_sms
-                    best_util = get_last_wave_util(best_block_m, best_block_n, best_n_block) + best_num_waves * best_n_block / num_sms
-                    success = util > best_util or (util == best_util and (block_m > best_block_m or (block_m == best_block_m and block_n > best_block_n) or (block_m == best_block_m and block_n == best_block_n and n_block < best_n_block)))
-                best_block_m, best_block_n, best_n_block= (block_m, block_n, n_block) if success else (best_block_m, best_block_n, best_n_block)
-    assert best_block_m is not None and best_block_n is not None and best_n_block is not None
+            success = False
+            num_waves, best_num_waves = get_num_waves(block_m, block_n), get_num_waves(best_block_m, best_block_n)
+            if best_block_m is None or best_block_n is None:
+                success = True
+            elif num_waves < best_num_waves:
+                success = True
+            elif num_waves == best_num_waves:
+                # Check last wave utilization
+                util = get_last_wave_util(block_m, block_n)
+                best_util = get_last_wave_util(best_block_m, best_block_n)
+                success = util > best_util or (util == best_util and (block_m > best_block_m or (block_m == best_block_m and block_n < best_block_n)))
+            best_block_m, best_block_n = (block_m, block_n) if success else (best_block_m, best_block_n)
+    assert best_block_m is not None and best_block_n is not None
 
     # Always pick the longest one
     # NOTES: for double B scales, the best number of stages may be reduced
@@ -101,10 +98,17 @@ def get_best_configs(m: int, n: int, k: int, num_groups: int, num_sms: int,
 
     # Decide the number of TMA multicast
     best_num_tma_multicast = 1
-    if m >= 1024 and is_tma_multicast_legal(n, best_block_n, 2, best_n_block) and num_groups == 1:
+    if m >= 1024 and is_tma_multicast_legal(n, best_block_n, 2, num_sms) and num_groups == 1:
         best_num_tma_multicast = 2
 
-    return best_block_m, best_block_n, best_n_block, best_num_stages, best_num_tma_multicast, best_smem_size
+    # Recompute the minimal number of SMs required
+    # NOTES: less L2 cache usage and less GPU frequency drop
+    num_waves = get_num_waves(best_block_m, best_block_n)
+    num_min_sms = ceil_div(ceil_div(m, best_block_m) * ceil_div(n, best_block_n) * num_groups, num_waves)
+    num_min_sms = ceil_div(max(num_min_sms, num_sms - 8), 2) * 2
+    assert num_min_sms <= num_sms
+
+    return num_min_sms, best_block_m, best_block_n, best_num_stages, best_num_tma_multicast, best_smem_size
 
 
 def gemm_fp8_fp8_bf16_nt(lhs: Tuple[torch.Tensor, torch.Tensor],
@@ -154,8 +158,8 @@ def gemm_fp8_fp8_bf16_nt(lhs: Tuple[torch.Tensor, torch.Tensor],
     # Auto-tuning with compilation
     global includes, template
     num_sms = get_num_sms()
-    block_m, block_n, n_block, num_stages, num_tma_multicast, smem_size = get_best_configs(m, n, k, 1, num_sms)
-    args = (lhs, lhs_scales, rhs, rhs_scales, out, m, torch.cuda.current_stream(), n_block, smem_size)
+    num_sms, block_m, block_n, num_stages, num_tma_multicast, smem_size = get_best_configs(m, n, k, 1, num_sms)
+    args = (lhs, lhs_scales, rhs, rhs_scales, out, m, torch.cuda.current_stream(), num_sms, smem_size)
     runtime = jit_tuner.compile_and_tune(
         name='gemm_fp8_fp8_bf16_nt',
         keys={'N': n, 'K': k, 'BLOCK_M': block_m, 'BLOCK_N': block_n,
@@ -165,7 +169,7 @@ def gemm_fp8_fp8_bf16_nt(lhs: Tuple[torch.Tensor, torch.Tensor],
         arg_defs=(('lhs', torch.float8_e4m3fn), ('lhs_scales', torch.float),
                   ('rhs', torch.float8_e4m3fn), ('rhs_scales', torch.float),
                   ('out', torch.bfloat16), ('m', int),
-                  ('stream', torch.cuda.Stream), ('n_block', int), ('smem_size', int)),
+                  ('stream', torch.cuda.Stream), ('num_sms', int), ('smem_size', int)),
         template=template,
         args=args
     )

--- a/deep_gemm/jit_kernels/gemm.py
+++ b/deep_gemm/jit_kernels/gemm.py
@@ -105,8 +105,8 @@ def get_best_configs(m: int, n: int, k: int, num_groups: int, num_sms: int,
     # NOTES: less L2 cache usage and less GPU frequency drop
     num_waves = get_num_waves(best_block_m, best_block_n)
     num_min_sms = ceil_div(ceil_div(m, best_block_m) * ceil_div(n, best_block_n) * num_groups, num_waves)
-    num_min_sms = ceil_div(max(num_min_sms, num_sms - 8), 2) * 2
-    assert num_min_sms <= num_sms
+    num_min_sms = ceil_div(max(num_min_sms, num_sms - 8), best_num_tma_multicast) * best_num_tma_multicast
+    assert num_min_sms <= num_sms and is_tma_multicast_legal(n, best_block_n, best_num_tma_multicast, num_min_sms)
 
     return num_min_sms, best_block_m, best_block_n, best_num_stages, best_num_tma_multicast, best_smem_size
 

--- a/deep_gemm/jit_kernels/m_grouped_gemm.py
+++ b/deep_gemm/jit_kernels/m_grouped_gemm.py
@@ -28,7 +28,7 @@ auto tma_d_desc = GemmType::make_2d_tma_d_desc(out, m);
 GemmType::run(out, rhs_scales, grouped_layout,
               m,
               tma_a_desc, tma_b_desc, tma_scales_a_desc, tma_d_desc,
-              stream, num_sms, smem_size);
+              stream, n_block, smem_size);
 """
 
 
@@ -84,11 +84,11 @@ def m_grouped_gemm_fp8_fp8_bf16_nt_contiguous(lhs: Tuple[torch.Tensor, torch.Ten
     # Auto-tuning with compilation
     global includes, template
     num_sms = get_num_sms()
-    block_m, block_n, num_stages, num_tma_multicast, smem_size = get_best_configs(m, n, k, 1, num_sms,
+    block_m, block_n, n_block, num_stages, num_tma_multicast, smem_size = get_best_configs(m, n, k, 1, num_sms,
                                                                                   is_grouped_contiguous=True)
     args = (lhs, lhs_scales, rhs, rhs_scales, out,
             m_indices, m, num_groups,
-            torch.cuda.current_stream(), num_sms, smem_size)
+            torch.cuda.current_stream(), n_block, smem_size)
     runtime = jit_tuner.compile_and_tune(
         name='m_grouped_gemm_fp8_fp8_bf16_nt',
         keys={'N': n, 'K': k, 'BLOCK_M': block_m, 'BLOCK_N': block_n, 'NUM_GROUPS': num_groups,
@@ -99,7 +99,7 @@ def m_grouped_gemm_fp8_fp8_bf16_nt_contiguous(lhs: Tuple[torch.Tensor, torch.Ten
                   ('rhs', torch.float8_e4m3fn), ('rhs_scales', torch.float),
                   ('out', torch.bfloat16),
                   ('grouped_layout', torch.int32), ('m', int), ('num_groups', int),
-                  ('stream', torch.cuda.Stream), ('num_sms', int), ('smem_size', int)),
+                  ('stream', torch.cuda.Stream), ('n_block', int), ('smem_size', int)),
         template=template,
         args=args
     )
@@ -158,7 +158,7 @@ def m_grouped_gemm_fp8_fp8_bf16_nt_masked(lhs: Tuple[torch.Tensor, torch.Tensor]
     # Auto-tuning with compilation
     global includes, template
     num_sms = get_num_sms()
-    block_m, block_n, num_stages, num_tma_multicast, smem_size = get_best_configs(expected_m, n, k, num_groups, num_sms)
+    block_m, block_n, n_block, num_stages, num_tma_multicast, smem_size = get_best_configs(expected_m, n, k, num_groups, num_sms)
 
     # Extra checks for TMA store
     if num_groups > 1 and m > block_m:
@@ -166,7 +166,7 @@ def m_grouped_gemm_fp8_fp8_bf16_nt_masked(lhs: Tuple[torch.Tensor, torch.Tensor]
 
     args = (lhs, lhs_scales, rhs, rhs_scales, out,
             masked_m, m,
-            torch.cuda.current_stream(), num_sms, smem_size)
+            torch.cuda.current_stream(), n_block, smem_size)
     runtime = jit_tuner.compile_and_tune(
         name='m_grouped_gemm_fp8_fp8_bf16_nt',
         keys={'N': n, 'K': k, 'BLOCK_M': block_m, 'BLOCK_N': block_n, 'NUM_GROUPS': num_groups,
@@ -177,7 +177,7 @@ def m_grouped_gemm_fp8_fp8_bf16_nt_masked(lhs: Tuple[torch.Tensor, torch.Tensor]
                   ('rhs', torch.float8_e4m3fn), ('rhs_scales', torch.float),
                   ('out', torch.bfloat16),
                   ('grouped_layout', torch.int32), ('m', int),
-                  ('stream', torch.cuda.Stream), ('num_sms', int), ('smem_size', int)),
+                  ('stream', torch.cuda.Stream), ('n_block', int), ('smem_size', int)),
         template=template,
         args=args
     )


### PR DESCRIPTION
Configuration algorithms tuned to minimize the impact of tail effects, for 4096x7168x16384, approximately 1.6% performance gain.

|  M   |   N   |   K   | Base_BlockS | Computation    | Tail_BlockS | Computation    | Speedup |
|:----:|:-----:|:-----:|:-----:   |:-----------: |:-----:   |:-----------: |:-------:|
|  64  | 2112  | 7168  | 132    | 195 TFLOPS   | 132      | 194 TFLOPS   |  -0.51%   |
|  64  | 24576 | 1536  | 132    | 281 TFLOPS   | **128**  | 283 TFLOPS   |  0.71%   |
|  64  | 32768 |  512  | 132    | 217 TFLOPS   | **128**  | 218 TFLOPS   |  0.46%   |
|  64  | 7168  | 16384 | 132    | 329 TFLOPS   | 132      | 328 TFLOPS   |  -0.30%   |
|  64  | 4096  | 7168  | 132    | 269 TFLOPS   | 132      | 268 TFLOPS   |  -0.37%   |
|  64  | 7168  | 2048  | 132    | 272 TFLOPS   | 132      | 269 TFLOPS   |  -1.10%   |
| 128  | 2112  | 7168  | 132    | 341 TFLOPS   | 132      | 340 TFLOPS   |  -0.29%   |
| 128  | 24576 | 1536  | 132    | 521 TFLOPS   | **128**  | 520 TFLOPS   |  -0.19%   |
| 128  | 32768 |  512  | 132    | 358 TFLOPS   | **128**  | 365 TFLOPS   |  1.96%   |
| 128  | 7168  | 16384 | 132    | 631 TFLOPS   | 132      | 633 TFLOPS   |  0.32%   |
| 128  | 4096  | 7168  | 132    | 505 TFLOPS   | 132      | 504 TFLOPS   |  -0.20%   |
| 128  | 7168  | 2048  | 132    | 486 TFLOPS   | 132      | 485 TFLOPS   |  -0.21%   |
| 4096 | 2112  | 7168  | 132    | 1054  TFLOPS | **124**  | 1071  TFLOPS |  1.61%   |
| 4096 | 24576 | 1536  | 132    | 992 TFLOPS   | 132      | 988 TFLOPS   |  -0.40%   |
| 4096 | 32768 |  512  | 132    | 595 TFLOPS   | 132      | 591 TFLOPS   |  -0.67%   |
| 4096 | 7168  | 16384 | 132    | 1348  TFLOPS | **128**  | 1369  TFLOPS |  1.56%   |
| 4096 | 4096  | 7168  | 132    | 1325  TFLOPS | **128**  | 1333  TFLOPS |  0.60%   |
| 4096 | 7168  | 2048  | 132    | 1026  TFLOPS | **128**  | 1022  TFLOPS |  -0.39%   |

Together with the optimization of FFMA interleaving, for 4096x7168x16384, approximately 4% performance gain，up to 1402TFLOPS

|  M   |   N   |   K   | Base_BlockS | Computation    | Tail+FFMA_BlockS | Computation    | Speedup |
|:----:|:-----:|:-----:|:-----:   |:-----------: |:-----:   |:-----------:  |:-------:|
|  64  | 2112  | 7168  | 132      | 195 TFLOPS   | 132      | 194 TFLOPS    |  -0.51%   |
|  64  | 24576 | 1536  | 132      | 281 TFLOPS   | **128**  | 282 TFLOPS    |  0.36%  |
|  64  | 32768 |  512  | 132      | 217 TFLOPS   | **128**  | 219 TFLOPS    |  0.92%  |
|  64  | 7168  | 16384 | 132      | 329 TFLOPS   | 132      | 328 TFLOPS    |  -0.30%   |
|  64  | 4096  | 7168  | 132      | 269 TFLOPS   | 132      | 270 TFLOPS    |  0.37%   |
|  64  | 7168  | 2048  | 132      | 272 TFLOPS   | 132      | 271 TFLOPS    |  -0.37%   |
| 128  | 2112  | 7168  | 132      | 341 TFLOPS   | 132      | 339 TFLOPS    |  -0.59%   |
| 128  | 24576 | 1536  | 132      | 521 TFLOPS   | **128**  | 523 TFLOPS    |  0.38%   |
| 128  | 32768 |  512  | 132      | 358 TFLOPS   | **128**  | 355 TFLOPS    |  -0.84%  |
| 128  | 7168  | 16384 | 132      | 631 TFLOPS   | 132      | 633 TFLOPS    |  0.32%  |
| 128  | 4096  | 7168  | 132      | 505 TFLOPS   | 132      | 511 TFLOPS    |  1.19%   |
| 128  | 7168  | 2048  | 132      | 486 TFLOPS   | 132      | 485 TFLOPS    |  -0.21%   |
| 4096 | 2112  | 7168  | 132      | 1054  TFLOPS | **124**  | 1065 TFLOPS   |  1.04%  |
| 4096 | 24576 | 1536  | 132      | 992 TFLOPS   | 132      | 1009 TFLOPS   |  1.71%   |
| 4096 | 32768 |  512  | 132      | 595 TFLOPS   | 132      | 592 TFLOPS    |  -0.50%   |
| 4096 | 7168  | 16384 | 132      | 1348  TFLOPS | **128**  | 1402   TFLOPS |  4.01%  |
| 4096 | 4096  | 7168  | 132      | 1325  TFLOPS | **128**  | 1355   TFLOPS |  2.26%  |
| 4096 | 7168  | 2048  | 132      | 1026  TFLOPS | **128**  | 1042   TFLOPS |  1.56%   |

Test on H100-SXM && CUDA 12.8.