### PR TITLE
docs: add DG_MINIMIZE_NUM_SMS environment variable to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ The library also provides some environment variables, which may be useful:
   - `DG_JIT_PRINT_COMPILER_COMMAND`: `0` or `1`, print NVCC compilation command, `0` by default
 - Heuristic selection
   - `DG_PRINT_CONFIGS`: `0` or `1`, print selected configs for each shape, `0` by default
+  - `DG_MINIMIZE_NUM_SMS`: `0` or `1`, minimize the number of SMs used for better L2 cache usage and reduced GPU frequency drops; may cause additional kernel compilations on first run, `1` by default
 
 For additional examples and details, please refer to [the test code](tests/test_core.py) or review the corresponding Python documentation.
 


### PR DESCRIPTION
## Summary

Add documentation for the new `DG_MINIMIZE_NUM_SMS` environment variable to the README.

This environment variable was added in PR #244 (addressing issue #239) to control whether the kernel should minimize the number of SMs used.

## Changes

Added to the "Heuristic selection" section:
- `DG_MINIMIZE_NUM_SMS`: `0` or `1`, minimize the number of SMs used for better L2 cache usage and reduced GPU frequency drops; may cause additional kernel compilations on first run, `1` by default

## Usage

```bash
# Disable min SMS optimization for faster startup (TTFT)
export DG_MINIMIZE_NUM_SMS=0

# Enable min SMS optimization (default behavior)
export DG_MINIMIZE_NUM_SMS=1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)