### PR TITLE
[Fix] fix B200 cu128 NVCC compilation failed

### DIFF
--- a/csrc/jit/compiler.hpp
+++ b/csrc/jit/compiler.hpp
@@ -155,10 +155,14 @@ public:
         signature = fmt::format("NVCC{}.{}", nvcc_major, nvcc_minor);
 
         // The override the compiler flags
+        std::string selected_arch = device_runtime->get_arch();
+        // Compatibility: NVCC < 12.9 may not recognize sm_100f; fallback to sm_100a
+        if (selected_arch == "100f" && (nvcc_major < 12 || (nvcc_major == 12 && nvcc_minor < 9)))
+            selected_arch = "100a";
         flags = fmt::format("{} -I{} --gpu-architecture=sm_{} "
                             "--compiler-options=-fPIC,-O3,-fconcepts,-Wno-deprecated-declarations,-Wno-abi "
                             "-cubin -O3 --expt-relaxed-constexpr --expt-extended-lambda",
-                            flags, library_include_path.c_str(), device_runtime->get_arch());
+                            flags, library_include_path.c_str(), selected_arch);
     }
 
     void compile(const std::string &code, const std::filesystem::path& dir_path, const std::filesystem::path &cubin_path) const override {
@@ -205,8 +209,12 @@ public:
         }
 
         // Override the compiler flags
+        std::string selected_arch = device_runtime->get_arch();
+        // Compatibility: NVRTC < 12.9 may not recognize sm_100f; fallback to sm_100a
+        if (selected_arch == "100f" && (major < 12 || (major == 12 && minor < 9)))
+            selected_arch = "100a";
         flags = fmt::format("{} {}--gpu-architecture=sm_{} -default-device {}",
-                            flags, include_dirs, device_runtime->get_arch(), pch_flags);
+                            flags, include_dirs, selected_arch, pch_flags);
     }
 
     void compile(const std::string &code, const std::filesystem::path& dir_path, const std::filesystem::path &cubin_path) const override {


### PR DESCRIPTION
cu128 B200 failed with
```bash
➜  DeepGEMM git:(main) python3 /sgl-workspace/DeepGEMM/tests/test_bf16.py                                           
Library path:
 > ['/usr/local/lib/python3.12/dist-packages/deep_gemm']

Testing GEMM:
Warning: please use at least NVCC 12.9 for the best DeepGEMM performanceNVCC compilation failed: nvcc fatal   : Unsupported gpu architecture 'sm_100f'

Traceback (most recent call last):
  File "/sgl-workspace/DeepGEMM/tests/test_bf16.py", line 123, in <module>
    test_gemm()
  File "/sgl-workspace/DeepGEMM/tests/test_bf16.py", line 30, in test_gemm
    getattr(deep_gemm, func_name)(a, b, d, c=c)
RuntimeError: Assertion error (csrc/apis/../jit_kernels/impls/../../jit/compiler.hpp:176): false and "NVCC compilation failed"
```

After fix
```bash
➜  DeepGEMM git:(main) ✗ python3 /sgl-workspace/DeepGEMM/tests/test_bf16.py                                         
Library path:
 > ['/usr/local/lib/python3.12/dist-packages/deep_gemm']

Testing GEMM:
 > Perf (m=  128, n= 2112, k= 7168, layout=NT, BF16, acc=0):   18 us |  221 TFLOPS | 1860 GB/s | 0.79x cuBLAS
 > Perf (m=  128, n= 2112, k= 7168, layout=NT, FP32, acc=0):   18 us |  212 TFLOPS | 1815 GB/s | 0.00x cuBLAS
 > Perf (m=  128, n= 2112, k= 7168, layout=NT, FP32, acc=1):   18 us |  212 TFLOPS | 1871 GB/s | 0.00x cuBLAS
 > Perf (m=  128, n= 2112, k= 7168, layout=NN, BF16, acc=0):   18 us |  218 TFLOPS | 1833 GB/s | 0.78x cuBLAS
 > Perf (m=  128, n= 2112, k= 7168, layout=NN, FP32, acc=0):   19 us |  207 TFLOPS | 1774 GB/s | 0.00x cuBLAS
 > Perf (m=  128, n= 2112, k= 7168, layout=NN, FP32, acc=1):   19 us |  206 TFLOPS | 1821 GB/s | 0.00x cuBLAS
 > Perf (m=  128, n= 2112, k= 7168, layout=TT, BF16, acc=0):   18 us |  220 TFLOPS | 1851 GB/s | 0.79x cuBLAS
 > Perf (m=  128, n= 2112, k= 7168, layout=TT, FP32, acc=0):   18 us |  212 TFLOPS | 1820 GB/s | 0.00x cuBLAS
 > Perf (m=  128, n= 2112, k= 7168, layout=TT, FP32, acc=1):   18 us |  210 TFLOPS | 1855 GB/s | 0.00x cuBLAS
 > Perf (m=  128, n= 2112, k= 7168, layout=TN, BF16, acc=0):   18 us |  218 TFLOPS | 1837 GB/s | 0.77x cuBLAS
```