### PR TITLE
[Feat] Single Batch Overlap (SBO): Overlaping of Down GEMM with Combine Send

### DIFF
--- a/csrc/apis/gemm.hpp
+++ b/csrc/apis/gemm.hpp
@@ -265,7 +265,7 @@ static std::pair<int, int> m_grouped_fp8_gemm_nt_signal(const std::pair<torch::T
     const auto& arch_major = device_runtime->get_arch_major();
     if (arch_major == 9 and sfa.scalar_type() == torch::kFloat) {
         return sm90_m_grouped_fp8_gemm_signal_1d2d(a.first, sfa, b.first, sfb, d, masked_m, signal,
-                                            num_groups, m, n, k, expected_m, major_a, major_b, compiled_dims);
+                                            num_groups, m, n, k, expected_m, major_a, major_b, compiled_dims, max_block_n);
     } else {
         DG_HOST_UNREACHABLE("Unsupported architecture or scaling factor types");
     }

--- a/csrc/apis/gemm.hpp
+++ b/csrc/apis/gemm.hpp
@@ -229,7 +229,8 @@ static std::pair<int, int> m_grouped_fp8_gemm_nt_signal(const std::pair<torch::T
                                          const int& expected_m,
                                          std::optional<std::tuple<int, int, int>> recipe,
                                          const std::string& compiled_dims,
-                                         const bool& disable_ue8m0_cast) {
+                                         const bool& disable_ue8m0_cast,
+                                         const int& max_block_n = 256) {
     // Shape must be `[G, M, K] @ [G, N, K].mT`
     const auto& major_a = get_major_type_ab(a.first);
     const auto& major_b = get_major_type_ab(b.first);
@@ -489,7 +490,7 @@ static void register_apis(pybind11::module_& m) {
     m.def("m_grouped_fp8_gemm_nt_signal", &m_grouped_fp8_gemm_nt_signal,
           py::arg("a"), py::arg("b"), py::arg("d"), py::arg("masked_m"), py::arg("signal"),
           py::arg("expected_m"), py::arg("recipe") = std::nullopt,
-          py::arg("compiled_dims") = "nk", py::arg("disable_ue8m0_cast") = false);
+          py::arg("compiled_dims") = "nk", py::arg("disable_ue8m0_cast") = false, py::arg("max_block_n") = 256);
     m.def("k_grouped_fp8_gemm_tn_contiguous", &k_grouped_fp8_gemm_tn_contiguous,
           py::arg("a"), py::arg("b"), py::arg("d"), py::arg("ks"),
           py::arg("ks_tensor"), py::arg("c") = std::nullopt,

--- a/csrc/jit/handle.hpp
+++ b/csrc/jit/handle.hpp
@@ -37,7 +37,8 @@ static void unload_library(const LibraryHandle& library) {
 
 static LaunchConfigHandle construct_launch_config(const KernelHandle& kernel,
                                                   const cudaStream_t& stream, const int& smem_size,
-                                                  const dim3& grid_dim, const dim3& block_dim, const int& cluster_dim) {
+                                                  const dim3& grid_dim, const dim3& block_dim, 
+                                                  const int& cluster_dim, const bool& cooperative = false) {
     if (smem_size > 0)
         DG_CUDA_RUNTIME_CHECK(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
 
@@ -49,14 +50,27 @@ static LaunchConfigHandle construct_launch_config(const KernelHandle& kernel,
     config.numAttrs = 0;
     config.attrs = nullptr;
 
-    // NOTES: must use `static` or the `attr` will be deconstructed
-    static LaunchAttrHandle attr;
+    // 支持多个属性
+    static LaunchAttrHandle attrs[2];
+    int attr_count = 0;
+    
     if (cluster_dim > 1) {
-        attr.id = cudaLaunchAttributeClusterDimension;
-        attr.val.clusterDim = {static_cast<unsigned>(cluster_dim), 1, 1};
-        config.attrs = &attr;
-        config.numAttrs = 1;
+        attrs[attr_count].id = cudaLaunchAttributeClusterDimension;
+        attrs[attr_count].val.clusterDim = {static_cast<unsigned>(cluster_dim), 1, 1};
+        attr_count++;
     }
+    
+    if (cooperative) {
+        attrs[attr_count].id = cudaLaunchAttributeCooperative;
+        attrs[attr_count].val.cooperative = 1;
+        attr_count++;
+    }
+    
+    if (attr_count > 0) {
+        config.attrs = attrs;
+        config.numAttrs = attr_count;
+    }
+    
     return config;
 }
 
@@ -95,7 +109,7 @@ static void unload_library(const LibraryHandle& library) {
 
 static LaunchConfigHandle construct_launch_config(const KernelHandle& kernel,
                                                  const cudaStream_t& stream, const int& smem_size,
-                                                 const dim3& grid_dim, const dim3& block_dim, const int& cluster_dim) {
+                                                 const dim3& grid_dim, const dim3& block_dim, const int& cluster_dim, const bool& cooperative = false) {
     if (smem_size > 0)
         DG_CUDA_DRIVER_CHECK(cuFuncSetAttribute(kernel, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, smem_size));
 
@@ -111,16 +125,30 @@ static LaunchConfigHandle construct_launch_config(const KernelHandle& kernel,
     config.numAttrs = 0;
     config.attrs = nullptr;
 
+    // 支持多个属性
     // NOTES: must use `static` or the `attr` will be deconstructed
-    static LaunchAttrHandle attr;
+    static LaunchAttrHandle attrs[2];
+    int attr_count = 0;
+
     if (cluster_dim > 1) {
-        attr.id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
-        attr.value.clusterDim.x = cluster_dim;
-        attr.value.clusterDim.y = 1;
-        attr.value.clusterDim.z = 1;
-        config.attrs = &attr;
-        config.numAttrs = 1;
+        attrs[attr_count].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
+        attrs[attr_count].value.clusterDim.x = cluster_dim;
+        attrs[attr_count].value.clusterDim.y = 1;
+        attrs[attr_count].value.clusterDim.z = 1;
+        attr_count++;
     }
+
+    if (cooperative) {
+        attrs[attr_count].id = CU_LAUNCH_ATTRIBUTE_COOPERATIVE;
+        attrs[attr_count].value.cooperative = 1;
+        attr_count++;
+    }
+
+    if (attr_count > 0) {
+        config.attrs = attrs;
+        config.numAttrs = attr_count;
+    }
+
     return config;
 }
 

--- a/csrc/jit/kernel_runtime.hpp
+++ b/csrc/jit/kernel_runtime.hpp
@@ -13,12 +13,17 @@ struct LaunchArgs {
     int num_threads;
     int smem_size;
     int cluster_dim;
+    bool cooperative;
 
-    LaunchArgs(const int& grid_dim_x, const int& num_threads, const int& smem_size = 0, const int& cluster_dim = 1):
-        grid_dim({grid_dim_x, 1}), num_threads(num_threads), smem_size(smem_size), cluster_dim(cluster_dim) {}
+    LaunchArgs(const int& grid_dim_x, const int& num_threads, const int& smem_size = 0, 
+               const int& cluster_dim = 1, const bool& cooperative = false):
+        grid_dim({grid_dim_x, 1}), num_threads(num_threads), smem_size(smem_size), 
+        cluster_dim(cluster_dim), cooperative(cooperative) {}
 
-    LaunchArgs(const std::pair<int, int>& grid_dim, const int& num_threads, const int& smem_size = 0, const int& cluster_dim = 1):
-        grid_dim(grid_dim), num_threads(num_threads), smem_size(smem_size), cluster_dim(cluster_dim) {}
+    LaunchArgs(const std::pair<int, int>& grid_dim, const int& num_threads, const int& smem_size = 0, 
+               const int& cluster_dim = 1, const bool& cooperative = false):
+        grid_dim(grid_dim), num_threads(num_threads), smem_size(smem_size), 
+        cluster_dim(cluster_dim), cooperative(cooperative) {}
 };
 
 class KernelRuntime final {

--- a/csrc/jit_kernels/heuristics/common.hpp
+++ b/csrc/jit_kernels/heuristics/common.hpp
@@ -210,7 +210,7 @@ static GemmConfig get_best_config(const GemmType& gemm_type, const KernelType& k
         }
     }
     DG_HOST_ASSERT(best_block_m > 0 and best_block_n > 0);
-    printf("Best block size: (%d, %d)\n", best_block_m, best_block_n);
+    printf("Best num waves: %d, Best block size: (%d, %d)\n", best_num_waves, best_block_m, best_block_n);
 
     // Decide the number of TMA multicasts and whether broadcast on A
     MulticastConfig best_multicast_config = {1, true};

--- a/csrc/jit_kernels/heuristics/common.hpp
+++ b/csrc/jit_kernels/heuristics/common.hpp
@@ -150,6 +150,9 @@ static GemmConfig get_best_config(const GemmType& gemm_type, const KernelType& k
                                   const bool& with_accumulation, const int& num_sms) {
     DG_HOST_ASSERT(ab_dtype == torch::kFloat8_e4m3fn or ab_dtype == torch::kBFloat16);
     DG_HOST_ASSERT(cd_dtype == torch::kBFloat16 or cd_dtype == torch::kFloat);
+    printf("m: %d, n: %d, k: %d, num_groups: %d, major_a: %d, major_b: %d, ab_dtype: %d, cd_dtype: %d, with_accumulation: %d, num_sms: %d\n",
+           m, n, k, num_groups, static_cast<int>(major_a), static_cast<int>(major_b),
+           static_cast<int>(ab_dtype), static_cast<int>(cd_dtype), with_accumulation, num_sms);
 
     // Select M/N block sizes
     // TODO: support `% 16 == 8` block size on SM90

--- a/csrc/jit_kernels/heuristics/common.hpp
+++ b/csrc/jit_kernels/heuristics/common.hpp
@@ -210,6 +210,7 @@ static GemmConfig get_best_config(const GemmType& gemm_type, const KernelType& k
         }
     }
     DG_HOST_ASSERT(best_block_m > 0 and best_block_n > 0);
+    printf("Best block size: (%d, %d)\n", best_block_m, best_block_n);
 
     // Decide the number of TMA multicasts and whether broadcast on A
     MulticastConfig best_multicast_config = {1, true};

--- a/csrc/jit_kernels/heuristics/common.hpp
+++ b/csrc/jit_kernels/heuristics/common.hpp
@@ -61,6 +61,7 @@ struct GemmConfig {
     cute::UMMA::Major major_b;
     bool with_accumulation;
     int block_m, block_n, block_k;
+    int signal_threshold;
     int num_stages, num_last_stages;
 
     // Templated device configs
@@ -266,6 +267,7 @@ static GemmConfig get_best_config(const GemmType& gemm_type, const KernelType& k
         .block_m = best_block_m,
         .block_n = best_block_n,
         .block_k = block_k,
+        .signal_threshold = ceil_div(n, best_block_n),
         .num_stages = best_num_stages,
         .num_last_stages = ceil_div(k, block_k) % best_num_stages,
         .num_sms = num_min_sms,

--- a/csrc/jit_kernels/heuristics/sm90.hpp
+++ b/csrc/jit_kernels/heuristics/sm90.hpp
@@ -42,7 +42,7 @@ struct SM90ArchSpec {
 
         // Too many scaling factors in a single block: `block_n > block_k and std::gcd(block_n, block_k) != block_n - block_k`
         // Or too many register spills
-        if (block_n > 128 and kernel_type == KernelType::Kernel1D2D and (block_n != 144 and block_n != 160 and block_n != 192))
+        if (block_n > 128 and kernel_type == KernelType::Kernel1D2D and (block_n != 144 and block_n != 160 and block_n != 176 and block_n != 192))
             return false;
 
         // Avoid bank conflicts for FP32 output

--- a/csrc/jit_kernels/heuristics/sm90.hpp
+++ b/csrc/jit_kernels/heuristics/sm90.hpp
@@ -42,7 +42,7 @@ struct SM90ArchSpec {
 
         // Too many scaling factors in a single block: `block_n > block_k and std::gcd(block_n, block_k) != block_n - block_k`
         // Or too many register spills
-        if (block_n > 128 and kernel_type == KernelType::Kernel1D2D and (block_n != 144 and block_n != 160 and block_n != 176 and block_n != 192))
+        if (block_n > 128 and kernel_type == KernelType::Kernel1D2D and (block_n != 144 and block_n != 160 and block_n != 192))
             return false;
 
         // Avoid bank conflicts for FP32 output

--- a/csrc/jit_kernels/impls/sm90_fp8_gemm_1d2d.hpp
+++ b/csrc/jit_kernels/impls/sm90_fp8_gemm_1d2d.hpp
@@ -3,7 +3,6 @@
 #include <torch/python.h>
 
 #include "../../jit/compiler.hpp"
-#include "../../jit/device_runtime.hpp"
 #include "../../jit/kernel_runtime.hpp"
 #include "../../utils/exception.hpp"
 #include "../../utils/format.hpp"
@@ -140,7 +139,7 @@ static void sm90_m_grouped_fp8_gemm_contiguous_1d2d(const torch::Tensor& a, cons
     const auto& aligned_k = align(k, 128);
     const auto& config = get_best_config<SM90ArchSpec>(
         GemmType::MGroupedContiguous, KernelType::Kernel1D2D,
-        m, n, k, 1, major_a, major_b,
+        m, n, k, num_groups, major_a, major_b,
         torch::kFloat8_e4m3fn, d.scalar_type(), false,
         device_runtime->get_num_sms());
 
@@ -244,6 +243,127 @@ static void sm90_m_grouped_fp8_gemm_masked_1d2d(const torch::Tensor& a, const to
     const auto& code = SM90FP8Gemm1D2DRuntime::generate(args);
     const auto& runtime = compiler->build("sm90_fp8_m_grouped_gemm_masked_1d2d", code);
     SM90FP8Gemm1D2DRuntime::launch(runtime, args);
+}
+
+class SM90FP8SignalGemm1D2DRuntime final: public LaunchRuntime<SM90FP8SignalGemm1D2DRuntime> {
+public:
+    struct Args {
+        int m, n, k, num_groups;
+        const std::string& compiled_dims;
+
+        GemmConfig gemm_config;
+        LaunchArgs launch_args;
+
+        void *sfb, *grouped_layout, *signal;
+        CUtensorMap tensor_map_a;
+        CUtensorMap tensor_map_b;
+        CUtensorMap tensor_map_d;
+        CUtensorMap tensor_map_sfa;
+    };
+
+    static std::string generate_impl(const Args& args) {
+        return fmt::format(R"(
+#include <deep_gemm/impls/sm90_fp8_signal_gemm_1d2d.cuh>
+
+using namespace deep_gemm;
+
+static void __instantiate_kernel() {{
+    auto ptr = reinterpret_cast<void*>(&sm90_fp8_signal_gemm_1d2d_impl<
+        {}, {}, {},
+        {},
+        {}, {}, {},
+        {},
+        {}, {},
+        {}, {},
+        {}, {},
+        {}, {}
+    >);
+}};
+)",
+        get_compiled_dim(args.m, 'm', args.compiled_dims), 
+        get_compiled_dim(args.n, 'n', args.compiled_dims), 
+        get_compiled_dim(args.k, 'k', args.compiled_dims),
+        args.num_groups,
+        args.gemm_config.block_m, args.gemm_config.block_n, args.gemm_config.block_k,
+        args.gemm_config.smem_config.swizzle_cd_mode,
+        args.gemm_config.num_stages, args.gemm_config.num_last_stages,
+        args.gemm_config.thread_config.num_tma_threads, args.gemm_config.thread_config.num_math_threads,
+        args.gemm_config.multicast_config.num_multicast, args.gemm_config.multicast_config.is_multicast_on_a,
+        args.gemm_config.num_sms, to_string(args.gemm_config.gemm_type));
+    }
+
+    static void launch_impl(const KernelHandle& kernel, const LaunchConfigHandle& config, Args args) {
+        DG_CUDA_UNIFIED_CHECK(launch_kernel(kernel, config,
+            args.sfb, args.grouped_layout, args.signal,
+            args.m, args.n, args.k,
+            args.tensor_map_a, args.tensor_map_b,
+            args.tensor_map_d, args.tensor_map_sfa));
+    }
+};
+
+static std::pair<int, int> sm90_m_grouped_fp8_gemm_signal_1d2d(const torch::Tensor& a, const torch::Tensor& sfa,
+                                                const torch::Tensor& b, const torch::Tensor& sfb,
+                                                const torch::Tensor& d,
+                                                const torch::Tensor& masked_m,
+                                                const torch::Tensor& signal,
+                                                const int& num_groups, const int& m, const int& n, const int& k,
+                                                const int& expected_m,
+                                                const cute::UMMA::Major& major_a, const cute::UMMA::Major& major_b,
+                                                const std::string& compiled_dims) {
+    const auto& aligned_k = align(k, 128);
+    DG_HOST_ASSERT(d.scalar_type() == torch::kBFloat16);
+    DG_HOST_ASSERT(major_a == cute::UMMA::Major::K and major_b == cute::UMMA::Major::K);
+    DG_HOST_ASSERT(signal.scalar_type() == torch::kInt32);
+
+    const auto& config = get_best_config<SM90ArchSpec>(
+        GemmType::MGroupedMasked, KernelType::Kernel1D2D,
+        expected_m, n, k, num_groups, major_a, major_b,
+        torch::kFloat8_e4m3fn, d.scalar_type(), false,
+        device_runtime->get_num_sms());
+
+    // Requires no TMA splits
+    DG_HOST_ASSERT(config.smem_config.swizzle_a_mode == config.block_k);
+    DG_HOST_ASSERT(config.smem_config.swizzle_b_mode == config.block_k);
+    const auto& tensor_map_a = make_tma_a_desc(major_a, a, m, k,
+                                               SM90ArchSpec::get_ab_load_block_m(config.multicast_config, config.block_m),
+                                               config.block_k,
+                                               static_cast<int>(a.stride(get_non_contiguous_dim(major_a))), num_groups,
+                                               config.smem_config.swizzle_a_mode);
+    const auto& tensor_map_b = make_tma_b_desc(major_b, b, n, k,
+                                               SM90ArchSpec::get_ab_load_block_n(config.multicast_config, config.block_n),
+                                               config.block_k,
+                                               static_cast<int>(b.stride(get_non_contiguous_dim(major_b))), num_groups,
+                                               config.smem_config.swizzle_b_mode);
+    const auto& tensor_map_d = make_tma_cd_desc(d, m, n,
+                                                SM90ArchSpec::get_cd_store_block_m(config.block_m),
+                                                SM90ArchSpec::get_cd_store_block_n(config.block_n),
+                                                static_cast<int>(d.stride(-2)), num_groups,
+                                                config.smem_config.swizzle_cd_mode);
+    const auto& tensor_map_sfa = make_tma_sf_desc(cute::UMMA::Major::MN, sfa, m, k,
+                                                  config.block_m, config.block_k, num_groups, 0);
+
+    // Launch with cooperative groups support
+    const SM90FP8SignalGemm1D2DRuntime::Args& args = {
+        .m = m, .n = n, .k = aligned_k,
+        .num_groups = num_groups,
+        .compiled_dims = compiled_dims,
+        .gemm_config = config,
+        .launch_args = LaunchArgs(config.num_sms, config.thread_config.num_threads,
+                                  config.smem_config.smem_size,
+                                  config.multicast_config.num_multicast,
+                                  true), // 启用cooperative groups
+        .sfb = sfb.data_ptr(),
+        .grouped_layout = masked_m.data_ptr(),
+        .signal = signal.data_ptr(),
+        .tensor_map_a = tensor_map_a,
+        .tensor_map_b = tensor_map_b,
+        .tensor_map_d = tensor_map_d,
+        .tensor_map_sfa = tensor_map_sfa,
+    };
+    const auto& code = SM90FP8SignalGemm1D2DRuntime::generate(args);
+    const auto& runtime = compiler->build("sm90_fp8_m_grouped_gemm_signal_1d2d", code);
+    SM90FP8SignalGemm1D2DRuntime::launch(runtime, args);
+    return std::make_pair(config.block_m, config.signal_threshold);
 }
 
 } // namespace deep_gemm

--- a/csrc/jit_kernels/impls/sm90_fp8_gemm_1d2d.hpp
+++ b/csrc/jit_kernels/impls/sm90_fp8_gemm_1d2d.hpp
@@ -309,7 +309,7 @@ static std::pair<int, int> sm90_m_grouped_fp8_gemm_signal_1d2d(const torch::Tens
                                                 const int& num_groups, const int& m, const int& n, const int& k,
                                                 const int& expected_m,
                                                 const cute::UMMA::Major& major_a, const cute::UMMA::Major& major_b,
-                                                const std::string& compiled_dims) {
+                                                const std::string& compiled_dims, const int& max_block_n = 256) {
     const auto& aligned_k = align(k, 128);
     DG_HOST_ASSERT(d.scalar_type() == torch::kBFloat16);
     DG_HOST_ASSERT(major_a == cute::UMMA::Major::K and major_b == cute::UMMA::Major::K);
@@ -319,7 +319,7 @@ static std::pair<int, int> sm90_m_grouped_fp8_gemm_signal_1d2d(const torch::Tens
         GemmType::MGroupedMasked, KernelType::Kernel1D2D,
         expected_m, n, k, num_groups, major_a, major_b,
         torch::kFloat8_e4m3fn, d.scalar_type(), false,
-        device_runtime->get_num_sms());
+        device_runtime->get_num_sms(), max_block_n);
 
     // Requires no TMA splits
     DG_HOST_ASSERT(config.smem_config.swizzle_a_mode == config.block_k);

--- a/deep_gemm/__init__.py
+++ b/deep_gemm/__init__.py
@@ -28,6 +28,7 @@ from deep_gemm_cpp import (
     m_grouped_fp8_gemm_nt_contiguous,
     m_grouped_fp8_gemm_nn_contiguous,
     m_grouped_fp8_gemm_nt_masked,
+    m_grouped_fp8_gemm_nt_signal,
     k_grouped_fp8_gemm_tn_contiguous,
     # BF16 GEMMs
     bf16_gemm_nt, bf16_gemm_nn,

--- a/deep_gemm/include/deep_gemm/impls/sm90_fp8_signal_gemm_1d2d.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm90_fp8_signal_gemm_1d2d.cuh
@@ -432,12 +432,12 @@ sm90_fp8_signal_gemm_1d2d_impl(float* sfb, int* grouped_layout, int32_t* signal,
             }
             __syncwarp();
 
-            // if (threadIdx.x < BLOCK_N / TMA_D_BLOCK_N) {
-            //     cute::tma_store_wait<0>();
-            // }
+            if (threadIdx.x < BLOCK_N / TMA_D_BLOCK_N) {
+                cute::tma_store_wait<0>();
+            }
 
             group.sync();
-            __threadfence();  
+            // __threadfence();  
             
             if (threadIdx.x == 0) {
                 atomicAdd(signal + scheduler.current_group_idx * ceil_div(shape_m, BLOCK_M) + m_block_idx, 1);

--- a/deep_gemm/include/deep_gemm/impls/sm90_fp8_signal_gemm_1d2d.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm90_fp8_signal_gemm_1d2d.cuh
@@ -437,7 +437,6 @@ sm90_fp8_signal_gemm_1d2d_impl(float* sfb, int* grouped_layout, int32_t* signal,
             }
 
             group.sync();
-            // __threadfence();  
             
             if (threadIdx.x == 0) {
                 atomicAdd(signal + scheduler.current_group_idx * ceil_div(shape_m, BLOCK_M) + m_block_idx, 1);

--- a/deep_gemm/include/deep_gemm/impls/sm90_fp8_signal_gemm_1d2d.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm90_fp8_signal_gemm_1d2d.cuh
@@ -432,9 +432,9 @@ sm90_fp8_signal_gemm_1d2d_impl(float* sfb, int* grouped_layout, int32_t* signal,
             }
             __syncwarp();
 
-            if (threadIdx.x < BLOCK_N / TMA_D_BLOCK_N) {
-                cute::tma_store_wait<0>();
-            }
+            // if (threadIdx.x < BLOCK_N / TMA_D_BLOCK_N) {
+            //     cute::tma_store_wait<0>();
+            // }
 
             group.sync();
             __threadfence();  

--- a/deep_gemm/include/deep_gemm/impls/sm90_fp8_signal_gemm_1d2d.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm90_fp8_signal_gemm_1d2d.cuh
@@ -432,7 +432,12 @@ sm90_fp8_signal_gemm_1d2d_impl(float* sfb, int* grouped_layout, int32_t* signal,
             }
             __syncwarp();
 
+            if (threadIdx.x < BLOCK_N / TMA_D_BLOCK_N) {
+                cute::tma_store_wait<0>();
+            }
+
             group.sync();
+            __threadfence();  
             
             if (threadIdx.x == 0) {
                 atomicAdd(signal + scheduler.current_group_idx * ceil_div(shape_m, BLOCK_M) + m_block_idx, 1);

--- a/deep_gemm/include/deep_gemm/impls/sm90_fp8_signal_gemm_1d2d.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm90_fp8_signal_gemm_1d2d.cuh
@@ -1,0 +1,451 @@
+#pragma once
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunknown-attributes"
+
+#include <cooperative_groups.h>
+#include <cutlass/arch/barrier.h>
+#include <cutlass/arch/reg_reconfig.h>
+
+#include <cute/arch/cluster_sm90.hpp>
+#include <cute/arch/copy_sm90_desc.hpp>
+#include <cute/arch/copy_sm90_tma.hpp>
+
+#include <deep_gemm/common/utils.cuh>
+#include <deep_gemm/common/scheduler.cuh>
+#include <deep_gemm/common/sm90_utils.cuh>
+
+namespace cg = cooperative_groups;
+namespace deep_gemm {
+
+using namespace deep_gemm::sm90;
+
+template <uint32_t kNumFormerIters, uint32_t kGap, uint32_t kEnd>
+__device__ __host__ void outer_launch_k_iterations(const auto& inner_launch_k_iterations, const auto& func, uint32_t num_former_iters) {
+    if (num_former_iters == kNumFormerIters) {
+        inner_launch_k_iterations(func, cute::Int<kNumFormerIters>{});
+        return;
+    }
+
+    if constexpr (kNumFormerIters + kGap <= kEnd)
+        outer_launch_k_iterations<kNumFormerIters + kGap, kGap, kEnd>(inner_launch_k_iterations, func, num_former_iters);
+}
+
+template <uint32_t SHAPE_M, uint32_t SHAPE_N, uint32_t SHAPE_K,
+          uint32_t kNumGroups,
+          uint32_t BLOCK_M, uint32_t BLOCK_N, uint32_t BLOCK_K,
+          uint32_t kSwizzleDMode,
+          uint32_t kNumStages, uint32_t kNumLastStages,
+          uint32_t kNumTMAThreads, uint32_t kNumMathThreads,
+          uint32_t kNumTMAMulticast, bool kIsTMAMulticastOnA,
+          uint32_t kNumSMs, GemmType kGemmType>
+__global__ __launch_bounds__(kNumTMAThreads + kNumMathThreads, 1) void
+sm90_fp8_signal_gemm_1d2d_impl(float* sfb, int* grouped_layout, int32_t* signal,
+                               uint32_t shape_m, uint32_t shape_n, uint32_t shape_k,
+                               const __grid_constant__ cute::TmaDescriptor tensor_map_a,
+                               const __grid_constant__ cute::TmaDescriptor tensor_map_b,
+                               const __grid_constant__ cute::TmaDescriptor tensor_map_d,
+                               const __grid_constant__ cute::TmaDescriptor tensor_map_sfa) {
+#if (defined(__CUDA_ARCH__) and (__CUDA_ARCH__ >= 900)) or defined(__CLION_IDE__)
+    // Scaling checks
+    DG_STATIC_ASSERT(BLOCK_K == 128, "Only support per-128-channel FP8 scaling");
+    DG_STATIC_ASSERT(constexpr_ceil_div(BLOCK_N, BLOCK_K) == 1 or (constexpr_gcd(BLOCK_N, BLOCK_K) == BLOCK_N - BLOCK_K), "Too much B scales in a single block");
+
+    // Types
+    using WGMMA = typename FP8MMASelector<BLOCK_N>::type;
+    using Barrier = cutlass::arch::ClusterTransactionBarrier;
+    DG_STATIC_ASSERT(BLOCK_M % WGMMA::M == 0, "Invalid block size");
+
+    // Overwrite shape constants if the compiler gives
+    shape_m = SHAPE_M != 0 ? SHAPE_M : shape_m;
+    shape_n = SHAPE_N != 0 ? SHAPE_N : shape_n;
+    shape_k = SHAPE_K != 0 ? SHAPE_K : shape_k;
+
+    // Shared memory
+    static constexpr bool kMustUseUniformedScaleB = (BLOCK_K % BLOCK_N == 0);
+    static constexpr uint32_t SMEM_D_SIZE = BLOCK_M * BLOCK_N * sizeof(__nv_bfloat16);
+    static constexpr uint32_t SMEM_A_SIZE_PER_STAGE = BLOCK_M * BLOCK_K * sizeof(__nv_fp8_e4m3);
+    static constexpr uint32_t SMEM_B_SIZE_PER_STAGE = BLOCK_N * BLOCK_K * sizeof(__nv_fp8_e4m3);
+    static constexpr uint32_t SMEM_SFA_SIZE_PER_STAGE = BLOCK_M * sizeof(float);
+    const uint32_t& shape_k_scales = ceil_div(shape_k, BLOCK_K);
+    const uint32_t& smem_sfb_size = align<uint32_t>(shape_k_scales * (kMustUseUniformedScaleB ? 1 : 2) * sizeof(float), sizeof(Barrier));
+
+    // Configs
+    constexpr uint32_t kFullKOfAllStages = kNumStages * BLOCK_K;
+    const uint32_t num_iterations = ceil_div(shape_k, kFullKOfAllStages);
+    const uint32_t warp_idx = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
+    const uint32_t lane_idx = get_lane_idx();
+
+    // Prefetch TMA descriptors at the very beginning
+    if (threadIdx.x == kNumMathThreads) {
+        // NOTES: `reinterpret_cast` must be here, or NVRTC will fail
+        cute::prefetch_tma_descriptor(&tensor_map_a);
+        cute::prefetch_tma_descriptor(&tensor_map_b);
+        cute::prefetch_tma_descriptor(&tensor_map_sfa);
+        cute::prefetch_tma_descriptor(&tensor_map_d);
+    }
+    __syncwarp();
+
+    // Align to 1024 bytes for swizzle-128B
+    extern __shared__ __align__(1024) uint8_t smem_buffer[];
+    DG_STATIC_ASSERT(SMEM_D_SIZE % 1024 == 0, "Shared memory of A/B must be aligned to 1024 bytes");
+
+    // Data on shared memory
+    auto smem_d = reinterpret_cast<__nv_bfloat16*>(smem_buffer);
+    __nv_fp8_e4m3* smem_a[kNumStages];
+    __nv_fp8_e4m3* smem_b[kNumStages];
+    float* smem_sfa[kNumStages];
+    float* smem_sfb;
+
+    // TMA Barrier for both divisible and non-divisible cases
+    Barrier* full_barriers[kNumStages];
+    Barrier* empty_barriers[kNumStages];
+
+    // Fill shared memory pointers
+    #pragma unroll
+    for (uint32_t i = 0; i < kNumStages; ++ i) {
+        smem_a[i] = reinterpret_cast<__nv_fp8_e4m3*>(smem_buffer + SMEM_D_SIZE + i * SMEM_A_SIZE_PER_STAGE);
+        smem_b[i] = reinterpret_cast<__nv_fp8_e4m3*>(smem_buffer + SMEM_D_SIZE + kNumStages * SMEM_A_SIZE_PER_STAGE + i * SMEM_B_SIZE_PER_STAGE);
+        smem_sfa[i] = reinterpret_cast<float*>(smem_buffer + SMEM_D_SIZE + kNumStages * (SMEM_A_SIZE_PER_STAGE + SMEM_B_SIZE_PER_STAGE) + i * SMEM_SFA_SIZE_PER_STAGE);
+    }
+    smem_sfb = reinterpret_cast<float*>(smem_buffer + SMEM_D_SIZE + kNumStages * (SMEM_A_SIZE_PER_STAGE + SMEM_B_SIZE_PER_STAGE + SMEM_SFA_SIZE_PER_STAGE));
+
+    // Fill barriers
+    auto barrier_start_ptr = reinterpret_cast<Barrier*>(reinterpret_cast<uint8_t*>(smem_sfb) + smem_sfb_size);
+    #pragma unroll
+    for (uint32_t i = 0; i < kNumStages; ++ i) {
+        full_barriers[i] = barrier_start_ptr + i;
+        empty_barriers[i] = barrier_start_ptr + kNumStages + i;
+    }
+
+    // Initialize barriers
+    DG_STATIC_ASSERT(kNumTMAMulticast <= 32, "Too many TMA multicast");
+    if (threadIdx.x == kNumMathThreads) {
+        // NOTES: we always use `lane_idx` to arrive for the `lane_idx`-th CTA in the cluster,
+        // even with TMA multicast disabled, we want to make the behavior aligned
+        #pragma unroll
+        for (uint32_t i = 0; i < kNumStages; ++ i) {
+            full_barriers[i]->init(1);
+            empty_barriers[i]->init(kNumTMAMulticast * kNumMathThreads / 32);
+        }
+
+        // Make initialized barrier visible in async proxy
+        cutlass::arch::fence_view_async_shared();
+        cutlass::arch::fence_barrier_init();
+    }
+
+    // Synchronize all threads to make barrier visible in normal memory model
+    (kNumTMAMulticast > 1) ? cute::cluster_sync() : __syncthreads();
+
+    // For pipeline unrolling
+    struct DivisibleK {};
+    struct NotDivisibleK {};
+    struct SkipComputation {};
+    struct NotSkipComputation {};
+    auto launch_k_iterations = [=](const auto& func, bool skip_computation, uint32_t num_former_iters) {
+        constexpr bool kShouldOptimize = BLOCK_K / constexpr_gcd(BLOCK_K, BLOCK_N) <= 4 and not kMustUseUniformedScaleB;
+        constexpr uint32_t kGap = constexpr_gcd(BLOCK_K, BLOCK_N) / 8;
+        constexpr uint32_t kEnd = kShouldOptimize ? BLOCK_K / 8 : 0;
+
+        // NOTES: for too-many branches (> 5), we disable this optimization
+        // Otherwise, the compiler must know the dynamic variable `num_former_iters`'s real value
+        outer_launch_k_iterations<0, kGap, kEnd>([=](const auto& func, auto num_former_iters_type) {
+            if (skip_computation) {
+                for (uint32_t k_iter = 0; k_iter < num_iterations; ++ k_iter)
+                    func(k_iter, DivisibleK{}, SkipComputation{}, num_former_iters_type);
+            } else if (shape_k % kFullKOfAllStages == 0) {
+                for (uint32_t k_iter = 0; k_iter < num_iterations; ++ k_iter)
+                    func(k_iter, DivisibleK{}, NotSkipComputation{}, num_former_iters_type);
+            } else {
+                for (uint32_t k_iter = 0; k_iter < num_iterations - 1; ++ k_iter)
+                    func(k_iter, DivisibleK{}, NotSkipComputation{}, num_former_iters_type);
+                func(num_iterations - 1, NotDivisibleK{}, NotSkipComputation{}, num_former_iters_type);
+            }
+        }, func, kShouldOptimize ? num_former_iters : 0);
+    };
+
+    // Register reconfigurations
+    constexpr uint32_t kNumTMARegisters = 40;
+    constexpr uint32_t kNumMathRegisters = 232;
+
+    // Block scheduler
+    uint32_t m_block_idx, n_block_idx;
+    auto scheduler = Scheduler<kGemmType, BLOCK_M, BLOCK_N, kNumGroups, kNumTMAMulticast, kIsTMAMulticastOnA, kNumSMs>(shape_m, shape_n, grouped_layout);
+
+    if (threadIdx.x >= kNumMathThreads) {
+        // TMA warp-group for loading data
+        cutlass::arch::warpgroup_reg_dealloc<kNumTMARegisters>();
+
+        // NOTES: only one thread (or warp) will be used
+        if (threadIdx.x == kNumMathThreads) {
+            // Persistently schedule over blocks
+            while (scheduler.get_next_block(m_block_idx, n_block_idx)) {
+                launch_k_iterations([&](uint32_t k_iter, auto divisible_type, auto _, auto __) {
+                    constexpr bool kHasDivisibleStages = cute::is_same_v<decltype(divisible_type), DivisibleK>;
+                    constexpr uint32_t kNumInnerStages = kHasDivisibleStages ? kNumStages : kNumLastStages;
+
+                    // Assign TMA multicast number into A and B
+                    // NOTES: there may be additional odd rows/columns or cases where multicast is not possible.
+                    const bool is_tma_multicast_valid = scheduler.is_tma_multicast_valid(m_block_idx);
+                    const uint32_t num_tma_multicast_a = (kIsTMAMulticastOnA and is_tma_multicast_valid) ? kNumTMAMulticast : 1;
+                    const uint32_t num_tma_multicast_b = (not kIsTMAMulticastOnA and is_tma_multicast_valid) ? kNumTMAMulticast : 1;
+                    DG_STATIC_ASSERT(kNumTMAMulticast <= 2, "Scheduler does not support > 2 TMA multicast");
+
+                    // NOTES: unrolling and `kNumInnerStages` are vital for performance, NVCC will try to eliminate all
+                    // shared memory pointers, e.g. `full_barriers` registers, if all the access indices are constant
+                    #pragma unroll
+                    for (uint32_t s = 0; s < kNumInnerStages; ++ s) {
+                        // Wait consumer release
+                        empty_barriers[s]->wait((scheduler.current_iter * num_iterations + k_iter + 1) & 1);
+
+                        // Issue TMA A
+                        constexpr bool kWithGroupOffsetA = kGemmType == GemmType::MGroupedMasked;
+                        auto& full_barrier = *full_barriers[s];
+                        uint32_t k_idx = k_iter * kFullKOfAllStages + s * BLOCK_K;
+                        tma_copy(&tensor_map_a, reinterpret_cast<uint64_t*>(&full_barrier),
+                                 smem_a[s], k_idx, scheduler.get_global_idx<kWithGroupOffsetA>(shape_m, BLOCK_M, m_block_idx),
+                                 num_tma_multicast_a);
+                        tma_copy(&tensor_map_sfa, reinterpret_cast<uint64_t*>(&full_barrier),
+                                 smem_sfa[s], m_block_idx * BLOCK_M,
+                                 scheduler.get_global_idx<kWithGroupOffsetA>(shape_k_scales, 1, k_idx / BLOCK_K),
+                                 num_tma_multicast_a);
+
+                        // Issue TMA B
+                        tma_copy(&tensor_map_b, reinterpret_cast<uint64_t*>(&full_barrier),
+                                 smem_b[s], k_idx, scheduler.get_global_idx<true>(shape_n, BLOCK_N, n_block_idx, m_block_idx),
+                                 num_tma_multicast_b);
+                        full_barrier.arrive_and_expect_tx(SMEM_A_SIZE_PER_STAGE + SMEM_B_SIZE_PER_STAGE + SMEM_SFA_SIZE_PER_STAGE);
+                    }
+
+                    // Wait unaligned cases
+                    #pragma unroll
+                    for (uint32_t s = kNumInnerStages; s < kNumStages; ++ s) {
+                        empty_barriers[s]->wait((scheduler.current_iter * num_iterations + k_iter + 1) & 1);
+                        full_barriers[s]->arrive();
+                    }
+                }, false, 0);
+            }
+
+            // To safely deconstruct distributed shared barriers, we need another round of empty waits
+            if constexpr (kNumTMAMulticast > 1) {
+                #pragma unroll
+                for (uint32_t s = 0; s < kNumStages; ++ s)
+                    empty_barriers[s]->wait((scheduler.current_iter * num_iterations + 1) & 1);
+            }
+        }
+    } else {
+        cg::coalesced_group group = cg::coalesced_threads();
+        // Math warp-groups for WGMMA
+        cutlass::arch::warpgroup_reg_alloc<kNumMathRegisters>();
+
+        // NOTES: use `__shfl_sync` to encourage NVCC to use unified registers
+        const auto math_wg_idx = __shfl_sync(0xffffffff, threadIdx.x / 128, 0);
+        const auto r_0 = warp_idx * 16 + lane_idx / 4, r_1 = r_0 + 8;
+
+        // Persistently schedule over blocks
+        while (scheduler.get_next_block(m_block_idx, n_block_idx)) {
+            // Decide the number of scales B to load
+            DG_TRAP_ONLY_DEVICE_ASSERT(shape_n % 8 == 0);
+            uint32_t num_former_iters = BLOCK_N / 8, num_full_iters = num_former_iters;
+            if constexpr (not kMustUseUniformedScaleB) {
+                num_former_iters = min(BLOCK_N, BLOCK_K - n_block_idx * BLOCK_N % BLOCK_K) / 8;
+                num_full_iters = min(shape_n - n_block_idx * BLOCK_N, BLOCK_N) / 8;
+            }
+            uint32_t num_sfb = shape_k_scales * (num_former_iters >= num_full_iters ? 1 : 2);
+
+            // Load B scales with math warp-groups
+            // NOTES: except the first warp, we want to overlap loading B scales with TMA stores between tasks
+            if (threadIdx.x >= 32) {
+                auto num_previous_lines = scheduler.get_global_idx<true>(ceil_div(shape_n, BLOCK_K), 0, 0, m_block_idx);
+                auto local_sfb = sfb + (num_previous_lines + ((n_block_idx * BLOCK_N) / BLOCK_K)) * shape_k_scales;
+                #pragma unroll
+                for (uint32_t i = threadIdx.x - 32; i < num_sfb; i += kNumMathThreads - 32)
+                    st_shared(smem_sfb + i, __ldg(local_sfb + i));
+            }
+            cutlass::arch::NamedBarrier(kNumMathThreads).sync();
+
+            // Accumulation for WGMMA or CUDA promotion
+            constexpr uint32_t WAVE_BLOCK_M = WGMMA::M * (BLOCK_M <= 64 ? 1 : 2);
+            DG_STATIC_ASSERT(BLOCK_M % WAVE_BLOCK_M == 0, "Invalid block sizes");
+            float accum[WGMMA::kNumAccum], final_accum[WGMMA::kNumAccum * (BLOCK_M / WAVE_BLOCK_M)] = {0};
+
+            // Empty barrier arrival
+            auto empty_barrier_arrive = [&](uint32_t s) {
+                if constexpr (kNumTMAMulticast == 1) {
+                    lane_idx == 0 ? empty_barriers[s]->arrive() : void();
+                } else {
+                    auto target_cta = scheduler.is_peer_cta_alive ? lane_idx : cute::block_rank_in_cluster();
+                    lane_idx < kNumTMAMulticast ? empty_barriers[s]->arrive(target_cta) : void();
+                }
+            };
+
+            // Launch MMAs
+            launch_k_iterations([&](uint32_t k_iter, auto divisible_type, auto skip_type, auto _) {
+                constexpr bool kSkipComputation = cute::is_same_v<decltype(skip_type), SkipComputation>;
+                constexpr bool kHasDivisibleStages = cute::is_same_v<decltype(divisible_type), DivisibleK>;
+                constexpr uint32_t kNumInnerStages = kSkipComputation ? 0 : (kHasDivisibleStages ? kNumStages : kNumLastStages);
+
+                #pragma unroll
+                for (uint32_t s = 0; s < kNumInnerStages; ++ s) {
+                    // Read B scales
+                    float scale_b_0 = ld_shared(smem_sfb + k_iter * kNumStages + s), scale_b_1;
+                    // NOTES: even some blocks do not need to read the second row, but we still load one to align with other blocks
+                    if constexpr (not kMustUseUniformedScaleB)
+                        scale_b_1 = ld_shared(smem_sfb + k_iter * kNumStages + s + shape_k_scales);
+
+                    // Wait TMA arrivals
+                    full_barriers[s]->wait((scheduler.current_iter * num_iterations + k_iter) & 1);
+
+                    // TODO: remove some useless computation for unaligned Ms
+                    #pragma unroll
+                    for (uint32_t local_idx = 0; local_idx < BLOCK_M / WAVE_BLOCK_M; ++ local_idx) {
+                      	auto m_offset = local_idx * WAVE_BLOCK_M;
+
+                    	// Read A scales
+                    	// NOTES: all shared memory read must be prior to `warpgroup_arrive` to avoid next scheduled block polluting the results
+                    	auto scale_a_0 = ld_shared(smem_sfa[s] + r_0 + m_offset);
+                        auto scale_a_1 = ld_shared(smem_sfa[s] + r_1 + m_offset);
+
+                    	// Commit WGMMA instructions
+                    	#pragma unroll
+                    	for (uint32_t i = 0; i < WGMMA::kNumAccum; ++ i)
+                            warpgroup_fence_operand(accum[i]);
+                    	warpgroup_arrive();
+                    	#pragma unroll
+                    	for (uint32_t k = 0; k < BLOCK_K / WGMMA::K; ++ k) {
+                            auto desc_a = make_smem_desc(smem_a[s] + (math_wg_idx * WGMMA::M + m_offset) * BLOCK_K + k * WGMMA::K, 1);
+                            auto desc_b = make_smem_desc(smem_b[s] + k * WGMMA::K, 1);
+                            WGMMA::wgmma(desc_a, desc_b, accum, k);
+                    	}
+                    	warpgroup_commit_batch();
+                    	#pragma unroll
+                    	for (uint32_t i = 0; i < WGMMA::kNumAccum; ++ i)
+                            warpgroup_fence_operand(accum[i]);
+                    	warpgroup_wait<0>();
+
+                    	// Notify barrier arrival at the last warpgroup wave
+                        if (local_idx == BLOCK_M / WAVE_BLOCK_M - 1)
+                    	    empty_barrier_arrive(s);
+
+                    	// Promote with scales
+                    	// NOTES: making it as predicates is very important for performance, comparing to two loops
+                    	float scale_0_0 = scale_a_0 * scale_b_0, scale_1_0 = scale_a_1 * scale_b_0;
+                    	float scale_0_1, scale_1_1;
+                    	if constexpr (not kMustUseUniformedScaleB)
+                            scale_0_1 = scale_a_0 * scale_b_1, scale_1_1 = scale_a_1 * scale_b_1;
+
+                        auto shifted_accum = final_accum + WGMMA::kNumAccum * local_idx;
+                    	#pragma unroll
+                    	for (uint32_t i = 0; i < WGMMA::kNumAccum / 4; ++ i) {
+                            // NOTES: for unrolled `num_former_iters` cases, we expect the compiler to automatically make it a constant
+                            bool predicate = kMustUseUniformedScaleB or i < num_former_iters;
+                            shifted_accum[i * 4 + 0] += (predicate ? scale_0_0 : scale_0_1) * accum[i * 4 + 0];
+                            shifted_accum[i * 4 + 1] += (predicate ? scale_0_0 : scale_0_1) * accum[i * 4 + 1];
+                            shifted_accum[i * 4 + 2] += (predicate ? scale_1_0 : scale_1_1) * accum[i * 4 + 2];
+                            shifted_accum[i * 4 + 3] += (predicate ? scale_1_0 : scale_1_1) * accum[i * 4 + 3];
+                    	}
+                    }
+                }
+
+                // Wait unaligned cases
+                #pragma unroll
+                for (uint32_t s = kNumInnerStages; s < kNumStages; ++ s) {
+                    full_barriers[s]->wait((scheduler.current_iter * num_iterations + k_iter) & 1);
+                    empty_barrier_arrive(s);
+                }
+            }, not scheduler.is_computation_valid(m_block_idx, math_wg_idx * WGMMA::M), num_former_iters);
+
+            // TMA checks
+            constexpr uint32_t kNumElemBytes = sizeof(nv_bfloat16);
+            constexpr uint32_t TMA_D_BLOCK_N = kSwizzleDMode == 0 ? BLOCK_N : (kSwizzleDMode / kNumElemBytes);
+            constexpr uint32_t WGMMA_M_PER_WARP = WGMMA::M / 4;
+            DG_STATIC_ASSERT(BLOCK_M % 8 == 0, "Invalid swizzling atom");
+            DG_STATIC_ASSERT(BLOCK_N % TMA_D_BLOCK_N == 0 and BLOCK_N / TMA_D_BLOCK_N <= 32,
+                            "Unaligned TMA store or too many TMA store instructions");
+            DG_STATIC_ASSERT(TMA_D_BLOCK_N % 8 == 0, "Invalid TMA block N");
+
+            // Wait last TMA store to be finished
+            if (threadIdx.x < BLOCK_N / TMA_D_BLOCK_N)
+                cute::tma_store_wait<0>();
+            cutlass::arch::NamedBarrier(kNumMathThreads).sync();
+
+            // Write back to shared memory using STSM and issue TMA stores
+            DG_STATIC_ASSERT(WGMMA::kNumAccum % 4 == 0, "Invalid STSM x2 vectorization");
+            #pragma unroll
+            for (uint32_t local_idx = 0; local_idx < BLOCK_M / WAVE_BLOCK_M; ++ local_idx) {
+                auto m_offset = local_idx * WAVE_BLOCK_M;
+                auto shifted_accum = final_accum + WGMMA::kNumAccum * local_idx;
+                #pragma unroll
+                for (auto i = 0; i < WGMMA::kNumAccum / 4; ++ i) {
+                    // Swizzle or padding into the correct address
+                    uint8_t* smem_ptr = nullptr;
+                    if constexpr (kSwizzleDMode > 0) {
+                        // Calculate the swizzling atom offset and in-atom offset
+                        constexpr uint32_t kNumBankGroupBytes = 16;
+                        auto atom_offset = i / (TMA_D_BLOCK_N / 8), in_atom_offset = i % (TMA_D_BLOCK_N / 8);
+
+                        // Calculate the index of the bank group to be written in the atom
+                        auto bank_group_index = in_atom_offset + lane_idx * (kSwizzleDMode / kNumBankGroupBytes);
+
+                        // Reshape the atom in another view and swizzle
+                        //  - original: `(BLOCK_M, kSwizzleDMode / kNumBankGroupBytes)`
+                        //  - new: `(BLOCK_M * kSwizzleDMode / kNumBankGroupBytes / 8, 8)`
+                        constexpr bool kHasShortcut = (kSwizzleDMode / kNumBankGroupBytes) == 8;
+                        auto row = kHasShortcut ? (in_atom_offset / 8 + lane_idx) : (bank_group_index / 8);
+                        auto col = kHasShortcut ? (in_atom_offset) : (bank_group_index % 8);
+                        col ^= row % (kSwizzleDMode / 16);
+
+                        // Add back into the base pointer
+                        // NOTES: think twice before modifying this, as changes may affect the number of instructions
+                        smem_ptr = reinterpret_cast<uint8_t*>(smem_d) +                // Base pointer
+                            warp_idx * (WGMMA_M_PER_WARP * kSwizzleDMode) +            // Warp offset
+                            m_offset * kSwizzleDMode +                                 // Wave offset
+                            atom_offset * BLOCK_M * kSwizzleDMode +                    // Swizzle atom offset (constants)
+                            row * (kNumBankGroupBytes * 8) + col * kNumBankGroupBytes; // In-atom offset
+                    } else {
+                        // No swizzling, just padding
+                        smem_ptr = reinterpret_cast<uint8_t*>(smem_d + (m_offset + warp_idx * WGMMA_M_PER_WARP + lane_idx) * BLOCK_N + i * 8);
+                    }
+
+                    // NOTES: only 16 lanes' addresses are used
+                    SM90_U32x2_STSM_N<nv_bfloat162>::copy(
+                        __float22bfloat162_rn({shifted_accum[i * 4 + 0], shifted_accum[i * 4 + 1]}),
+                        __float22bfloat162_rn({shifted_accum[i * 4 + 2], shifted_accum[i * 4 + 3]}),
+                        smem_ptr
+                    );
+                }
+            }
+            cute::tma_store_fence();
+            cutlass::arch::NamedBarrier(kNumMathThreads).sync();
+
+            // Use TMA store to write back to global memory
+            // TODO: compatible with FP32 output
+            constexpr bool kWithGroupOffsetD = kGemmType == GemmType::MGroupedMasked;
+            DG_STATIC_ASSERT(kNumMathThreads >= BLOCK_N / TMA_D_BLOCK_N, "Too many TMA blocks");
+            if (threadIdx.x < BLOCK_N / TMA_D_BLOCK_N) {
+                auto in_block_n_offset = threadIdx.x * TMA_D_BLOCK_N;
+                auto smem_ptr = smem_d + in_block_n_offset * BLOCK_M;
+                cute::SM90_TMA_STORE_2D::copy(&tensor_map_d, smem_ptr,
+                                              n_block_idx * BLOCK_N + in_block_n_offset,
+                                              scheduler.get_global_idx<kWithGroupOffsetD>(shape_m, BLOCK_M, m_block_idx));
+                cute::tma_store_arrive();
+            }
+            __syncwarp();
+
+            group.sync();
+            
+            if (threadIdx.x == 0) {
+                atomicAdd(signal + scheduler.current_group_idx * ceil_div(shape_m, BLOCK_M) + m_block_idx, 1);
+            }
+
+        }
+    }
+#else
+    if (blockIdx.x == 0 and threadIdx.x == 0)
+        DG_DEVICE_ASSERT(false and "Signal GEMM kernel only supports SM90 architecture");
+#endif
+}
+
+};  // namespace deep_gemm
+
+#pragma clang diagnostic pop

--- a/deep_gemm/include/deep_gemm/impls/sm90_fp8_signal_gemm_1d2d.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm90_fp8_signal_gemm_1d2d.cuh
@@ -437,7 +437,9 @@ sm90_fp8_signal_gemm_1d2d_impl(float* sfb, int* grouped_layout, int32_t* signal,
             }
 
             group.sync();
-            
+
+            __threadfence();
+
             if (threadIdx.x == 0) {
                 atomicAdd(signal + scheduler.current_group_idx * ceil_div(shape_m, BLOCK_M) + m_block_idx, 1);
             }

--- a/tests/generators.py
+++ b/tests/generators.py
@@ -86,10 +86,15 @@ def enumerate_m_grouped_contiguous(use_bf16: bool = False) -> Generator:
 
 
 def enumerate_m_grouped_masked() -> Generator:
-    max_m = 4096
+    max_m = 2048
+    # max_m = 4096
+    # for kernel_type in get_kernel_types():
+    #     for num_groups, m in ((1, 1024), (2, 512), (4, 256)):
+    #         for n, k in ((4096, 7168), (7168, 2048), ):
+    #             yield kernel_type, num_groups, max_m, m, n, k
     for kernel_type in get_kernel_types():
-        for num_groups, m in ((1, 1024), (2, 512), (4, 256)):
-            for n, k in ((4096, 7168), (7168, 2048), ):
+        for num_groups, m in ((16, 32), (16, 64)):
+            for n, k in ((7168, 2048), ):
                 yield kernel_type, num_groups, max_m, m, n, k
 
 

--- a/tests/generators.py
+++ b/tests/generators.py
@@ -86,15 +86,10 @@ def enumerate_m_grouped_contiguous(use_bf16: bool = False) -> Generator:
 
 
 def enumerate_m_grouped_masked() -> Generator:
-    max_m = 2048
-    # max_m = 4096
-    # for kernel_type in get_kernel_types():
-    #     for num_groups, m in ((1, 1024), (2, 512), (4, 256)):
-    #         for n, k in ((4096, 7168), (7168, 2048), ):
-    #             yield kernel_type, num_groups, max_m, m, n, k
+    max_m = 4096
     for kernel_type in get_kernel_types():
-        for num_groups, m in ((16, 32), (16, 64)):
-            for n, k in ((7168, 2048), ):
+        for num_groups, m in ((1, 1024), (2, 512), (4, 256)):
+            for n, k in ((4096, 7168), (7168, 2048), ):
                 yield kernel_type, num_groups, max_m, m, n, k
 
 

--- a/tests/test_fp8.py
+++ b/tests/test_fp8.py
@@ -159,6 +159,44 @@ def test_k_grouped_gemm_contiguous() -> None:
     print()
 
 
+def test_m_grouped_gemm_signal() -> None:
+    print('Testing m-grouped signal GEMM:')
+    
+    # TODO: when the actual `m` is greater than `expected_m_per_group`, efficiency may significantly decrease.
+    for kernel_type, num_groups, max_m, expected_m_per_group, n, k in enumerate_m_grouped_masked():
+        kernel_opt = f'1D1D' if kernel_type.is_1d1d() else '1D2D'
+        use_ue8m0 = get_ue8m0_usage(kernel_type)
+        disable_ue8m0_cast = not use_ue8m0
+        
+        # Test correctness
+        for i in range(10):
+            a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)
+            # Create signal tensor
+            signal = torch.zeros((num_groups, max_m), dtype=torch.int32, device='cuda')
+            result = deep_gemm.m_grouped_fp8_gemm_nt_signal(a, b, d, masked_m, signal, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
+            for j in range(num_groups):
+                diff = calc_diff(d[j, :masked_m[j].item()], ref_d[j, :masked_m[j].item()])
+                assert diff < 0.001, f'{max_m=}, {n=}, {k=}, {j=}, masked_m={masked_m[j]}, {kernel_opt}, {num_groups=}, {diff:.5f}'
+        
+        # Construct full cases
+        a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)
+        # Create signal tensor
+        signal = torch.zeros((num_groups, max_m), dtype=torch.int32, device='cuda')
+        
+        # noinspection PyShadowingNames
+        def test_func():
+            deep_gemm.m_grouped_fp8_gemm_nt_signal(a, b, d, masked_m, signal, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
+        
+        # Test performance with fixed shapes
+        valid_m = masked_m.sum().item()
+        t = bench_kineto(test_func, 'fp8_gemm', suppress_kineto_output=True)
+        print(f' > Perf ({num_groups=}, expected_m_per_group={expected_m_per_group:4}, n={n:4}, k={k:4}, {kernel_opt}): '
+              f'{t * 1e6:4.0f} us | '
+              f'{2 * valid_m * n * k / t / 1e12:4.0f} TFLOPS | '
+              f'{(count_bytes(a, d) * valid_m / (max_m * num_groups) + count_bytes(b)) / 1e9 / t:4.0f} GB/s')
+    print()
+
+
 if __name__ == '__main__':
     torch.backends.cuda.matmul.allow_tf32 = True
     torch.backends.cudnn.allow_tf32 = True
@@ -172,3 +210,4 @@ if __name__ == '__main__':
     test_m_grouped_gemm_contiguous()
     test_m_grouped_gemm_masked()
     test_k_grouped_gemm_contiguous()
+    test_m_grouped_gemm_signal()

--- a/tests/test_signal_gemm.py
+++ b/tests/test_signal_gemm.py
@@ -65,21 +65,21 @@ def test_m_grouped_gemm_signal(max_block_n=256) -> None:
         print(f' > Correctness ({num_groups=}, expected_m_per_group={expected_m_per_group:4}, n={n:4}, k={k:4}, {kernel_opt}) checked ')
 
         # Construct full cases
-        # a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)
-        # max_signal_size = num_groups * ceil_div(max_m, 64)
-        # combine_signal = torch.zeros(max_signal_size, dtype=torch.int32, device='cuda')
+        a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)
+        max_signal_size = num_groups * ceil_div(max_m, 64)
+        combine_signal = torch.zeros(max_signal_size, dtype=torch.int32, device='cuda')
 
-        # # noinspection PyShadowingNames
-        # def test_func():
-        #     deep_gemm.m_grouped_fp8_gemm_nt_signal(a, b, d, masked_m, combine_signal, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
+        # noinspection PyShadowingNames
+        def test_func():
+            deep_gemm.m_grouped_fp8_gemm_nt_signal(a, b, d, masked_m, combine_signal, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
 
-        # # Test performance with fixed shapes
-        # valid_m = masked_m.sum().item()
-        # t = bench_kineto(test_func, 'fp8_signal_gemm', suppress_kineto_output=True)
-        # print(f' > Perf ({num_groups=}, expected_m_per_group={expected_m_per_group:4}, n={n:4}, k={k:4}, {kernel_opt}): '
-        #       f'{t * 1e6:4.0f} us | '
-        #       f'{2 * valid_m * n * k / t / 1e12:4.0f} TFLOPS | '
-        #       f'{(count_bytes(a, d) * valid_m / (max_m * num_groups) + count_bytes(b)) / 1e9 / t:4.0f} GB/s')
+        # Test performance with fixed shapes
+        valid_m = masked_m.sum().item()
+        t = bench_kineto(test_func, 'fp8_signal_gemm', suppress_kineto_output=True)
+        print(f' > Perf ({num_groups=}, expected_m_per_group={expected_m_per_group:4}, n={n:4}, k={k:4}, {kernel_opt}): '
+              f'{t * 1e6:4.0f} us | '
+              f'{2 * valid_m * n * k / t / 1e12:4.0f} TFLOPS | '
+              f'{(count_bytes(a, d) * valid_m / (max_m * num_groups) + count_bytes(b)) / 1e9 / t:4.0f} GB/s')
     print()
 
 
@@ -103,19 +103,19 @@ def test_m_grouped_gemm_masked() -> None:
         print(f' > Correctness ({num_groups=}, expected_m_per_group={expected_m_per_group:4}, n={n:4}, k={k:4}, {kernel_opt}) checked ')
 
         # Construct full cases
-        # a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)
+        a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)
 
-        # # noinspection PyShadowingNames
-        # def test_func():
-        #     deep_gemm.m_grouped_fp8_gemm_nt_masked(a, b, d, masked_m, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
+        # noinspection PyShadowingNames
+        def test_func():
+            deep_gemm.m_grouped_fp8_gemm_nt_masked(a, b, d, masked_m, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
 
-        # # Test performance with fixed shapes
-        # valid_m = masked_m.sum().item()
-        # t = bench_kineto(test_func, 'fp8_gemm', suppress_kineto_output=True)
-        # print(f' > Perf ({num_groups=}, expected_m_per_group={expected_m_per_group:4}, n={n:4}, k={k:4}, {kernel_opt}): '
-        #       f'{t * 1e6:4.0f} us | '
-        #       f'{2 * valid_m * n * k / t / 1e12:4.0f} TFLOPS | '
-        #       f'{(count_bytes(a, d) * valid_m / (max_m * num_groups) + count_bytes(b)) / 1e9 / t:4.0f} GB/s')
+        # Test performance with fixed shapes
+        valid_m = masked_m.sum().item()
+        t = bench_kineto(test_func, 'fp8_gemm', suppress_kineto_output=True)
+        print(f' > Perf ({num_groups=}, expected_m_per_group={expected_m_per_group:4}, n={n:4}, k={k:4}, {kernel_opt}): '
+              f'{t * 1e6:4.0f} us | '
+              f'{2 * valid_m * n * k / t / 1e12:4.0f} TFLOPS | '
+              f'{(count_bytes(a, d) * valid_m / (max_m * num_groups) + count_bytes(b)) / 1e9 / t:4.0f} GB/s')
     print()
 
 if __name__ == '__main__':
@@ -127,6 +127,5 @@ if __name__ == '__main__':
     print('Library path:')
     print(f' > {deep_gemm.__path__}\n')
 
-    for max_block_n in (144, 160, 192):
-        test_m_grouped_gemm_signal(max_block_n)
-        # test_m_grouped_gemm_masked()
+    test_m_grouped_gemm_signal()
+    test_m_grouped_gemm_masked()

--- a/tests/test_signal_gemm.py
+++ b/tests/test_signal_gemm.py
@@ -127,6 +127,5 @@ if __name__ == '__main__':
     print('Library path:')
     print(f' > {deep_gemm.__path__}\n')
 
-    for max_block_n in (144, 160, 192):
-        test_m_grouped_gemm_signal(max_block_n)
+    test_m_grouped_gemm_signal()
         # test_m_grouped_gemm_masked()

--- a/tests/test_signal_gemm.py
+++ b/tests/test_signal_gemm.py
@@ -54,10 +54,8 @@ def test_m_grouped_gemm_signal() -> None:
             max_signal_size = num_groups * ceil_div(max_m, 64)
             combine_signal = torch.zeros(max_signal_size, dtype=torch.int32, device='cuda')
             origin_sms = deep_gemm.get_num_sms()
-            print(f'Origin SMS: {origin_sms}')
             deep_gemm.set_num_sms(origin_sms - 3)
             block_m, threshold = deep_gemm.m_grouped_fp8_gemm_nt_signal(a, b, d, masked_m, combine_signal, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
-            print(f'Current SMS: {deep_gemm.get_num_sms()}')
             deep_gemm.set_num_sms(origin_sms)
             check_signal(num_groups, max_m, block_m, threshold, combine_signal, masked_m)
             for j in range(num_groups):

--- a/tests/test_signal_gemm.py
+++ b/tests/test_signal_gemm.py
@@ -92,7 +92,10 @@ def test_m_grouped_gemm_masked() -> None:
         # Test correctness
         for i in range(2):
             a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)
+            origin_sms = deep_gemm.get_num_sms()
+            deep_gemm.set_num_sms(origin_sms - 3)
             deep_gemm.m_grouped_fp8_gemm_nt_masked(a, b, d, masked_m, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
+            deep_gemm.set_num_sms(origin_sms)
             for j in range(num_groups):
                 diff = calc_diff(d[j, :masked_m[j].item()], ref_d[j, :masked_m[j].item()])
                 assert diff < 0.001, f'{max_m=}, {n=}, {k=}, {j=}, masked_m={masked_m[j]}, {kernel_opt}, {num_groups=}, {diff:.5f}'

--- a/tests/test_signal_gemm.py
+++ b/tests/test_signal_gemm.py
@@ -127,5 +127,6 @@ if __name__ == '__main__':
     print('Library path:')
     print(f' > {deep_gemm.__path__}\n')
 
-    test_m_grouped_gemm_signal()
+    for max_block_n in (144, 160, 192):
+        test_m_grouped_gemm_signal(max_block_n)
         # test_m_grouped_gemm_masked()

--- a/tests/test_signal_gemm.py
+++ b/tests/test_signal_gemm.py
@@ -39,7 +39,7 @@ def check_signal(num_local_expert, max_m, block_m, threshold, combine_signal, ma
                 else:
                     assert signal[i] == 0, f'{i=}, {signal[i]=}'
 
-def test_m_grouped_gemm_signal(max_block_n) -> None:
+def test_m_grouped_gemm_signal(max_block_n=256) -> None:
     print('Testing m-grouped masked GEMM:')
 
     # TODO: when the actual `m` is greater than `expected_m_per_group`, efficiency may significantly decrease.

--- a/tests/test_signal_gemm.py
+++ b/tests/test_signal_gemm.py
@@ -62,21 +62,21 @@ def test_m_grouped_gemm_signal() -> None:
         print(f' > Correctness ({num_groups=}, expected_m_per_group={expected_m_per_group:4}, n={n:4}, k={k:4}, {kernel_opt}) checked ')
 
         # Construct full cases
-        a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)
-        max_signal_size = num_groups * ceil_div(max_m, 64)
-        combine_signal = torch.zeros(max_signal_size, dtype=torch.int32, device='cuda')
+        # a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)
+        # max_signal_size = num_groups * ceil_div(max_m, 64)
+        # combine_signal = torch.zeros(max_signal_size, dtype=torch.int32, device='cuda')
 
-        # noinspection PyShadowingNames
-        def test_func():
-            deep_gemm.m_grouped_fp8_gemm_nt_signal(a, b, d, masked_m, combine_signal, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
+        # # noinspection PyShadowingNames
+        # def test_func():
+        #     deep_gemm.m_grouped_fp8_gemm_nt_signal(a, b, d, masked_m, combine_signal, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
 
-        # Test performance with fixed shapes
-        valid_m = masked_m.sum().item()
-        t = bench_kineto(test_func, 'fp8_signal_gemm', suppress_kineto_output=True)
-        print(f' > Perf ({num_groups=}, expected_m_per_group={expected_m_per_group:4}, n={n:4}, k={k:4}, {kernel_opt}): '
-              f'{t * 1e6:4.0f} us | '
-              f'{2 * valid_m * n * k / t / 1e12:4.0f} TFLOPS | '
-              f'{(count_bytes(a, d) * valid_m / (max_m * num_groups) + count_bytes(b)) / 1e9 / t:4.0f} GB/s')
+        # # Test performance with fixed shapes
+        # valid_m = masked_m.sum().item()
+        # t = bench_kineto(test_func, 'fp8_signal_gemm', suppress_kineto_output=True)
+        # print(f' > Perf ({num_groups=}, expected_m_per_group={expected_m_per_group:4}, n={n:4}, k={k:4}, {kernel_opt}): '
+        #       f'{t * 1e6:4.0f} us | '
+        #       f'{2 * valid_m * n * k / t / 1e12:4.0f} TFLOPS | '
+        #       f'{(count_bytes(a, d) * valid_m / (max_m * num_groups) + count_bytes(b)) / 1e9 / t:4.0f} GB/s')
     print()
 
 
@@ -98,19 +98,19 @@ def test_m_grouped_gemm_masked() -> None:
                 assert diff < 0.001, f'{max_m=}, {n=}, {k=}, {j=}, masked_m={masked_m[j]}, {kernel_opt}, {num_groups=}, {diff:.5f}'
 
         # Construct full cases
-        a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)
+        # a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)
 
-        # noinspection PyShadowingNames
-        def test_func():
-            deep_gemm.m_grouped_fp8_gemm_nt_masked(a, b, d, masked_m, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
+        # # noinspection PyShadowingNames
+        # def test_func():
+        #     deep_gemm.m_grouped_fp8_gemm_nt_masked(a, b, d, masked_m, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
 
-        # Test performance with fixed shapes
-        valid_m = masked_m.sum().item()
-        t = bench_kineto(test_func, 'fp8_gemm', suppress_kineto_output=True)
-        print(f' > Perf ({num_groups=}, expected_m_per_group={expected_m_per_group:4}, n={n:4}, k={k:4}, {kernel_opt}): '
-              f'{t * 1e6:4.0f} us | '
-              f'{2 * valid_m * n * k / t / 1e12:4.0f} TFLOPS | '
-              f'{(count_bytes(a, d) * valid_m / (max_m * num_groups) + count_bytes(b)) / 1e9 / t:4.0f} GB/s')
+        # # Test performance with fixed shapes
+        # valid_m = masked_m.sum().item()
+        # t = bench_kineto(test_func, 'fp8_gemm', suppress_kineto_output=True)
+        # print(f' > Perf ({num_groups=}, expected_m_per_group={expected_m_per_group:4}, n={n:4}, k={k:4}, {kernel_opt}): '
+        #       f'{t * 1e6:4.0f} us | '
+        #       f'{2 * valid_m * n * k / t / 1e12:4.0f} TFLOPS | '
+        #       f'{(count_bytes(a, d) * valid_m / (max_m * num_groups) + count_bytes(b)) / 1e9 / t:4.0f} GB/s')
     print()
 
 if __name__ == '__main__':

--- a/tests/test_signal_gemm.py
+++ b/tests/test_signal_gemm.py
@@ -1,0 +1,91 @@
+import copy
+import random
+import time
+import torch
+
+import deep_gemm
+from deep_gemm.testing import (
+    bench, bench_kineto,
+    calc_diff, count_bytes
+)
+
+from generators import (
+    KernelType, get_ue8m0_usage,
+    enumerate_normal, enumerate_m_grouped_contiguous, enumerate_m_grouped_masked, enumerate_k_grouped_contiguous,
+    generate_normal, generate_m_grouped_contiguous, generate_m_grouped_masked, generate_k_grouped_contiguous
+)
+
+def ceil_div(a, b):
+    return (a + b - 1) // b
+
+def check_signal(num_local_expert, max_m, block_m, threshold, combine_signal, masked_m):
+    signal = combine_signal.cpu().tolist()
+    # print(signal)
+    
+    expert_len = max_m // block_m
+    # print(len(signal))
+    for expert in range(num_local_expert):
+        mask = masked_m[expert]
+        start = expert * expert_len
+        end = expert * (expert_len + 1)
+        if mask == 0:
+            for i in range(start, end):
+                assert signal[i] == 0, f'{i=}, {signal[i]=}'
+        else:
+            valid_len = ceil_div(mask, block_m)
+            for i in range(start, end):
+                if i < start + valid_len:
+                    assert signal[i] == threshold, f'{i=}, {signal[i]=}, {threshold=}'
+                else:
+                    assert signal[i] == 0, f'{i=}, {signal[i]=}'
+
+def test_m_grouped_gemm_signal() -> None:
+    print('Testing m-grouped masked GEMM:')
+
+    # TODO: when the actual `m` is greater than `expected_m_per_group`, efficiency may significantly decrease.
+    for kernel_type, num_groups, max_m, expected_m_per_group, n, k in enumerate_m_grouped_masked():
+        kernel_opt = f'1D1D' if kernel_type.is_1d1d() else '1D2D'
+        use_ue8m0 = get_ue8m0_usage(kernel_type)
+        disable_ue8m0_cast = not use_ue8m0
+
+        # Test correctness
+        for i in range(10):
+            a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)
+            max_signal_size = num_groups * ceil_div(max_m, 64)
+            combine_signal = torch.zeros(max_signal_size, dtype=torch.int32, device='cuda')
+            block_m, threshold = deep_gemm.m_grouped_fp8_gemm_nt_signal(a, b, d, masked_m, combine_signal, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
+            check_signal(num_groups, max_m, block_m, threshold, combine_signal, masked_m)
+            for j in range(num_groups):
+                diff = calc_diff(d[j, :masked_m[j].item()], ref_d[j, :masked_m[j].item()])
+                assert diff < 0.001, f'{m=}, {n=}, {k=}, {j=}, masked_m={masked_m[j]}, {kernel_opt}, {num_groups=}, {diff:.5f}'
+        
+        print(f' > Correctness ({num_groups=}, expected_m_per_group={expected_m_per_group:4}, n={n:4}, k={k:4}, {kernel_opt}) checked ')
+
+        # Construct full cases
+        a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)
+        max_signal_size = num_groups * ceil_div(max_m, 64)
+        combine_signal = torch.zeros(max_signal_size, dtype=torch.int32, device='cuda')
+
+        # noinspection PyShadowingNames
+        def test_func():
+            deep_gemm.m_grouped_fp8_gemm_nt_signal(a, b, d, masked_m, combine_signal, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
+
+        # Test performance with fixed shapes
+        valid_m = masked_m.sum().item()
+        t = bench_kineto(test_func, 'fp8_signal_gemm', suppress_kineto_output=True)
+        print(f' > Perf ({num_groups=}, expected_m_per_group={expected_m_per_group:4}, n={n:4}, k={k:4}, {kernel_opt}): '
+              f'{t * 1e6:4.0f} us | '
+              f'{2 * valid_m * n * k / t / 1e12:4.0f} TFLOPS | '
+              f'{(count_bytes(a, d) * valid_m / (max_m * num_groups) + count_bytes(b)) / 1e9 / t:4.0f} GB/s')
+    print()
+
+if __name__ == '__main__':
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.manual_seed(0)
+    random.seed(0)
+
+    print('Library path:')
+    print(f' > {deep_gemm.__path__}\n')
+
+    test_m_grouped_gemm_signal()

--- a/tests/test_signal_gemm.py
+++ b/tests/test_signal_gemm.py
@@ -79,6 +79,40 @@ def test_m_grouped_gemm_signal() -> None:
               f'{(count_bytes(a, d) * valid_m / (max_m * num_groups) + count_bytes(b)) / 1e9 / t:4.0f} GB/s')
     print()
 
+
+def test_m_grouped_gemm_masked() -> None:
+    print('Testing m-grouped masked GEMM:')
+
+    # TODO: when the actual `m` is greater than `expected_m_per_group`, efficiency may significantly decrease.
+    for kernel_type, num_groups, max_m, expected_m_per_group, n, k in enumerate_m_grouped_masked():
+        kernel_opt = f'1D1D' if kernel_type.is_1d1d() else '1D2D'
+        use_ue8m0 = get_ue8m0_usage(kernel_type)
+        disable_ue8m0_cast = not use_ue8m0
+
+        # Test correctness
+        for i in range(10):
+            a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)
+            deep_gemm.m_grouped_fp8_gemm_nt_masked(a, b, d, masked_m, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
+            for j in range(num_groups):
+                diff = calc_diff(d[j, :masked_m[j].item()], ref_d[j, :masked_m[j].item()])
+                assert diff < 0.001, f'{max_m=}, {n=}, {k=}, {j=}, masked_m={masked_m[j]}, {kernel_opt}, {num_groups=}, {diff:.5f}'
+
+        # Construct full cases
+        a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)
+
+        # noinspection PyShadowingNames
+        def test_func():
+            deep_gemm.m_grouped_fp8_gemm_nt_masked(a, b, d, masked_m, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
+
+        # Test performance with fixed shapes
+        valid_m = masked_m.sum().item()
+        t = bench_kineto(test_func, 'fp8_gemm', suppress_kineto_output=True)
+        print(f' > Perf ({num_groups=}, expected_m_per_group={expected_m_per_group:4}, n={n:4}, k={k:4}, {kernel_opt}): '
+              f'{t * 1e6:4.0f} us | '
+              f'{2 * valid_m * n * k / t / 1e12:4.0f} TFLOPS | '
+              f'{(count_bytes(a, d) * valid_m / (max_m * num_groups) + count_bytes(b)) / 1e9 / t:4.0f} GB/s')
+    print()
+
 if __name__ == '__main__':
     torch.backends.cuda.matmul.allow_tf32 = True
     torch.backends.cudnn.allow_tf32 = True
@@ -89,3 +123,4 @@ if __name__ == '__main__':
     print(f' > {deep_gemm.__path__}\n')
 
     test_m_grouped_gemm_signal()
+    test_m_grouped_gemm_masked()

--- a/tests/test_signal_gemm.py
+++ b/tests/test_signal_gemm.py
@@ -53,7 +53,12 @@ def test_m_grouped_gemm_signal() -> None:
             a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)
             max_signal_size = num_groups * ceil_div(max_m, 64)
             combine_signal = torch.zeros(max_signal_size, dtype=torch.int32, device='cuda')
+            origin_sms = deep_gemm.get_num_sms()
+            print(f'Origin SMS: {origin_sms}')
+            deep_gemm.set_num_sms(origin_sms - 3)
             block_m, threshold = deep_gemm.m_grouped_fp8_gemm_nt_signal(a, b, d, masked_m, combine_signal, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
+            print(f'Current SMS: {deep_gemm.get_num_sms()}')
+            deep_gemm.set_num_sms(origin_sms)
             check_signal(num_groups, max_m, block_m, threshold, combine_signal, masked_m)
             for j in range(num_groups):
                 diff = calc_diff(d[j, :masked_m[j].item()], ref_d[j, :masked_m[j].item()])
@@ -92,12 +97,7 @@ def test_m_grouped_gemm_masked() -> None:
         # Test correctness
         for i in range(2):
             a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)
-            origin_sms = deep_gemm.get_num_sms()
-            print(f'Origin SMS: {origin_sms}')
-            deep_gemm.set_num_sms(origin_sms - 3)
             deep_gemm.m_grouped_fp8_gemm_nt_masked(a, b, d, masked_m, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
-            print(f'Current SMS: {deep_gemm.get_num_sms()}')
-            deep_gemm.set_num_sms(origin_sms)
             for j in range(num_groups):
                 diff = calc_diff(d[j, :masked_m[j].item()], ref_d[j, :masked_m[j].item()])
                 assert diff < 0.001, f'{max_m=}, {n=}, {k=}, {j=}, masked_m={masked_m[j]}, {kernel_opt}, {num_groups=}, {diff:.5f}'

--- a/tests/test_signal_gemm.py
+++ b/tests/test_signal_gemm.py
@@ -39,7 +39,7 @@ def check_signal(num_local_expert, max_m, block_m, threshold, combine_signal, ma
                 else:
                     assert signal[i] == 0, f'{i=}, {signal[i]=}'
 
-def test_m_grouped_gemm_signal() -> None:
+def test_m_grouped_gemm_signal(max_block_n) -> None:
     print('Testing m-grouped masked GEMM:')
 
     # TODO: when the actual `m` is greater than `expected_m_per_group`, efficiency may significantly decrease.
@@ -55,7 +55,7 @@ def test_m_grouped_gemm_signal() -> None:
             combine_signal = torch.zeros(max_signal_size, dtype=torch.int32, device='cuda')
             origin_sms = deep_gemm.get_num_sms()
             deep_gemm.set_num_sms(origin_sms - 3)
-            block_m, threshold = deep_gemm.m_grouped_fp8_gemm_nt_signal(a, b, d, masked_m, combine_signal, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
+            block_m, threshold = deep_gemm.m_grouped_fp8_gemm_nt_signal(a, b, d, masked_m, combine_signal, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast, max_block_n=max_block_n)
             deep_gemm.set_num_sms(origin_sms)
             check_signal(num_groups, max_m, block_m, threshold, combine_signal, masked_m)
             for j in range(num_groups):
@@ -127,5 +127,6 @@ if __name__ == '__main__':
     print('Library path:')
     print(f' > {deep_gemm.__path__}\n')
 
-    test_m_grouped_gemm_signal()
-    test_m_grouped_gemm_masked()
+    for max_block_n in (144, 160, 192):
+        test_m_grouped_gemm_signal(max_block_n)
+        # test_m_grouped_gemm_masked()

--- a/tests/test_signal_gemm.py
+++ b/tests/test_signal_gemm.py
@@ -93,8 +93,10 @@ def test_m_grouped_gemm_masked() -> None:
         for i in range(2):
             a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)
             origin_sms = deep_gemm.get_num_sms()
+            print(f'Origin SMS: {origin_sms}')
             deep_gemm.set_num_sms(origin_sms - 3)
             deep_gemm.m_grouped_fp8_gemm_nt_masked(a, b, d, masked_m, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
+            print(f'Current SMS: {deep_gemm.get_num_sms()}')
             deep_gemm.set_num_sms(origin_sms)
             for j in range(num_groups):
                 diff = calc_diff(d[j, :masked_m[j].item()], ref_d[j, :masked_m[j].item()])

--- a/tests/test_signal_gemm.py
+++ b/tests/test_signal_gemm.py
@@ -49,7 +49,7 @@ def test_m_grouped_gemm_signal() -> None:
         disable_ue8m0_cast = not use_ue8m0
 
         # Test correctness
-        for i in range(10):
+        for i in range(2):
             a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)
             max_signal_size = num_groups * ceil_div(max_m, 64)
             combine_signal = torch.zeros(max_signal_size, dtype=torch.int32, device='cuda')
@@ -90,12 +90,14 @@ def test_m_grouped_gemm_masked() -> None:
         disable_ue8m0_cast = not use_ue8m0
 
         # Test correctness
-        for i in range(10):
+        for i in range(2):
             a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)
             deep_gemm.m_grouped_fp8_gemm_nt_masked(a, b, d, masked_m, expected_m_per_group, disable_ue8m0_cast=disable_ue8m0_cast)
             for j in range(num_groups):
                 diff = calc_diff(d[j, :masked_m[j].item()], ref_d[j, :masked_m[j].item()])
                 assert diff < 0.001, f'{max_m=}, {n=}, {k=}, {j=}, masked_m={masked_m[j]}, {kernel_opt}, {num_groups=}, {diff:.5f}'
+
+        print(f' > Correctness ({num_groups=}, expected_m_per_group={expected_m_per_group:4}, n={n:4}, k={k:4}, {kernel_opt}) checked ')
 
         # Construct full cases
         # a, b, masked_m, d, ref_d = generate_m_grouped_masked(num_groups, max_m, expected_m_per_group, n, k, use_ue8m0=use_ue8m0)


### PR DESCRIPTION
# 1. Motivation
The optimization effect of Two-Batch Overlap (TBO) is suboptimal for the Decode phase on low-compute-power cards (i.e., H20). This is due to two main factors: First, on the Hopper architecture, the WGMMA block_m is 64. Consequently, when TBO is enabled with a small Decode batch size, the MLP GEMM suffers from redundant computations. A positive throughput gain is only observed at larger batch sizes (e.g., 64, 128). Second, at these larger batch sizes, low-compute-power cards like the H20 fail to meet the SLA guarantees for TPOT/ITL.

Therefore, it is necessary to find a solution that can improve Decode throughput even with small batch sizes. Single Batch Overlap (SBO) presents itself as a viable solution.

We implement SBO for DeepSeek v3/R1 by modifying DeepEP and DeepGEMM, including the overlap of Shared Expert and Dispatch Recv, as well as the overlap of Down GEMM with Combine Send.

The overlap of Down GEMM with Combine Send is implemented by modifying SGlang, DeepEP and DeepGEMM, with the detailed implementation available in the PRs below:
* DeepEP: https://github.com/deepseek-ai/DeepEP/pull/390.
* DeepGEMM: this PR.

We also conducted integration and evaluation in SGLang: https://github.com/sgl-project/sglang/pull/9660.

# 2. Overlap Design
SBO implements two overlap for the MoE layers of DeepSeek-V3/R1. One is to overlap the Shared Expert computation with the Dispatch Recv communication, and the other is to overlap the Down GEMM computation with the Combine Send communication.
<img width="2484" height="772" alt="image" src="https://github.com/user-attachments/assets/b4d1f131-a1b5-4bf6-b623-fbf7b6fe6497" />
The interaction between Down GEMM and Combine Send is structured as a producer-consumer model synchronized by signals. For each local expert, a signal unit is allocated for every block_m tokens. The Down GEMM computes the results for these block_m tokens and atomically increments the signaling unit after completing a portion of the work. The Combine Send polls this signaling unit. Once the value reaches a threshold, it sends the corresponding block_m tokens.
<img width="358" height="350" alt="image" src="https://github.com/user-attachments/assets/514134a5-0225-4698-855b-5a43c0a08bc7" />

# 3. Modifications
* Add the `m_grouped_fp8_gemm_nt_signal` Python interface to support overlapping Down GEMM with Combine Send.
* Add the `SM90FP8SignalGemm1D2DRuntime` and `sm90_m_grouped_fp8_gemm_signal_1d2d` to support Signal Down GEMM in SM90.
* The `sm90_fp8_signal_gemm_1d2d_impl` kernel uses `atomicAdd` to write signal after the corresponding block_m tokens are computed.

# 4. Evaluation
We integrated the modified DeepEP and DeepGEMM into SGLang for performance evaluation.

## 4.1. Experiment Setup
* 5 nodes, with 8 × H20 GPUs per node. Each prefill node uses TP8, and the other 2 decode nodes use DP_Attn 16 + EP 16.
* Input length 4096, output length 1536.

## 4.2. Performance Evaluation
The following is the evaluation results based on DeepGEMM v1. SBO has adapted SGLang and DeepGEMM v2, and is evaluating. The results will be updated soon.

* bs 32, origin
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    4.8
Max request concurrency:                 512
Successful requests:                     10240
Benchmark duration (s):                  2343.93
Total input tokens:                      41943040
Total generated tokens:                  15728640
Total generated tokens (retokenized):    15673809
Request throughput (req/s):              4.37
Input token throughput (tok/s):          17894.29
Output token throughput (tok/s):         6710.36
Total token throughput (tok/s):          24604.65
Concurrency:                             489.92
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   112143.54
Median E2E Latency (ms):                 113007.21
---------------Time to First Token----------------
Mean TTFT (ms):                          1052.21
Median TTFT (ms):                        939.13
P99 TTFT (ms):                           2528.55
---------------Inter-Token Latency----------------
Mean ITL (ms):                           72.37
Median ITL (ms):                         71.14
P95 ITL (ms):                            89.53
P99 ITL (ms):                            150.60
Max ITL (ms):                            1022.47
==================================================
```
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    5.0
Max request concurrency:                 512
Successful requests:                     10240
Benchmark duration (s):                  2346.74
Total input tokens:                      41943040
Total generated tokens:                  15728640
Total generated tokens (retokenized):    15673126
Request throughput (req/s):              4.36
Input token throughput (tok/s):          17872.88
Output token throughput (tok/s):         6702.33
Total token throughput (tok/s):          24575.22
Concurrency:                             490.96
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   112515.52
Median E2E Latency (ms):                 113174.24
---------------Time to First Token----------------
Mean TTFT (ms):                          1100.37
Median TTFT (ms):                        950.60
P99 TTFT (ms):                           2931.98
---------------Inter-Token Latency----------------
Mean ITL (ms):                           72.58
Median ITL (ms):                         71.20
P95 ITL (ms):                            89.90
P99 ITL (ms):                            150.52
Max ITL (ms):                            912.97
==================================================
```

* bs 32, sbo
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    4.8
Max request concurrency:                 512
Successful requests:                     10240
Benchmark duration (s):                  2235.23
Total input tokens:                      41943040
Total generated tokens:                  15728640
Total generated tokens (retokenized):    15673167
Request throughput (req/s):              4.58
Input token throughput (tok/s):          18764.56
Output token throughput (tok/s):         7036.71
Total token throughput (tok/s):          25801.26
Concurrency:                             485.50
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   105977.11
Median E2E Latency (ms):                 106863.39
---------------Time to First Token----------------
Mean TTFT (ms):                          1275.84
Median TTFT (ms):                        1151.83
P99 TTFT (ms):                           3623.72
---------------Inter-Token Latency----------------
Mean ITL (ms):                           68.21
Median ITL (ms):                         67.05
P95 ITL (ms):                            84.90
P99 ITL (ms):                            141.44
Max ITL (ms):                            829.91
==================================================
```
```
============ Serving Benchmark Result ============
Backend:                                 sglang
Traffic request rate:                    5.0
Max request concurrency:                 512
Successful requests:                     10240
Benchmark duration (s):                  2226.19
Total input tokens:                      41943040
Total generated tokens:                  15728640
Total generated tokens (retokenized):    15673172
Request throughput (req/s):              4.60
Input token throughput (tok/s):          18840.70
Output token throughput (tok/s):         7065.26
Total token throughput (tok/s):          25905.96
Concurrency:                             489.36
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   106386.88
Median E2E Latency (ms):                 106958.25
---------------Time to First Token----------------
Mean TTFT (ms):                          1205.13
Median TTFT (ms):                        1109.33
P99 TTFT (ms):                           3184.52
---------------Inter-Token Latency----------------
Mean ITL (ms):                           68.52
Median ITL (ms):                         67.14
P95 ITL (ms):                            85.35
P99 ITL (ms):                            142.63
Max ITL (ms):                            1225.78
==================================================
```

## 4.3. Accuracy Tests
```
#python -m benchmark.gsm8k.bench_sglang --port 8000 --num-questions 1000
100%|█████████████████████████████████████████████████████████████| 1000/1000 [01:22<00:00, 12.17it/s]
Accuracy: 0.951
Invalid: 0.000
Latency: 82.471 s
Output throughput: 1165.550 token/s
```

## 4.4. Repro Script
Please refer to https://github.com/sgl-project/sglang/pull/9660.