### PR TITLE
chore: add __all__ export list for explicit public API

### DIFF
--- a/deep_gemm/__init__.py
+++ b/deep_gemm/__init__.py
@@ -4,6 +4,55 @@ import torch
 from torch.version import cuda as cuda_version
 from packaging import version
 
+__all__ = [
+    # Version
+    '__version__',
+    # Configuration functions
+    'set_num_sms',
+    'get_num_sms',
+    'set_tc_util',
+    'get_tc_util',
+    # cuBLASLt kernels
+    'cublaslt_gemm_nt',
+    'cublaslt_gemm_nn',
+    'cublaslt_gemm_tn',
+    'cublaslt_gemm_tt',
+    # FP8 GEMM kernels
+    'fp8_gemm_nt',
+    'fp8_gemm_nn',
+    'fp8_gemm_tn',
+    'fp8_gemm_tt',
+    'fp8_gemm_nt_skip_head_mid',
+    'm_grouped_fp8_gemm_nt_contiguous',
+    'm_grouped_fp8_gemm_nn_contiguous',
+    'm_grouped_fp8_gemm_nt_masked',
+    'k_grouped_fp8_gemm_nt_contiguous',
+    'k_grouped_fp8_gemm_tn_contiguous',
+    # BF16 GEMM kernels
+    'bf16_gemm_nt',
+    'bf16_gemm_nn',
+    'bf16_gemm_tn',
+    'bf16_gemm_tt',
+    'm_grouped_bf16_gemm_nt_contiguous',
+    'm_grouped_bf16_gemm_nn_contiguous',
+    'm_grouped_bf16_gemm_nt_masked',
+    'k_grouped_bf16_gemm_tn_contiguous',
+    # Einsum kernels
+    'einsum',
+    'fp8_einsum',
+    # Attention kernels
+    'fp8_mqa_logits',
+    'get_paged_mqa_logits_metadata',
+    'fp8_paged_mqa_logits',
+    # Layout utilities
+    'transform_sf_into_required_layout',
+    'get_mk_alignment_for_contiguous_layout',
+    # Submodules
+    'testing',
+    'utils',
+    'legacy',
+]
+
 # Set some default environment provided at setup
 try:
     # noinspection PyUnresolvedReferences


### PR DESCRIPTION
## Summary

Add `__all__` to `deep_gemm/__init__.py` to explicitly define the public API of the package.

## Changes

Added a comprehensive `__all__` list that includes:

### Configuration Functions
- `set_num_sms`, `get_num_sms`
- `set_tc_util`, `get_tc_util`

### cuBLASLt Kernels
- `cublaslt_gemm_nt`, `cublaslt_gemm_nn`, `cublaslt_gemm_tn`, `cublaslt_gemm_tt`

### FP8 GEMM Kernels
- Normal: `fp8_gemm_nt`, `fp8_gemm_nn`, `fp8_gemm_tn`, `fp8_gemm_tt`
- Special: `fp8_gemm_nt_skip_head_mid`
- M-Grouped: `m_grouped_fp8_gemm_nt_contiguous`, `m_grouped_fp8_gemm_nn_contiguous`, `m_grouped_fp8_gemm_nt_masked`
- K-Grouped: `k_grouped_fp8_gemm_nt_contiguous`, `k_grouped_fp8_gemm_tn_contiguous`

### BF16 GEMM Kernels
- Normal: `bf16_gemm_nt`, `bf16_gemm_nn`, `bf16_gemm_tn`, `bf16_gemm_tt`
- M-Grouped: `m_grouped_bf16_gemm_nt_contiguous`, `m_grouped_bf16_gemm_nn_contiguous`, `m_grouped_bf16_gemm_nt_masked`
- K-Grouped: `k_grouped_bf16_gemm_tn_contiguous`

### Other Kernels
- Einsum: `einsum`, `fp8_einsum`
- Attention: `fp8_mqa_logits`, `get_paged_mqa_logits_metadata`, `fp8_paged_mqa_logits`

### Utilities
- `transform_sf_into_required_layout`, `get_mk_alignment_for_contiguous_layout`

### Submodules
- `testing`, `utils`, `legacy`

## Benefits

- **Better IDE support**: Autocompletion shows only public API
- **Clearer documentation**: Explicit list of public symbols
- **Proper wildcard imports**: `from deep_gemm import *` works correctly
- **Static analysis**: Tools like mypy/pyright understand the public API

🤖 Generated with [Claude Code](https://claude.com/claude-code)