### PR TITLE
Add torch as build dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
-[project]
-name = "deep_gemm"
-dependencies = ["torch>=2.1.0"]
+[build-system]
+requires = ["torch>=2.1.0"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[project]
+name = "deep_gemm"
+dependencies = ["torch>=2.1.0"]

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,9 @@ if __name__ == '__main__':
         name='deep_gemm',
         version='2.0.0' + revision,
         packages=find_packages('.'),
+        install_requires=[
+            'torch>=2.1.0',
+        ],
         package_data={
             'deep_gemm': [
                 'include/deep_gemm/**/*',

--- a/setup.py
+++ b/setup.py
@@ -4,44 +4,22 @@ import shutil
 import subprocess
 from setuptools import find_packages
 from setuptools.command.build_py import build_py
-
+from torch.utils.cpp_extension import CppExtension, CUDA_HOME
 
 current_dir = os.path.dirname(os.path.realpath(__file__))
 cxx_flags = ['-std=c++20', '-O3', '-fPIC', '-Wno-psabi']
 sources = ['csrc/python_api.cpp']
-
-
-def get_cuda_home():
-    """Get CUDA_HOME path, with fallback to environment variable"""
-    try:
-        from torch.utils.cpp_extension import CUDA_HOME
-        return CUDA_HOME
-    except ImportError:
-        import os
-        return os.environ.get('CUDA_HOME', '/usr/local/cuda')
-
-
-def get_build_include_dirs():
-    """Get build include directories"""
-    cuda_home = get_cuda_home()
-    return [
-        f'{cuda_home}/include',
-        'deep_gemm/include',
-        'third-party/cutlass/include',
-        'third-party/fmt/include',
-    ]
-
-
-def get_build_library_dirs():
-    """Get build library directories"""
-    cuda_home = get_cuda_home()
-    return [
-        f'{cuda_home}/lib64',
-        f'{cuda_home}/lib64/stub'
-    ]
-
-
+build_include_dirs = [
+    f'{CUDA_HOME}/include',
+    'deep_gemm/include',
+    'third-party/cutlass/include',
+    'third-party/fmt/include',
+]
 build_libraries = ['cuda', 'cudart']
+build_library_dirs = [
+    f'{CUDA_HOME}/lib64',
+    f'{CUDA_HOME}/lib64/stub'
+]
 third_party_include_dirs = [
     'third-party/cutlass/include/cute',
     'third-party/cutlass/include/cutlass',
@@ -88,7 +66,6 @@ class CustomBuildPy(build_py):
 
 
 if __name__ == '__main__':
-    from torch.utils.cpp_extension import CppExtension
     # noinspection PyBroadException
     try:
         cmd = ['git', 'rev-parse', '--short', 'HEAD']
@@ -114,9 +91,9 @@ if __name__ == '__main__':
         ext_modules=[
             CppExtension(name='deep_gemm_cpp',
                          sources=sources,
-                         include_dirs=get_build_include_dirs(),
+                         include_dirs=build_include_dirs,
                          libraries=build_libraries,
-                         library_dirs=get_build_library_dirs(),
+                         library_dirs=build_library_dirs,
                          extra_compile_args=cxx_flags)
         ],
         zip_safe=False,


### PR DESCRIPTION
We import torch in the setup.py, so installing this package with pip may fail with import error.
This PR adds torch as dependency to solve this issue.