### PR TITLE
Add CODEOWNERS for automatic review assignments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,26 @@
+# CODEOWNERS - Automatic review assignments for DeepGEMM
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+*                           @deepseek-ai/deepgemm-maintainers
+
+# CUDA kernel implementations
+/csrc/                      @deepseek-ai/deepgemm-maintainers
+
+# Python bindings and utilities
+/deep_gemm/                 @deepseek-ai/deepgemm-maintainers
+
+# Tests
+/tests/                     @deepseek-ai/deepgemm-maintainers
+
+# Build system and packaging
+/setup.py                   @deepseek-ai/deepgemm-maintainers
+/pyproject.toml             @deepseek-ai/deepgemm-maintainers
+/CMakeLists.txt             @deepseek-ai/deepgemm-maintainers
+
+# Documentation
+/README.md                  @deepseek-ai/deepgemm-maintainers
+/docs/                      @deepseek-ai/deepgemm-maintainers
+
+# CI/CD and GitHub configuration
+/.github/                   @deepseek-ai/deepgemm-maintainers


### PR DESCRIPTION
## Summary
Add CODEOWNERS file to automatically request reviews from appropriate team members.

### Code Ownership Structure:
| Path | Owner |
|------|-------|
| `*` (default) | @deepseek-ai/deepgemm-maintainers |
| `/csrc/` | @deepseek-ai/deepgemm-maintainers |
| `/deep_gemm/` | @deepseek-ai/deepgemm-maintainers |
| `/tests/` | @deepseek-ai/deepgemm-maintainers |
| Build files | @deepseek-ai/deepgemm-maintainers |
| `/.github/` | @deepseek-ai/deepgemm-maintainers |

### Benefits:
- Automatically requests reviews on PRs
- Ensures appropriate reviewers see relevant changes
- Protects critical paths with required reviews (if branch protection enabled)

### Setup Required:
For this to work, create a GitHub team `@deepseek-ai/deepgemm-maintainers` and add maintainer accounts to it. Individual usernames can also be used instead of team names.

## Test plan
- [x] Valid CODEOWNERS syntax
- [ ] Create team and verify auto-assignment works

🤖 Generated with [Claude Code](https://claude.com/claude-code)