### PR TITLE
Better error handling, code consistency, compile-time safety

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ def get_package_version():
 
             cmd = ['git', 'rev-parse', '--short', 'HEAD']
             revision = '+' + subprocess.check_output(cmd).decode('ascii').rstrip()
-        except:
+        except (subprocess.CalledProcessError, FileNotFoundError, OSError):
             revision = '+local'
     return f'{public_version}{revision}'
 


### PR DESCRIPTION
# Add [[nodiscard]] to early_return for compile-time safety

##
Added the `[[nodiscard]]` attribute to the [early_return] function in [gemm.hpp] to prevent potential logic bugs  as I ran into a couple, where the return value might be accidentally ignored.
