### PR TITLE
Fix illegal memory address when skipping -1 m indices

### DIFF
--- a/deep_gemm/include/deep_gemm/scheduler.cuh
+++ b/deep_gemm/include/deep_gemm/scheduler.cuh
@@ -116,7 +116,7 @@ struct Scheduler {
         if constexpr (kGemmType == GemmType::Normal) {
             return block_idx * block_size;
         } else if constexpr (kGemmType == GemmType::GroupedContiguous) {
-            auto offset = kIgnoreGroupedForGroupedContiguous ? 0 : __ldg(grouped_layout + m_block_idx * BLOCK_M);
+            auto offset = kIgnoreGroupedForGroupedContiguous ? 0 : max(0, __ldg(grouped_layout + m_block_idx * BLOCK_M));
             return offset * shape_dim + block_idx * block_size;
         } else if constexpr (kGemmType == GemmType::GroupedMasked) {
             return curr_group_idx * shape_dim + block_idx * block_size;


### PR DESCRIPTION
I'm testing vllm integration with latest `m_grouped_gemm_fp8_fp8_bf16_nt_contiguous` but I faced an issue when I pad m_indices with `-1` for skipping useless compute. 
When VLLM tries to capture the whole CUDA Graph for the model, it fails with error
```
RuntimeError: CUDA error: an illegal memory access was encountered
```
After debugging this is related to tma_copy operation at [this line](https://github.com/deepseek-ai/DeepGEMM/blob/8dfa3298274bfe6b242f6f8a3e6f3eff2707dd9f/deep_gemm/include/deep_gemm/fp8_gemm.cuh#L211). `scheduler.get_global_idx` will return an invalid index for -1 m block. 

With the changes in the PR it fixes the issue. However after some research, it seems invalid address is an no-op for tma_copy, and maybe by design to skip useless loading? 

Can anyone help clarifying this and suggest on the different behavior by CUDA Graph capturing? Thanks!!