### PR TITLE
[refact] use cute::tensor to define smem_d layout

### DIFF
--- a/deep_gemm/include/deep_gemm/impls/sm90_fp8_gemm_1d2d.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm90_fp8_gemm_1d2d.cuh
@@ -9,6 +9,9 @@
 #include <cute/arch/cluster_sm90.hpp>
 #include <cute/arch/copy_sm90_desc.hpp>
 #include <cute/arch/copy_sm90_tma.hpp>
+#include <cute/tensor.hpp>
+#include <cute/layout.hpp>
+#include <cute/swizzle.hpp>
 
 #include <deep_gemm/common/utils.cuh>
 #include <deep_gemm/common/scheduler.cuh>
@@ -58,7 +61,14 @@ sm90_fp8_gemm_1d2d_impl(float* sfb, int* grouped_layout,
     shape_m = SHAPE_M != 0 ? SHAPE_M : shape_m;
     shape_n = SHAPE_N != 0 ? SHAPE_N : shape_n;
     shape_k = SHAPE_K != 0 ? SHAPE_K : shape_k;
-
+    // TMA checks
+    constexpr uint32_t kNumElemBytes = sizeof(nv_bfloat16);
+    constexpr uint32_t TMA_D_BLOCK_N = kSwizzleDMode == 0 ? BLOCK_N : (kSwizzleDMode / kNumElemBytes);
+    constexpr uint32_t WGMMA_M_PER_WARP = WGMMA::M / 4;
+    DG_STATIC_ASSERT(BLOCK_M % 8 == 0, "Invalid swizzling atom");
+    DG_STATIC_ASSERT(BLOCK_N % TMA_D_BLOCK_N == 0 and BLOCK_N / TMA_D_BLOCK_N <= 32,
+                    "Unaligned TMA store or too many TMA store instructions");
+    DG_STATIC_ASSERT(TMA_D_BLOCK_N % 8 == 0, "Invalid TMA block N");
     // Shared memory
     static constexpr bool kMustUseUniformedScaleB = (BLOCK_K % BLOCK_N == 0);
     static constexpr uint32_t SMEM_D_SIZE = BLOCK_M * BLOCK_N * sizeof(__nv_bfloat16);
@@ -89,7 +99,19 @@ sm90_fp8_gemm_1d2d_impl(float* sfb, int* grouped_layout,
     DG_STATIC_ASSERT(SMEM_D_SIZE % 1024 == 0, "Shared memory of A/B must be aligned to 1024 bytes");
 
     // Data on shared memory
-    auto smem_d = reinterpret_cast<__nv_bfloat16*>(smem_buffer);
+    // auto smem_d = reinterpret_cast<__nv_bfloat16*>(smem_buffer);
+    constexpr auto BBits = kSwizzleDMode == 128 ? 3 : (kSwizzleDMode == 64 ? 2 : 1);
+    auto smem_d = cute::make_tensor(
+        cute::make_smem_ptr(reinterpret_cast<cute::bfloat16_t*>(smem_buffer)),
+        cute::composition(
+            cute::Swizzle<BBits, 3, 3>{}, 
+            cute::make_layout(
+            cute::make_shape(BLOCK_N / TMA_D_BLOCK_N, BLOCK_M, TMA_D_BLOCK_N),
+                cute::LayoutRight{}
+            )
+        )
+    );
+
     __nv_fp8_e4m3* smem_a[kNumStages];
     __nv_fp8_e4m3* smem_b[kNumStages];
     float* smem_sfa[kNumStages];
@@ -352,15 +374,6 @@ sm90_fp8_gemm_1d2d_impl(float* sfb, int* grouped_layout,
                 }
             }, not scheduler.is_computation_valid(m_block_idx, math_wg_idx * WGMMA::M), num_former_iters);
 
