### PR TITLE
fix: add sscanf return value check to prevent uninitialized value return

### DIFF
--- a/csrc/utils/system.hpp
+++ b/csrc/utils/system.hpp
@@ -25,7 +25,10 @@ static dtype_t get_env(const std::string& name, const dtype_t& default_value = d
         return std::string(c_str);
     } else if constexpr (std::is_same_v<dtype_t, int>) {
         int value;
-        std::sscanf(c_str, "%d", &value);
+        if (std::sscanf(c_str, "%d", &value) != 1) {
+            // Failed to parse as int, return default value
+            return default_value;
+        }
         return value;
     } else {
         DG_HOST_ASSERT(false and "Unexpected type");


### PR DESCRIPTION
## Summary

This PR fixes a potential bug in `csrc/utils/system.hpp` where the return value of `std::sscanf` was not being checked when parsing integer environment variables.

## Problem

In the `get_env<int>()` function template, `std::sscanf` was used to parse an environment variable string as an integer, but the return value was never checked. If the environment variable contains a value that cannot be parsed as an integer (e.g., "abc", "12.3", or an empty string), `sscanf` fails and the `value` variable remains uninitialized. This uninitialized value is then returned, leading to undefined behavior.

## Solution

Added a check for `sscanf`'s return value (which should be 1 for successful parsing of one integer). If parsing fails, the function now returns the provided default value instead of the uninitialized variable.

## Changes

```cpp
// Before: Uninitialized value returned on sscanf failure
} else if constexpr (std::is_same_v<dtype_t, int>) {
    int value;
    std::sscanf(c_str, "%d", &value);
    return value;
}

// After: Returns default value on parsing failure
} else if constexpr (std::is_same_v<dtype_t, int>) {
    int value;
    if (std::sscanf(c_str, "%d", &value) != 1) {
        // Failed to parse as int, return default value
        return default_value;
    }
    return value;
}
```

## Test plan

- [x] Code compiles successfully
- [x] No behavior change for valid integer environment variables
- [x] Graceful handling of invalid integer environment variables (returns default instead of UB)
- [x] Minimal code change, focused fix

## Impact

- Fixes potential undefined behavior when environment variables contain invalid integer values
- Makes the function more robust and predictable
- No breaking changes to API or behavior for valid inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)