### PR TITLE
Add EditorConfig for consistent coding style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,65 @@
+# EditorConfig for DeepGEMM
+# https://editorconfig.org
+
+root = true
+
+# Default settings for all files
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+# Python files
+[*.py]
+indent_size = 4
+max_line_length = 120
+
+# Python stubs
+[*.pyi]
+indent_size = 4
+
+# C/C++/CUDA files
+[*.{c,cc,cpp,cxx,h,hh,hpp,hxx,cu,cuh}]
+indent_size = 4
+
+# CMake files
+[CMakeLists.txt]
+indent_size = 2
+
+[*.cmake]
+indent_size = 2
+
+# YAML files
+[*.{yml,yaml}]
+indent_size = 2
+
+# TOML files
+[*.toml]
+indent_size = 4
+
+# JSON files
+[*.json]
+indent_size = 2
+
+# Markdown files
+[*.md]
+trim_trailing_whitespace = false
+max_line_length = 0
+
+# Shell scripts
+[*.sh]
+indent_size = 4
+
+# Makefiles require tabs
+[Makefile]
+indent_style = tab
+
+[*.mk]
+indent_style = tab
+
+# Git config files
+[.git*]
+indent_size = 4


### PR DESCRIPTION
## Summary
Add `.editorconfig` to ensure consistent coding style across different editors and IDEs.

### Configuration includes:
- **Encoding**: UTF-8 for all files
- **Line endings**: LF (Unix-style) for all files
- **Python/C++/CUDA/Shell**: 4-space indentation
- **YAML/CMake/JSON**: 2-space indentation
- **Makefiles**: Tab indentation (required)
- **Markdown**: Preserves trailing whitespace (needed for line breaks)
- **All files**: Final newline insertion, trailing whitespace trimming

### Benefits
- Ensures contributors use consistent settings regardless of their editor
- Reduces unnecessary whitespace changes in diffs
- Supported natively by most modern editors (VS Code, JetBrains IDEs, Vim, etc.)

See https://editorconfig.org for more information.

## Test plan
- [x] Validate EditorConfig syntax
- [ ] Verify settings work in VS Code
- [ ] Verify settings work in other editors

🤖 Generated with [Claude Code](https://claude.com/claude-code)