### PR TITLE
chore: Rename project to ds-deem-gemm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -185,7 +185,7 @@ class CachedWheelsCommand(_bdist_wheel):
 if __name__ == '__main__':
     # noinspection PyTypeChecker
     setuptools.setup(
-        name='deepgemm',
+        name='ds_deep_gemm',
         version=get_package_version(),
         packages=find_packages('.'),
         package_data={


### PR DESCRIPTION
Unfortunately `deepgemm` also doesn't work, PyPI rejects the name since it's too close to `deep-gemm`.

So let's go with `ds_deep_gemm` (same as `pip install ds-deep-gemm`)