### PR TITLE
Updated submodules to use https:// vs git@

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "third-party/cutlass"]
 	path = third-party/cutlass
-	url = git@github.com:NVIDIA/cutlass.git
+	url = https://github.com/NVIDIA/cutlass.git
 [submodule "third-party/fmt"]
 	path = third-party/fmt
-	url = git@github.com:fmtlib/fmt.git
+	url = https://github.com/fmtlib/fmt.git


### PR DESCRIPTION
Anonymous cloning is more difficult with git@ (it requires per user
SSH keys), which makes CI automation more difficult.

I suggest reverting to using https:// as it was before #112

```
$ git clone git@github.com:fmtlib/fmt.git 
Cloning into 'fmt'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```