### PR TITLE
Fix issue with "__assertfail"

### DIFF
--- a/deep_gemm/jit/runtime.py
+++ b/deep_gemm/jit/runtime.py
@@ -49,7 +49,7 @@ class Runtime:
             result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
             assert result.returncode == 0
             kernel_names = [line.split()[-1] for line in result.stdout.splitlines()
-                            if line.startswith('STT_FUNC') and '__instantiate_kernel' not in line]
+                            if line.startswith('STT_FUNC') and '__instantiate_kernel' not in line and '__assertfail' not in line]
             assert len(kernel_names) == 1, f'Too many kernels in the library: {kernel_names}'
 
             # Load kernel from the library


### PR DESCRIPTION
Sometimes, an "__assertfail" line pops up in the compilation process:
```
    m_grouped_gemm_fp8_fp8_bf16_nt_contiguous(
  File "/mnt/large_shared/users/federico/env_nightly/lib/python3.11/site-packages/deep_gemm-1.0.0+ee916df-py3.11.egg/deep_gemm/jit_kernels/m_grouped_gemm.py", line 116, in m_grouped_gemm_fp8_fp8_bf16_nt_contiguous
    runtime(**best_keys, **kwargs)
  File "/mnt/large_shared/users/federico/env_nightly/lib/python3.11/site-packages/deep_gemm-1.0.0+ee916df-py3.11.egg/deep_gemm/jit/runtime.py", line 53, in __call__
    assert len(kernel_names) == 1, f'Too many kernels in the library: {kernel_names}'
           ^^^^^^^^^^^^^^^^^^^^^^
AssertionError: Too many kernels in the library: ['_ZN9deep_gemm15fp8_gemm_kernelILj2816ELj256ELj128ELj160ELj128ELj0ELj64ELj64ELj2ELj128ELj128ELj1ELb0ELNS_8GemmTypeE1EEEvPfPij14CUtensorMap_stS4_S4_S4_', '__assertfail']
```
Ignoring it fixes the issue.