### PR TITLE
Fix an ABI breakage we met

### DIFF
--- a/csrc/jit/compiler.hpp
+++ b/csrc/jit/compiler.hpp
@@ -19,15 +19,28 @@ class Compiler {
     std::string library_version;
     std::filesystem::path library_root_path;
 
-    std::string get_library_version() const {
-        // Recursively walk through all subdirectories and update hash
-        std::stringstream ss;
-        for (const auto& entry: std::filesystem::recursive_directory_iterator(library_include_path / "deep_gemm")) {
-            if (entry.is_regular_file() and entry.path().extension() == ".cuh") {
-                std::ifstream file(entry.path(), std::ios::binary);
-                std::string content((std::istreambuf_iterator(file)), std::istreambuf_iterator<char>());
-                ss << content;
+    static void collect_files(const std::filesystem::path& dir,
+                        std::vector<std::filesystem::path>& out) {
+        // We met ABI breakage using std::filesystem::recursive_directory_iterator
+        // Use std::filesystem::directory_iterator instead
+        for (const auto& entry : std::filesystem::directory_iterator(dir)) {
+            if (entry.is_directory()) {
+                collect_files(entry.path(), out);
+            } else if (entry.is_regular_file() && entry.path().extension()==".cuh") {
+                out.emplace_back(entry.path());
             }
+        }
+    }
+
+    std::string get_library_version() const {
+        std::vector<std::filesystem::path> files;
+        collect_files(library_include_path / "deep_gemm", files);
+        std::sort(files.begin(), files.end());
+
+        std::stringstream ss;
+        for (const auto& f : files) {
+            std::ifstream in(f, std::ios::binary);
+            ss << in.rdbuf();
         }
         return get_hex_digest(ss.str());
     }


### PR DESCRIPTION
Use std::filesystem::directory_iterator instead of std::filesystem::recursive_directory_iterator to avoid an ABI breakage we met.