### PR TITLE
Fix build error "lvalue required as unary '&' operand"

### DIFF
--- a/csrc/utils/system.hpp
+++ b/csrc/utils/system.hpp
@@ -38,8 +38,8 @@ static std::tuple<int, std::string> call_external_command(std::string command) {
     std::string output;
     while (fgets(buffer.data(), buffer.size(), pipe.get()))
         output += buffer.data();
-    const auto& exit_code = WEXITSTATUS(pclose(pipe.release()));
-    return {exit_code, output};
+    const auto exit_code = pclose(pipe.release());
+    return {WEXITSTATUS(exit_code), output};
 }
 
 static std::vector<std::filesystem::path> collect_files(const std::filesystem::path& root) {


### PR DESCRIPTION
My build was failing with this error - this change fixes it
```
 /home/XXXX/ENV/bin/x86_64-conda-linux-gnu-cc -Wno-unused-result -Wsign-compare -DNDEBUG -fwrapv -O2 -Wall -fPIC -O2 -isystem /home/XXXX/ENV/include -fPIC -O2 -isystem /home/XXXX/ENV/include -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2 -ffunction-sections -pipe -isystem /home/XXXX/ENV/include -DNDEBUG -D_FORTIFY_SOURCE=2 -O2 -isystem /home/XXXX/ENV/include -fPIC -I/home/htouvron/cuda/cuda-12.9//include -Ideep_gemm/include -Ithird-party/cutlass/include -Ithird-party/fmt/include -I/home/XXXX/ENV/lib/python3.10/site-packages/torch/include -I/home/XXXX/ENV/lib/python3.10/site-packages/torch/include/torch/csrc/api/include -I/home/XXXX/ENV/include/python3.10 -c csrc/python_api.cpp -o build/temp.linux-x86_64-cpython-310/csrc/python_api.o -std=c++20 -O3 -fPIC -Wno-psabi
  In file included from /home/XXXX/ENV/x86_64-conda-linux-gnu/sysroot/usr/include/stdlib.h:42,
                   from /home/XXXX/ENV/lib/gcc/x86_64-conda-linux-gnu/12.3.0/include/c++/cstdlib:75,
                   from /home/XXXX/ENV/lib/gcc/x86_64-conda-linux-gnu/12.3.0/include/c++/stdlib.h:36,
                   from /home/XXXX/ENV/include/python3.10/Python.h:34,
                   from /home/XXXX/ENV/lib/python3.10/site-packages/torch/include/pybind11/detail/common.h:274,
                   from /home/XXXX/ENV/lib/python3.10/site-packages/torch/include/pybind11/attr.h:13,
                   from /home/XXXX/ENV/lib/python3.10/site-packages/torch/include/pybind11/detail/class.h:12,
                   from /home/XXXX/ENV/lib/python3.10/site-packages/torch/include/pybind11/pybind11.h:12,
                   from csrc/python_api.cpp:1:
  csrc/jit/../utils/system.hpp: In function 'std::tuple<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > deep_gemm::call_external_command(std::string)':
  csrc/jit/../utils/system.hpp:41:46: error: lvalue required as unary '&' operand
     41 |     const auto exit_code = WEXITSTATUS(pclose(pipe.release()));
        |                                              ^
  In file included from csrc/jit/compiler.hpp:12,
                   from csrc/python_api.cpp:4:
  csrc/jit/../utils/system.hpp:42:30: error: could not convert '{exit_code, output}' from '<brace-enclosed initializer list>' to 'std::tuple<int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >'
     42 |     return {exit_code, output};
        |                              ^
        |                              |
        |                              <brace-enclosed initializer list>
  error: command '/home/XXXX/ENV/bin/x86_64-conda-linux-gnu-cc' failed with exit code 1
```