### PR TITLE
Fix inappropriate configs for some small shapes

### DIFF
--- a/csrc/jit_kernels/heuristics/common.hpp
+++ b/csrc/jit_kernels/heuristics/common.hpp
@@ -194,7 +194,9 @@ static GemmConfig get_best_config(const GemmType& gemm_type, const KernelType& k
                     // Case 2: same `block_n`, smaller `block_m` (wasted)
                     success |= block_n == best_block_n and block_m < best_block_m;
                     // Case 3: different for both `block_m` and `block_n`, larger `block_n` is better
-                    success |= block_m != best_block_m and block_n > best_block_n;
+                    // NOTES: don't pick `block_m/block_n` larger than shape `m/n` in this case
+                    success |= block_m != best_block_m and block_n > best_block_n 
+                               and block_n <= n and block_m <= m;
                 }
             }
 


### PR DESCRIPTION
This PR polishes get_best_configs modeling, to avoid picking inappropriate `(block_m, block_n)` for some shapes.
Bad cases before this PR:
|| (m, n, k) | picked (block_m, block_n, block_k) | expected best (block_m, block_n, block_k) | kernel duration (on H20) |
|:---|:---|:---|:---|:---|
| sm90_fp8_gemm_1d2d | 64, 16, 8192 | 256, 48, 128 | 64, 16, 128 | 58 us |


After this PR, a larger `block_n` is picked only when `block_m`, `block_n` are smaller than shape `m`, `n`, respectively.
After this PR:
|| (m, n, k) | picked (block_m, block_n, block_k) | expected best (block_m, block_n, block_k) | kernel duration (on H20) |
|:---|:---|:---|:---|:---|
| sm90_fp8_gemm_1d2d | 64, 16, 8192 |  64, 16, 128 | 64, 16, 128 | 12 us |

Normal shapes (listed in tests/generators.py) are fully tested, and there is no performance degression.
It might also  be a bug for some shapes on sm100. But I don't have sm100 gpus for testing this case.