-            // TMA checks
-            constexpr uint32_t kNumElemBytes = sizeof(nv_bfloat16);
-            constexpr uint32_t TMA_D_BLOCK_N = kSwizzleDMode == 0 ? BLOCK_N : (kSwizzleDMode / kNumElemBytes);
-            constexpr uint32_t WGMMA_M_PER_WARP = WGMMA::M / 4;
-            DG_STATIC_ASSERT(BLOCK_M % 8 == 0, "Invalid swizzling atom");
-            DG_STATIC_ASSERT(BLOCK_N % TMA_D_BLOCK_N == 0 and BLOCK_N / TMA_D_BLOCK_N <= 32,
-                            "Unaligned TMA store or too many TMA store instructions");
-            DG_STATIC_ASSERT(TMA_D_BLOCK_N % 8 == 0, "Invalid TMA block N");
-
             // Wait last TMA store to be finished
             if (threadIdx.x < BLOCK_N / TMA_D_BLOCK_N)
                 cute::tma_store_wait<0>();
@@ -375,36 +388,8 @@ sm90_fp8_gemm_1d2d_impl(float* sfb, int* grouped_layout,
                 #pragma unroll
                 for (auto i = 0; i < WGMMA::kNumAccum / 4; ++ i) {
                     // Swizzle or padding into the correct address
-                    uint8_t* smem_ptr = nullptr;
-                    if constexpr (kSwizzleDMode > 0) {
-                        // Calculate the swizzling atom offset and in-atom offset
-                        constexpr uint32_t kNumBankGroupBytes = 16;
-                        auto atom_offset = i / (TMA_D_BLOCK_N / 8), in_atom_offset = i % (TMA_D_BLOCK_N / 8);
-
-                        // Calculate the index of the bank group to be written in the atom
-                        auto bank_group_index = in_atom_offset + lane_idx * (kSwizzleDMode / kNumBankGroupBytes);
-
-                        // Reshape the atom in another view and swizzle
-                        //  - original: `(BLOCK_M, kSwizzleDMode / kNumBankGroupBytes)`
-                        //  - new: `(BLOCK_M * kSwizzleDMode / kNumBankGroupBytes / 8, 8)`
-                        constexpr bool kHasShortcut = (kSwizzleDMode / kNumBankGroupBytes) == 8;
-                        auto row = kHasShortcut ? (in_atom_offset / 8 + lane_idx) : (bank_group_index / 8);
-                        auto col = kHasShortcut ? (in_atom_offset) : (bank_group_index % 8);
-                        col ^= row % (kSwizzleDMode / 16);
-
-                        // Add back into the base pointer
-                        // NOTES: think twice before modifying this, as changes may affect the number of instructions
-                        smem_ptr = reinterpret_cast<uint8_t*>(smem_d) +                // Base pointer
-                            warp_idx * (WGMMA_M_PER_WARP * kSwizzleDMode) +            // Warp offset
-                            m_offset * kSwizzleDMode +                                 // Wave offset
-                            atom_offset * BLOCK_M * kSwizzleDMode +                    // Swizzle atom offset (constants)
-                            row * (kNumBankGroupBytes * 8) + col * kNumBankGroupBytes; // In-atom offset
-                    } else {
-                        // No swizzling, just padding
-                        smem_ptr = reinterpret_cast<uint8_t*>(smem_d + (m_offset + warp_idx * WGMMA_M_PER_WARP + lane_idx) * BLOCK_N + i * 8);
-                    }
-
                     // NOTES: only 16 lanes' addresses are used
+                    auto smem_ptr = &smem_d(i * 8 / TMA_D_BLOCK_N, m_offset + warp_idx * WGMMA_M_PER_WARP + lane_idx, i * 8 % TMA_D_BLOCK_N);
                     SM90_U32x2_STSM_N<nv_bfloat162>::copy(
                         __float22bfloat162_rn({shifted_accum[i * 4 + 0], shifted_accum[i * 4 + 1]}),
                         __float22bfloat162_rn({shifted_accum[i * 4 + 2], shifted_accum[i * 4 + 3]}),
@@ -421,7 +406,7 @@ sm90_fp8_gemm_1d2d_impl(float* sfb, int* grouped_layout,
             DG_STATIC_ASSERT(kNumMathThreads >= BLOCK_N / TMA_D_BLOCK_N, "Too many TMA blocks");
             if (threadIdx.x < BLOCK_N / TMA_D_BLOCK_N) {
                 auto in_block_n_offset = threadIdx.x * TMA_D_BLOCK_N;
-                auto smem_ptr = smem_d + in_block_n_offset * BLOCK_M;
+                auto smem_ptr = &smem_d(threadIdx.x, 0, 0);
                 cute::SM90_TMA_STORE_2D::copy(&tensor_map_d, smem_ptr,
                                               n_block_idx * BLOCK_N + in_block_n_offset,
                                               scheduler.get_global_idx<kWithGroupOffsetD>(shape_m, BLOCK_M, m_block_idx));


### PR DESCRIPTION
Manually index smem_d is tedious and hard to maintain. By using cute::tensor, we can leverage CuTe's layout system to automatically handle the indexing and swizzling of shared memory.

As we only need to perform swizzle on smem_d, make it as a CuTe Tensor will be helpful like follow:
```cpp
  constexpr auto BBits = kSwizzleDMode == 128 ? 3 : (kSwizzleDMode == 64 ? 2 : 1);
  auto smem_d = cute::make_tensor(
      cute::make_smem_ptr(reinterpret_cast<cute::bfloat16_t*>(smem_buffer)),
      cute::composition(
          cute::Swizzle<BBits, 3, 3>{}, 
          cute::make_layout(
          cute::make_shape(BLOCK_N / TMA_D_BLOCK_N, BLOCK_M, TMA_D_BLOCK_N),
              cute::LayoutRight{}
          )
      )
  );
```

And instead of:
```cpp
  uint8_t* smem_ptr = nullptr;
  if constexpr (kSwizzleDMode > 0) {
      // Calculate the swizzling atom offset and in-atom offset
      constexpr uint32_t kNumBankGroupBytes = 16;
      auto atom_offset = i / (TMA_D_BLOCK_N / 8), in_atom_offset = i % (TMA_D_BLOCK_N / 8);

      // Calculate the index of the bank group to be written in the atom
      auto bank_group_index = in_atom_offset + lane_idx * (kSwizzleDMode / kNumBankGroupBytes);

      // Reshape the atom in another view and swizzle
      //  - original: `(BLOCK_M, kSwizzleDMode / kNumBankGroupBytes)`
      //  - new: `(BLOCK_M * kSwizzleDMode / kNumBankGroupBytes / 8, 8)`
      constexpr bool kHasShortcut = (kSwizzleDMode / kNumBankGroupBytes) == 8;
      auto row = kHasShortcut ? (in_atom_offset / 8 + lane_idx) : (bank_group_index / 8);
      auto col = kHasShortcut ? (in_atom_offset) : (bank_group_index % 8);
      col ^= row % (kSwizzleDMode / 16);

      // Add back into the base pointer
      // NOTES: think twice before modifying this, as changes may affect the number of instructions
      smem_ptr = reinterpret_cast<uint8_t*>(smem_d) +                // Base pointer
          warp_idx * (WGMMA_M_PER_WARP * kSwizzleDMode) +            // Warp offset
          m_offset * kSwizzleDMode +                                 // Wave offset
          atom_offset * BLOCK_M * kSwizzleDMode +                    // Swizzle atom offset (constants)
          row * (kNumBankGroupBytes * 8) + col * kNumBankGroupBytes; // In-atom offset
  } else {
      // No swizzling, just padding
      smem_ptr = reinterpret_cast<uint8_t*>(smem_d + (m_offset + warp_idx * WGMMA_M_PER_WARP + lane_idx) * BLOCK_N + i * 8);
  }
```
We only need to write:
```cpp
auto smem_ptr = &smem_d(i * 8 / TMA_D_BLOCK_N, m_offset + warp_idx * WGMMA_M_PER_WARP + lane_idx, i * 8 % TMA_D_BLOCK_N);
```

which is more readable and maintainable. As for Performance, I have tested on H20, and results show that this will not incur any overheads:
Before Modification
```
Testing GEMM:
 > Perf (m=  128, n= 2112, k= 7168, 1D2D, layout=NT, BF16, acc=0): launch   38 us |   21 us |  181 TFLOPS |  778 GB/s
 > Perf (m=  128, n=24576, k= 1536, 1D2D, layout=NT, BF16, acc=0): launch   46 us |   44 us |  219 TFLOPS | 1001 GB/s
 > Perf (m=  128, n=32768, k=  512, 1D2D, layout=NT, BF16, acc=0): launch   46 us |   25 us |  174 TFLOPS | 1022 GB/s
 > Perf (m=  128, n= 7168, k=16384, 1D2D, layout=NT, BF16, acc=0): launch   44 us |  117 us |  257 TFLOPS | 1040 GB/s
 > Perf (m=  128, n= 4096, k= 7168, 1D2D, layout=NT, BF16, acc=0): launch   46 us |   34 us |  223 TFLOPS |  932 GB/s
 > Perf (m=  128, n= 7168, k= 2048, 1D2D, layout=NT, BF16, acc=0): launch   43 us |   19 us |  202 TFLOPS |  902 GB/s
 > Perf (m= 4096, n= 2112, k= 7168, 1D2D, layout=NT, BF16, acc=0): launch   42 us |  465 us |  266 TFLOPS |  135 GB/s
 > Perf (m= 4096, n=24576, k= 1536, 1D2D, layout=NT, BF16, acc=0): launch   46 us | 1160 us |  267 TFLOPS |  212 GB/s
 > Perf (m= 4096, n=32768, k=  512, 1D2D, layout=NT, BF16, acc=0): launch   43 us |  568 us |  242 TFLOPS |  506 GB/s
 > Perf (m= 4096, n= 7168, k=16384, 1D2D, layout=NT, BF16, acc=0): launch   50 us | 3583 us |  269 TFLOPS |   68 GB/s
 > Perf (m= 4096, n= 4096, k= 7168, 1D2D, layout=NT, BF16, acc=0): launch   44 us |  923 us |  261 TFLOPS |  101 GB/s
 > Perf (m= 4096, n= 7168, k= 2048, 1D2D, layout=NT, BF16, acc=0): launch   44 us |  469 us |  257 TFLOPS |  175 GB/s

Testing m-grouped contiguous GEMM:
 > Perf (num_groups=4, m=35456, n= 4096, k= 7168, 1D2D, layout=NT): 7579 us |  275 TFLOPS |   88 GB/s
 > Perf (num_groups=4, m=36096, n= 7168, k= 2048, 1D2D, layout=NT): 4036 us |  263 TFLOPS |  162 GB/s
 > Perf (num_groups=8, m=32384, n= 4096, k= 7168, 1D2D, layout=NT): 6918 us |  275 TFLOPS |  107 GB/s
 > Perf (num_groups=8, m=31232, n= 7168, k= 2048, 1D2D, layout=NT): 3527 us |  260 TFLOPS |  179 GB/s

Testing m-grouped masked GEMM:
 > Perf (num_groups=1, expected_m_per_group=1024, n=4096, k=7168, 1D2D):  350 us |  176 TFLOPS |  131 GB/s
 > Perf (num_groups=1, expected_m_per_group=1024, n=7168, k=2048, 1D2D):  160 us |  206 TFLOPS |  207 GB/s
 > Perf (num_groups=2, expected_m_per_group= 512, n=4096, k=7168, 1D2D):  351 us |  194 TFLOPS |  219 GB/s
 > Perf (num_groups=2, expected_m_per_group= 512, n=7168, k=2048, 1D2D):  143 us |  202 TFLOPS |  319 GB/s
 > Perf (num_groups=4, expected_m_per_group= 256, n=4096, k=7168, 1D2D):  467 us |  139 TFLOPS |  289 GB/s
 > Perf (num_groups=4, expected_m_per_group= 256, n=7168, k=2048, 1D2D):  161 us |  165 TFLOPS |  458 GB/s
```

After modification:
```
Testing GEMM:
 > Perf (m=  128, n= 2112, k= 7168, 1D2D, layout=NT, BF16, acc=0): launch   37 us |   21 us |  181 TFLOPS |  775 GB/s
 > Perf (m=  128, n=24576, k= 1536, 1D2D, layout=NT, BF16, acc=0): launch   45 us |   44 us |  218 TFLOPS |  998 GB/s
 > Perf (m=  128, n=32768, k=  512, 1D2D, layout=NT, BF16, acc=0): launch   44 us |   25 us |  174 TFLOPS | 1022 GB/s
 > Perf (m=  128, n= 7168, k=16384, 1D2D, layout=NT, BF16, acc=0): launch   44 us |  117 us |  258 TFLOPS | 1041 GB/s
 > Perf (m=  128, n= 4096, k= 7168, 1D2D, layout=NT, BF16, acc=0): launch   48 us |   34 us |  223 TFLOPS |  930 GB/s
 > Perf (m=  128, n= 7168, k= 2048, 1D2D, layout=NT, BF16, acc=0): launch   43 us |   18 us |  203 TFLOPS |  908 GB/s
 > Perf (m= 4096, n= 2112, k= 7168, 1D2D, layout=NT, BF16, acc=0): launch   44 us |  466 us |  266 TFLOPS |  135 GB/s
 > Perf (m= 4096, n=24576, k= 1536, 1D2D, layout=NT, BF16, acc=0): launch   46 us | 1165 us |  265 TFLOPS |  211 GB/s
 > Perf (m= 4096, n=32768, k=  512, 1D2D, layout=NT, BF16, acc=0): launch   44 us |  570 us |  241 TFLOPS |  504 GB/s
 > Perf (m= 4096, n= 7168, k=16384, 1D2D, layout=NT, BF16, acc=0): launch   46 us | 3568 us |  270 TFLOPS |   69 GB/s
 > Perf (m= 4096, n= 4096, k= 7168, 1D2D, layout=NT, BF16, acc=0): launch   45 us |  917 us |  262 TFLOPS |  102 GB/s
 > Perf (m= 4096, n= 7168, k= 2048, 1D2D, layout=NT, BF16, acc=0): launch   44 us |  465 us |  259 TFLOPS |  177 GB/s

Testing m-grouped contiguous GEMM:
 > Perf (num_groups=4, m=35456, n= 4096, k= 7168, 1D2D, layout=NT): 7509 us |  277 TFLOPS |   89 GB/s
 > Perf (num_groups=4, m=36096, n= 7168, k= 2048, 1D2D, layout=NT): 4010 us |  264 TFLOPS |  163 GB/s
 > Perf (num_groups=8, m=32384, n= 4096, k= 7168, 1D2D, layout=NT): 6852 us |  278 TFLOPS |  108 GB/s
 > Perf (num_groups=8, m=31232, n= 7168, k= 2048, 1D2D, layout=NT): 3492 us |  263 TFLOPS |  181 GB/s

Testing m-grouped masked GEMM:
 > Perf (num_groups=1, expected_m_per_group=1024, n=4096, k=7168, 1D2D):  347 us |  177 TFLOPS |  132 GB/s
 > Perf (num_groups=1, expected_m_per_group=1024, n=7168, k=2048, 1D2D):  159 us |  207 TFLOPS |  208 GB/s
 > Perf (num_groups=2, expected_m_per_group= 512, n=4096, k=7168, 1D2D):  348 us |  195 TFLOPS |  220 GB/s
 > Perf (num_groups=2, expected_m_per_group= 512, n=7168, k=2048, 1D2D):  142 us |  203 TFLOPS |  321 GB/s
 > Perf (num_groups=4, expected_m_per_group= 256, n=4096, k=7168, 1D2D):  463 us |  140 TFLOPS |  291 GB/s
 > Perf (num_groups=4, expected_m_per_group= 256, n=7168, k=2048, 1D2D):  160 us |  166 TFLOPS |  461 GB/s
```