### PR TITLE
Add Makefile for common development commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,89 @@
+# Makefile for DeepGEMM development
+# Run 'make help' to see available commands
+
+.PHONY: help build develop install clean test lint format check all
+
+# Default target
+help:
+	@echo "DeepGEMM Development Commands"
+	@echo "=============================="
+	@echo ""
+	@echo "Build:"
+	@echo "  make build      - Build the package"
+	@echo "  make develop    - Build for development (creates symlinks)"
+	@echo "  make install    - Build and install the package"
+	@echo ""
+	@echo "Testing:"
+	@echo "  make test       - Run all tests"
+	@echo "  make test-fp8   - Run FP8 GEMM tests"
+	@echo "  make test-bf16  - Run BF16 GEMM tests"
+	@echo ""
+	@echo "Code Quality:"
+	@echo "  make lint       - Run linters (ruff)"
+	@echo "  make format     - Format code (ruff)"
+	@echo "  make check      - Run all checks (lint + format check)"
+	@echo "  make typos      - Check for typos"
+	@echo ""
+	@echo "Cleanup:"
+	@echo "  make clean      - Remove build artifacts"
+	@echo "  make clean-all  - Remove all generated files"
+	@echo ""
+	@echo "Other:"
+	@echo "  make all        - Build, check, and test"
+
+# Build targets
+build:
+	python setup.py build
+
+develop: clean
+	./develop.sh
+
+install: clean
+	./install.sh
+
+# Test targets
+test:
+	python -m pytest tests/ -v
+
+test-fp8:
+	python tests/test_fp8.py
+
+test-bf16:
+	python tests/test_bf16.py
+
+test-attention:
+	python tests/test_attention.py
+
+# Code quality targets
+lint:
+	ruff check .
+
+format:
+	ruff format .
+	ruff check --fix .
+
+format-check:
+	ruff format --check .
+	ruff check .
+
+check: format-check lint
+
+typos:
+	typos .
+
+# Cleanup targets
+clean:
+	rm -rf build/
+	rm -rf dist/
+	rm -rf *.egg-info/
+	rm -f deep_gemm/*.so
+	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+	find . -type f -name "*.pyc" -delete 2>/dev/null || true
+
+clean-all: clean
+	rm -rf stubs/
+	rm -f deep_gemm/include/cute
+	rm -f deep_gemm/include/cutlass
+
+# Combined targets
+all: build check test


### PR DESCRIPTION
## Summary
Add a Makefile to simplify common development tasks with easy-to-remember commands.

### Available Commands:

| Command | Description |
|---------|-------------|
| `make help` | Show all available commands |
| **Build** | |
| `make build` | Build the package |
| `make develop` | Build for development (symlinks) |
| `make install` | Build and install |
| **Testing** | |
| `make test` | Run all tests with pytest |
| `make test-fp8` | Run FP8 GEMM tests |
| `make test-bf16` | Run BF16 GEMM tests |
| **Code Quality** | |
| `make lint` | Run ruff linter |
| `make format` | Auto-format code |
| `make check` | Run all checks |
| `make typos` | Check for typos |
| **Cleanup** | |
| `make clean` | Remove build artifacts |
| `make clean-all` | Remove all generated files |

### Benefits:
- Consistent interface for common tasks
- Self-documenting via `make help`
- Reduces need to remember specific commands
- Standard practice in C/C++ projects

## Test plan
- [x] Valid Makefile syntax
- [ ] Verify `make help` works
- [ ] Test build commands on development machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)