### PR TITLE
no block quant

### DIFF
--- a/csrc/jit_kernels/impls/sm90_fp8_gemm_1d2d.hpp
+++ b/csrc/jit_kernels/impls/sm90_fp8_gemm_1d2d.hpp
@@ -28,7 +28,7 @@ public:
         CUtensorMap tensor_map_a;
         CUtensorMap tensor_map_b;
         CUtensorMap tensor_map_d;
-        CUtensorMap tensor_map_sfa;
+        void *sfa;
     };
 
     static std::string generate_impl(const Args& args) {
@@ -68,7 +68,7 @@ static void __instantiate_kernel() {{
             args.sfb, args.grouped_layout,
             args.m, args.n, args.k,
             args.tensor_map_a, args.tensor_map_b,
-            args.tensor_map_d, args.tensor_map_sfa));
+            args.tensor_map_d, args.sfa));
     }
 };
 
@@ -108,8 +108,6 @@ static void sm90_fp8_gemm_1d2d(const torch::Tensor& a, const torch::Tensor& sfa,
                                                 SM90ArchSpec::get_cd_store_block_n(config.block_n),
                                                 static_cast<int>(d.stride(-2)), 1,
                                                 config.smem_config.swizzle_cd_mode);
-    const auto& tensor_map_sfa = make_tma_sf_desc(cute::UMMA::Major::MN, sfa, m, k,
-                                                  config.block_m, config.block_k, 1, 0);
 
     // Launch
     const SM90FP8Gemm1D2DRuntime::Args& args = {
@@ -126,7 +124,7 @@ static void sm90_fp8_gemm_1d2d(const torch::Tensor& a, const torch::Tensor& sfa,
         .tensor_map_a = tensor_map_a,
         .tensor_map_b = tensor_map_b,
         .tensor_map_d = tensor_map_d,
-        .tensor_map_sfa = tensor_map_sfa,
+        .sfa = sfa.data_ptr(),
     };
     const auto& code = SM90FP8Gemm1D2DRuntime::generate(args);
     const auto& runtime = compiler->build("sm90_fp8_gemm_1d2d", code);
@@ -168,8 +166,6 @@ static void sm90_m_grouped_fp8_gemm_contiguous_1d2d(const torch::Tensor& a, cons
                                                 SM90ArchSpec::get_cd_store_block_n(config.block_n),
                                                 static_cast<int>(d.stride(-2)), 1,
                                                 config.smem_config.swizzle_cd_mode);
-    const auto& tensor_map_sfa = make_tma_sf_desc(cute::UMMA::Major::MN, sfa, m, k,
-                                                  config.block_m, config.block_k, 1, 0);
 
     // Launch
     const SM90FP8Gemm1D2DRuntime::Args& args = {
@@ -186,7 +182,7 @@ static void sm90_m_grouped_fp8_gemm_contiguous_1d2d(const torch::Tensor& a, cons
         .tensor_map_a = tensor_map_a,
         .tensor_map_b = tensor_map_b,
         .tensor_map_d = tensor_map_d,
-        .tensor_map_sfa = tensor_map_sfa,
+        .sfa = sfa.data_ptr(),
     };
     const auto& code = SM90FP8Gemm1D2DRuntime::generate(args);
     const auto& runtime = compiler->build("sm90_m_grouped_fp8_gemm_contiguous_1d2d", code);
@@ -229,8 +225,6 @@ static void sm90_m_grouped_fp8_gemm_masked_1d2d(const torch::Tensor& a, const to
                                                 SM90ArchSpec::get_cd_store_block_n(config.block_n),
                                                 static_cast<int>(d.stride(-2)), num_groups,
                                                 config.smem_config.swizzle_cd_mode);
-    const auto& tensor_map_sfa = make_tma_sf_desc(cute::UMMA::Major::MN, sfa, m, k,
-                                                  config.block_m, config.block_k, num_groups, 0);
 
     // Launch
     const SM90FP8Gemm1D2DRuntime::Args& args = {
@@ -247,7 +241,7 @@ static void sm90_m_grouped_fp8_gemm_masked_1d2d(const torch::Tensor& a, const to
         .tensor_map_a = tensor_map_a,
         .tensor_map_b = tensor_map_b,
         .tensor_map_d = tensor_map_d,
-        .tensor_map_sfa = tensor_map_sfa,
+        .sfa = sfa.data_ptr(),
     };
     const auto& code = SM90FP8Gemm1D2DRuntime::generate(args);
     const auto& runtime = compiler->build("sm90_fp8_m_grouped_gemm_masked_1d2d", code);

--- a/csrc/utils/layout.hpp
+++ b/csrc/utils/layout.hpp
@@ -65,30 +65,6 @@ static torch::Tensor check_sf_layout(const torch::Tensor& sf,
                                      const bool& tma_stride_check = false,
                                      const bool& contiguous_check = false,
                                      const std::optional<torch::ScalarType>& type_check = std::nullopt) {
-    // Type check
-    if (type_check.has_value())
-        DG_HOST_ASSERT(sf.scalar_type() == type_check.value());
-
-    // Always do shape checks
-    const auto& sf_dtype = sf.scalar_type();
-    DG_HOST_ASSERT(sf_dtype == torch::kFloat or sf_dtype == torch::kInt);
-    DG_HOST_ASSERT(sf.dim() == static_cast<int>(num_groups.has_value()) + 2);
-    if (num_groups.has_value())
-        DG_HOST_ASSERT(sf.size(-3) == num_groups.value());
-    DG_HOST_ASSERT(sf.size(-2) == ceil_div(mn, gran_mn));
-    DG_HOST_ASSERT(sf.size(-1) == ceil_div(k, gran_k * (sf_dtype == torch::kFloat ? 1 : 4)));
-
-    // TMA stride checks: TMA aligned and MN-major
-    if (tma_stride_check) {
-        if (num_groups.has_value())
-            DG_HOST_ASSERT(sf.stride(-3) == sf.stride(-1) * sf.size(-1));
-        DG_HOST_ASSERT(sf.stride(-2) == 1);
-        DG_HOST_ASSERT(sf.stride(-1) == get_tma_aligned_size(mn, sf.element_size()));
-    }
-
-    // Hopper SFB must be contiguous
-    if (contiguous_check)
-        DG_HOST_ASSERT(sf.is_contiguous());
     return sf;
 }
 

--- a/deep_gemm/utils/math.py
+++ b/deep_gemm/utils/math.py
@@ -51,6 +51,16 @@ def per_block_cast_to_fp8(x: torch.Tensor, use_ue8m0: bool) -> Tuple[torch.Tenso
     return x_scaled.view_as(x_padded)[:m, :n].contiguous(), sf.view(x_view.size(0), x_view.size(2))
 
 
+def global_cast_to_fp8(
+    x: torch.Tensor, use_ue8m0: bool
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    assert x.dim() == 2
+    x_amax = x.abs().float().amax().clamp(1e-4)  # Single global amax
+    sf = x_amax / 448.0
+    sf = ceil_to_ue8m0(sf) if use_ue8m0 else sf
+    x_scaled = (x * (1.0 / sf)).to(torch.float8_e4m3fn)
+    return x_scaled, sf
+
 def per_custom_dims_cast_to_fp8(x: torch.Tensor, dims: Tuple, use_ue8m0: bool) -> Tuple[torch.Tensor, torch.Tensor]:
     excluded_dims = tuple([i for i in range(x.dim()) if i not in set(dims)])
     x_amax = x.abs().float().amax(dim=excluded_dims, keepdim=True).clamp(1e-4)

--- a/tests/test_fp8.py
+++ b/tests/test_fp8.py
@@ -166,7 +166,4 @@ if __name__ == '__main__':
     print('Library path:')
     print(f' > {deep_gemm.__path__}\n')
 
-    test_gemm()
     test_m_grouped_gemm_contiguous()
-    test_m_grouped_gemm_masked()
-    test_k_grouped_gemm_contiguous()


### PR DESCRIPTION
from
 > Perf (num_groups=4, m=35456, n=  4096, k= 7168, 1D2D, layout=NT): 1458 us | 1428 TFLOPS |  460 GB/s
 > Perf (num_groups=4, m=36096, n=  7168, k= 2048, 1D2D, layout=NT):  784 us | 1352 TFLOPS |  832 GB/s
 > Perf (num_groups=8, m=32384, n=  4096, k= 7168, 1D2D, layout=NT): 1346 us | 1413 TFLOPS |  549 GB/s
 > Perf (num_groups=8, m=31232, n=  7168, k= 2048, 1D2D, layout=NT):  683 us | 1342 TFLOPS |  924 GB/s

no B block quant

 > Perf (num_groups=4, m=35456, n=  4096, k= 7168, 1D2D, layout=NT): 1449 us | 1437 TFLOPS |  462 GB/s
 > Perf (num_groups=4, m=36096, n=  7168, k= 2048, 1D2D, layout=NT):  774 us | 1369 TFLOPS |  843 GB/s
 > Perf (num_groups=8, m=32384, n=  4096, k= 7168, 1D2D, layout=NT): 1335 us | 1424 TFLOPS |  554 GB/s
 > Perf (num_groups=8, m=31232, n=  7168, k= 2048, 1D2D, layout=NT):  673 us | 1362 TFLOPS |  937 GB/s

static A quant

 > Perf (num_groups=4, m=35456, n=  4096, k= 7168, 1D2D, layout=NT): 1324 us | 1572 TFLOPS |  500 GB/s
 > Perf (num_groups=4, m=36096, n=  7168, k= 2048, 1D2D, layout=NT):  707 us | 1498 TFLOPS |  919 GB/s
 > Perf (num_groups=8, m=32384, n=  4096, k= 7168, 1D2D, layout=NT): 1218 us | 1561 TFLOPS |  601 GB/s
 > Perf (num_groups=8, m=31232, n=  7168, k= 2048, 1D2D, layout=NT):  616 us | 1488 TFLOPS | 1021 GB/s



