### PR TITLE
Add .clang-format for consistent C++/CUDA code style

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,78 @@
+# Clang-format configuration for DeepGEMM
+# Based on existing code style in csrc/
+
+Language: Cpp
+BasedOnStyle: Google
+
+# Indentation
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ContinuationIndentWidth: 4
+IndentCaseLabels: false
+IndentPPDirectives: None
+NamespaceIndentation: None
+
+# Braces
+BreakBeforeBraces: Attach
+Cpp11BracedListStyle: true
+
+# Line breaks
+ColumnLimit: 120
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterReturnType: None
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+
+# Spaces
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: false
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInContainerLiterals: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+# Alignment
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: true
+AlignTrailingComments: true
+
+# Includes
+IncludeBlocks: Preserve
+SortIncludes: false
+
+# Other
+FixNamespaceComments: true
+MaxEmptyLinesToKeep: 2
+PointerAlignment: Left
+ReflowComments: true
+Standard: c++17
+
+# Keep CUDA-specific formatting
+ForEachMacros:
+  - CUTLASS_PRAGMA_UNROLL
+  - CUTLASS_PRAGMA_NO_UNROLL

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,9 @@ deep_gemm/include/cutlass
 # VS Code settings
 /.vscode
 
-# clangd settings
-/.clang*
+# clangd settings (but keep .clang-format)
+/.clangd
+/.clang-tidy
 /.cache
 
 # Generated stub files


### PR DESCRIPTION
## Summary
Add clang-format configuration for consistent C++/CUDA code formatting.

### Configuration Highlights:
- **Base**: Google style with project-specific adjustments
- **Indentation**: 4 spaces (matches existing code)
- **Line limit**: 120 characters
- **Braces**: Attached (same line as control statement)
- **Standard**: C++17
- **Includes**: Preserve existing order (no auto-sorting)
- **CUTLASS**: Support for CUTLASS pragma macros

### Also Includes:
- Update `.gitignore` to specifically ignore `.clangd` and `.clang-tidy` instead of all `.clang*` files

### Usage
```bash
# Format a single file
clang-format -i csrc/file.hpp

# Format all C++/CUDA files
find csrc -name "*.hpp" -o -name "*.cpp" -o -name "*.cu" -o -name "*.cuh" | xargs clang-format -i
```

### Integration
Works with pre-commit hooks (PR #252) to automatically format code on commit.

## Test plan
- [x] Configuration is valid YAML
- [x] Style matches existing codebase
- [ ] Verify formatting output on sample files

🤖 Generated with [Claude Code](https://claude.com/claude-code)