### PR TITLE
fix: prevent int32 overflow in k-grouped GEMM size calculations

### DIFF
--- a/csrc/apis/gemm.hpp
+++ b/csrc/apis/gemm.hpp
@@ -280,13 +280,13 @@ static void k_grouped_fp8_gemm_nt_contiguous(const std::pair<torch::Tensor, torc
 
     // Shape checks
     const auto& [num_groups, m, n] = get_shape<3>(d);
-    const auto& sum_mk = a.first.numel();
-    const auto& sum_nk = b.first.numel();
-    int sum_k = 0;
+    const auto& sum_mk = static_cast<uint64_t>(a.first.numel());
+    const auto& sum_nk = static_cast<uint64_t>(b.first.numel());
+    uint64_t sum_k = 0;
     for (const auto& k: ks)
-        sum_k += k;
-    DG_HOST_ASSERT(sum_mk == m * sum_k);
-    DG_HOST_ASSERT(sum_nk == n * sum_k);
+        sum_k += static_cast<uint64_t>(k);
+    DG_HOST_ASSERT(sum_mk == static_cast<uint64_t>(m) * sum_k);
+    DG_HOST_ASSERT(sum_nk == static_cast<uint64_t>(n) * sum_k);
 
     // Contiguity checks
     DG_HOST_ASSERT(a.first.is_contiguous());


### PR DESCRIPTION
## Fix Int32 Overflow: Prevent overflow in k-grouped GEMM size validation

### Description
Fix integer overflow in k-grouped GEMM when validating tensor sizes with large dimensions.

While training the Deepseek-v3 model using DeepGemm on an H100 machine, we encountered an error in the group GEMM kernel when using long sequences ($>256\text{k}$). Upon investigation, we found the cause was an overflow during the calculation of the product of sum_k and hidden_size.

**Root cause**: When `m` or `n` are large and multiplied with `sum_k`, the result exceeds int32 max value (2,147,483,647), causing incorrect validation or undefined behavior.

**Solution**: Cast `m` and `n` to `uint64_t` before multiplication to safely handle large matrix dimensions.

### Changes
`csrc/apis/gemm.hpp:289-290`: Cast to `uint64_t` in size assertions
  ```cpp
  // Before
  DG_HOST_ASSERT(sum_mk == m * sum_k);
  DG_HOST_ASSERT(sum_nk == n * sum_k);
  
  // After
  DG_HOST_ASSERT(sum_mk == static_cast<uint64_t>(m) * sum_k);
  DG_HOST_ASSERT(sum_nk == static_cast<uint64_t>(n) * sum_k);
  ```
