### PR TITLE
Grouped GEMM skip useless computation for unaligned Ms

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Despite its lightweight design, DeepGEMM's performance matches or exceeds expert
 - [ ] Larger block size on N (up to 256)
 - [x] MoE scheduler with TMA multicast compatibility
 - [x] Fix TMA multicast compatibility for indivisible shapes
-- [ ] Skip useless computation on M
+- [x] Skip useless computation on M
 - [x] NVRTC as a faster compiler
 - [ ] Stolen JIT cache
 - [ ] Sanitizer for testing

--- a/deep_gemm/include/deep_gemm/scheduler.cuh
+++ b/deep_gemm/include/deep_gemm/scheduler.cuh
@@ -48,6 +48,16 @@ struct Scheduler {
         }
     }
 
+    __device__ __forceinline__ bool is_valid_m(const uint32_t m_offset, const uint32_t& m_block_idx) const {
+        if constexpr (kGemmType == GemmType::Normal) {
+            return true;
+        } else if constexpr (kGemmType == GemmType::GroupedContiguous) {
+            return __ldg(grouped_layout + m_offset + m_block_idx * BLOCK_M) != -1;
+        } else if constexpr (kGemmType == GemmType::GroupedMasked) {
+            return m_offset + m_block_idx * BLOCK_M < __ldg(grouped_layout + curr_group_idx);
+        }
+    }
+
     __device__ __forceinline__ bool is_tma_multicast_valid(const uint32_t& m_block_idx) const {
         if (num_blocks_in_group == 1)
             return false;


### PR DESCRIPTION
Skip useless computation on M and reconstruct test_m_grouped_gemm_contiguous and test_m_grouped_gemm_masked'.

In test_m_grouped_gemm_contiguous, there is a speedup of 0-15 TFLOPS (Due to the larger expected_m_per_group, the speedup effect is not very significant).

In test_m_grouped_gemm_masked, there is a speedup of 10-20 TFLOPS.

For GEMM, incorporating this optimization may affect the efficiency of certain shapes. I tested with m = 4160 and observed some speedup, but when m = 4096, there is a 10-20 TFLOPS reduction in efficiency.

This scenario can be specifically optimized by adding a template parameter to check whether m is a multiple of block_m. However, since GEMM is not the current optimization focus, I have not implemented this enhancement yet.