### PR TITLE
feat: add w4afp8 on Hopper GPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ out_ij = out_ij.sum()  # Scalar
 
 For more details and the paged version `fp8_paged_mqa_logits`, please refer to `tests/test_attention.py`.
 
+#### W4Afp8
+- W4AFP8 (INT4-bit weight, FP8 activation) GEMM kernel for Hopper (SM90). Supports Normal GEMM, M-Grouped Contiguous GEMM, and M-Grouped Masked GEMM.
+
+- Algorithm compatible with https://huggingface.co/Barrrrry/DeepSeek-R1-W4AFP8, but uses a custom weight layout (see `convert_fp8_to_int4` in `tests/generators.py`).
+
 #### Mega MoE
 
 Mega MoE fuses and overlaps EP dispatch, linear 1 (FP8xFP4), SwiGLU, linear 2 (FP8xFP4), and EP combine into a single mega-kernel, overlapping NVLink communication and tensor core computation. It requires multi-process launch with symmetric memory. Usage:

--- a/csrc/apis/gemm.hpp
+++ b/csrc/apis/gemm.hpp
@@ -361,6 +361,113 @@ static void k_grouped_fp8_gemm_nt_contiguous(const std::pair<torch::Tensor, torc
         DG_HOST_UNREACHABLE("Unsupported architecture");
     }
 }
+
+// ====================
+// SM90 W4AFP8 APIs
+// ====================
+
+static void sm90_w4afp8_gemm_nt(const std::pair<torch::Tensor, torch::Tensor>& a,
+                                const std::pair<torch::Tensor, torch::Tensor>& b,
+                                const torch::Tensor& d,
+                                const std::optional<torch::Tensor>& c,
+                                const std::string& compiled_dims) {
+    const auto major_a = get_major_type_ab(a.first);
+    const auto major_b = get_major_type_ab(b.first);
+    DG_HOST_ASSERT(major_a == cute::UMMA::Major::K);
+    DG_HOST_ASSERT(major_b == cute::UMMA::Major::K);
+    check_major_type_cd(d);
+
+    const auto [m , k ] = get_shape<2>(a.first);
+    const auto [n , k_] = get_shape<2>(b.first);
+    const auto [m_, n_] = get_shape<2>(d);
+    DG_HOST_ASSERT(m == m_ and n == n_ and k == k_ * 2);
+    DG_HOST_ASSERT(a.first.scalar_type() == torch::kFloat8_e4m3fn);
+    DG_HOST_ASSERT(d.scalar_type() == torch::kBFloat16 or d.scalar_type() == torch::kFloat);
+
+    if (early_return(m, n, k, d, c))
+        return;
+
+    const auto recipe = std::make_tuple(m, 1, 128);
+    const auto sfa = a.second;
+    const auto sfb = layout::transform_sf_into_required_layout(
+        b.second, n, k, recipe, std::nullopt, false, false);
+    const auto major_sfb = cute::UMMA::Major::K;
+
+    sm90_fp8_gemm_1d2d(a.first, sfa, b.first, sfb, c, d, m, n, k,
+                       major_a, major_b, major_sfb, compiled_dims);
+}
+
+static void sm90_m_grouped_w4afp8_gemm_nt_contiguous(
+        const std::pair<torch::Tensor, torch::Tensor>& a,
+        const std::pair<torch::Tensor, torch::Tensor>& b,
+        const torch::Tensor& d,
+        const torch::Tensor& m_indices,
+        const std::string& compiled_dims) {
+    const auto major_a = get_major_type_ab(a.first);
+    const auto major_b = get_major_type_ab(b.first);
+    DG_HOST_ASSERT(major_a == cute::UMMA::Major::K);
+    DG_HOST_ASSERT(major_b == cute::UMMA::Major::K);
+    DG_HOST_ASSERT(m_indices.is_contiguous());
+    check_major_type_cd(d);
+
+    const auto [m , k ] = get_shape<2>(a.first);
+    const auto [num_groups, n, k_] = get_shape<3>(b.first);
+    const auto [m_, n_] = get_shape<2>(d);
+    DG_HOST_ASSERT(m == m_ and n == n_ and k == k_ * 2);
+    DG_HOST_ASSERT(n > 0 and k > 0 and num_groups > 0);
+    DG_HOST_ASSERT(d.scalar_type() == torch::kBFloat16);
+    DG_HOST_ASSERT(m_indices.scalar_type() == torch::kInt);
+
+    const auto [m__] = get_shape<1>(m_indices);
+    DG_HOST_ASSERT(m == m__);
+
+    if (m == 0)
+        return;
+
+    const auto recipe = std::make_tuple(m, 1, 128);
+    const auto sfa = a.second;
+    const auto sfb = layout::transform_sf_into_required_layout(
+        b.second, n, k, recipe, num_groups, false, false);
+    const auto major_sfb = cute::UMMA::Major::K;
+
+    sm90_m_grouped_fp8_gemm_contiguous_1d2d(a.first, sfa, b.first, sfb, d, m_indices,
+                                            num_groups, m, n, k, major_a, major_b, major_sfb,
+                                            compiled_dims, false, std::nullopt);
+}
+
+static void sm90_m_grouped_w4afp8_gemm_nt_masked(
+        const std::pair<torch::Tensor, torch::Tensor>& a,
+        const std::pair<torch::Tensor, torch::Tensor>& b,
+        const torch::Tensor& d,
+        const torch::Tensor& masked_m,
+        const int& expected_m,
+        const std::string& compiled_dims) {
+    const auto major_a = get_major_type_ab(a.first);
+    const auto major_b = get_major_type_ab(b.first);
+    DG_HOST_ASSERT(major_a == cute::UMMA::Major::K and major_b == cute::UMMA::Major::K);
+    DG_HOST_ASSERT(masked_m.is_contiguous());
+    check_major_type_cd(d);
+
+    const auto [num_groups  , m , k ] = get_shape<3>(a.first);
+    const auto [num_groups_ , n , k_] = get_shape<3>(b.first);
+    const auto [num_groups__, m_, n_] = get_shape<3>(d);
+    const auto num_groups___ = static_cast<int>(masked_m.numel());
+    DG_HOST_ASSERT(num_groups == num_groups_ and num_groups == num_groups__ and num_groups == num_groups___);
+    DG_HOST_ASSERT(m == m_ and n == n_ and k == k_ * 2);
+    DG_HOST_ASSERT(expected_m > 0 and m > 0 and n > 0 and k > 0 and num_groups > 0);
+    DG_HOST_ASSERT(d.scalar_type() == torch::kBFloat16);
+    DG_HOST_ASSERT(masked_m.scalar_type() == torch::kInt);
+
+    const auto recipe = std::make_tuple(m, 1, 128);
+    const auto sfa = a.second;
+    const auto sfb = layout::transform_sf_into_required_layout(
+        b.second, n, k, recipe, num_groups, false, false);
+    const auto major_sfb = cute::UMMA::Major::K;
+
+    sm90_m_grouped_fp8_gemm_masked_1d2d(a.first, sfa, b.first, sfb, d, masked_m,
+                                        num_groups, m, n, k, expected_m, major_a, major_b, major_sfb, compiled_dims);
+}
+
 #endif
 
 #if DG_TENSORMAP_COMPATIBLE
@@ -663,6 +770,19 @@ static void register_apis(pybind11::module_& m) {
     m.attr("m_grouped_fp8_gemm_nt_contiguous") = m.attr("m_grouped_fp8_fp4_gemm_nt_contiguous");
     m.attr("m_grouped_fp8_gemm_nn_contiguous") = m.attr("m_grouped_fp8_fp4_gemm_nn_contiguous");
     m.attr("m_grouped_fp8_gemm_nt_masked") = m.attr("m_grouped_fp8_fp4_gemm_nt_masked");
+
+    // SM90 W4AFP8 GEMMs
+    m.def("sm90_w4afp8_gemm_nt", &sm90_w4afp8_gemm_nt,
+          py::arg("a"), py::arg("b"), py::arg("d"),
+          py::arg("c") = std::nullopt,
+          py::arg("compiled_dims") = "nk");
+    m.def("sm90_m_grouped_w4afp8_gemm_nt_contiguous", &sm90_m_grouped_w4afp8_gemm_nt_contiguous,
+          py::arg("a"), py::arg("b"), py::arg("d"), py::arg("m_indices"),
+          py::arg("compiled_dims") = "nk");
+    m.def("sm90_m_grouped_w4afp8_gemm_nt_masked", &sm90_m_grouped_w4afp8_gemm_nt_masked,
+          py::arg("a"), py::arg("b"), py::arg("d"), py::arg("masked_m"),
+          py::arg("expected_m"),
+          py::arg("compiled_dims") = "nk");
 #endif
 
 #if DG_TENSORMAP_COMPATIBLE

--- a/csrc/jit_kernels/heuristics/config.hpp
+++ b/csrc/jit_kernels/heuristics/config.hpp
@@ -22,6 +22,11 @@ struct GemmDesc {
     int num_sms, tc_util;
     std::string compiled_dims;
 
+    // W4AFP8 mode (INT4 weight, FP8 activation), SM90 only
+    // Weight encoding: true when B is INT4 packed as FP8 (requires software dequant).
+    // Detected from a.size(-1) != b.size(-1) at the API layer.
+    bool is_w4 = false;
+
     // Shape for heuristic generation
     int expected_m = 0, expected_n = 0, expected_k = 0, expected_num_groups = 0;
     int get_expected_m() const { return expected_m > 0 ? expected_m : m; }
@@ -63,7 +68,8 @@ struct GemmDesc {
            << ", expected_m=" << desc.expected_m
            << ", expected_n=" << desc.expected_n
            << ", expected_k=" << desc.expected_k
-           << ", expected_num_groups=" << desc.expected_num_groups << ")";
+           << ", expected_num_groups=" << desc.expected_num_groups
+           << ", is_w4=" << static_cast<int>(desc.is_w4) << ")";
         return os;
     }
 };

--- a/csrc/jit_kernels/heuristics/sm90.hpp
+++ b/csrc/jit_kernels/heuristics/sm90.hpp
@@ -16,7 +16,23 @@ struct SM90ArchSpec {
     static std::vector<Layout> get_layout_candidates(const GemmDesc& desc) {
         // Block M candidates
         std::vector<int> block_m_candidates;
-        if (desc.gemm_type == GemmType::Normal or
+        if (desc.is_w4) {
+            // W4 uses swap_ab: STSM pattern requires BLOCK_M >= 64
+            // For masked GEMM, restrict block_m candidates based on expected_m to avoid
+            // unnecessary multi-M-block scheduling when a larger block_m fits exactly.
+            if (desc.gemm_type == GemmType::MGroupedContiguous)
+                block_m_candidates = std::vector{heuristics_runtime->get_mk_alignment_for_contiguous_layout()};
+            else if (desc.gemm_type == GemmType::MGroupedMasked) {
+                // W4 BM=128 (MMA_N=128): async WGMMA runs longer, hiding more of the ldmatrix+dequant latency.
+                // Validated for single-tile-per-SM cases; larger problems keep BM=64 as safe default.
+                const int est_tiles = ceil_div(desc.get_expected_m(), 64)
+                    * ceil_div(desc.get_expected_n(), 256)
+                    * desc.get_expected_num_groups();
+                const bool use_large_block_m = est_tiles <= desc.num_sms and desc.get_expected_m() >= 49;
+                block_m_candidates = use_large_block_m ? std::vector{128} : std::vector{64};
+            } else
+                block_m_candidates = {64, 128, 256};
+        } else if (desc.gemm_type == GemmType::Normal or
             desc.gemm_type == GemmType::Batched or
             desc.gemm_type == GemmType::KGroupedContiguous) {
             // TODO: check 256's performance
@@ -37,24 +53,30 @@ struct SM90ArchSpec {
 
         // Block N candidates
         std::vector<int> block_n_candidates;
-        int step = std::lcm(16, heuristics_runtime->get_block_n_multiple_of());
-        int start = step;
-        // Avoid bank conflicts for 1D1D kernel FP32 output
-        if (desc.kernel_type == KernelType::Kernel1D1D and desc.cd_dtype == torch::kFloat) {
-            DG_HOST_ASSERT(desc.major_a == cute::UMMA::Major::K);
-            DG_HOST_ASSERT(desc.major_b == cute::UMMA::Major::K);
-            start = 24;
-            block_n_candidates.push_back(16);
+        if (desc.is_w4) {
+            // W4 small-m: STSM only fills MMA_N/64 of smem_d atom, restrict to {64}
+            const bool w4_small_m = (desc.gemm_type == GemmType::Normal) and (desc.m > 0 and desc.m <= 56);
+            block_n_candidates = w4_small_m ? std::vector{64} : std::vector{64, 128, 256};
+        } else {
+            int step = std::lcm(16, heuristics_runtime->get_block_n_multiple_of());
+            int start = step;
+            // Avoid bank conflicts for 1D1D kernel FP32 output
+            if (desc.kernel_type == KernelType::Kernel1D1D and desc.cd_dtype == torch::kFloat) {
+                DG_HOST_ASSERT(desc.major_a == cute::UMMA::Major::K);
+                DG_HOST_ASSERT(desc.major_b == cute::UMMA::Major::K);
+                start = 24;
+                block_n_candidates.push_back(16);
+            }
+            // Register spills
+            int end = 256;
+            if (desc.kernel_type == KernelType::Kernel1D2D)
+                end = 192;
+            if (desc.kernel_type == KernelType::Kernel1D1D)
+                end = 160;
+            // Enumerate
+            for (int i = start; i <= end; i += step)
+                block_n_candidates.push_back(i);
         }
-        // Register spills
-        int end = 256;
-        if (desc.kernel_type == KernelType::Kernel1D2D)
-            end = 192;
-        if (desc.kernel_type == KernelType::Kernel1D1D)
-            end = 160;
-        // Enumerate
-        for (int i = start; i <= end; i += step)
-            block_n_candidates.push_back(i);
 
         // Block K is always in a fixed manner
         const int block_k = 128 / get_element_size(desc.get_mma_kind());
@@ -91,7 +113,10 @@ struct SM90ArchSpec {
                             continue;
 
                         // The block sizes cannot be too large (for enough registers), so at least one dim less than 128
-                        if (block_m > 128 and block_n > 128)
+                        // W4 RS-mode swaps layout↔compute: block_n→compute_m, block_m→compute_n
+                        const int compute_m = desc.is_w4 ? block_n : block_m;
+                        const int compute_n = desc.is_w4 ? block_m : block_n;
+                        if (compute_m > 128 and compute_n > 128)
                             continue;
 
                         // Calculate swizzling
@@ -119,6 +144,7 @@ struct SM90ArchSpec {
 
     static StorageConfig get_storage_config(const GemmDesc& desc, const Layout& layout) {
         constexpr int wgmma_m = 64;
+        const int weight_ratio = desc.is_w4 ? 2 : 1;
 
         // Load/store block sizes (w/o consideration of swizzling atoms, w/ consideration of loop atoms)
         // TODO: support swap AB
@@ -132,8 +158,9 @@ struct SM90ArchSpec {
         // Decide swizzling by the inner dim
         const auto swizzle_mode_a = get_swizzle_mode(
             desc.major_a == cute::UMMA::Major::K ? layout.block_k : load_block_m, c10::elementSize(desc.a_dtype));
+        // W4: B weight is packed INT4 (half the bytes per element), so swizzle uses block_k / weight_ratio
         const auto swizzle_mode_b = get_swizzle_mode(
-            desc.major_b == cute::UMMA::Major::K ? layout.block_k : load_block_n, c10::elementSize(desc.b_dtype));
+            desc.major_b == cute::UMMA::Major::K ? (layout.block_k / weight_ratio) : load_block_n, c10::elementSize(desc.b_dtype));
         // We only enable swizzling for non-FP32 outputs
         const auto swizzle_mode_cd = desc.cd_dtype != torch::kFloat ?
             get_swizzle_mode(store_block_n, c10::elementSize(desc.cd_dtype)) : 0;
@@ -147,6 +174,7 @@ struct SM90ArchSpec {
 
     static PipelineConfig get_pipeline_config(const GemmDesc& desc, const Layout& layout, const StorageConfig& storage_config) {
         constexpr int kNumMaxStages = 16;
+        const int weight_ratio = desc.is_w4 ? 2 : 1;
 
         // TODO: consider swap AB
         // C/D for TMA stores
@@ -157,17 +185,20 @@ struct SM90ArchSpec {
 
         // Calculate A/B per stages
         const int smem_a_per_stage = storage_config.load_block_m * layout.block_k * c10::elementSize(desc.a_dtype);
-        const int smem_b_per_stage = storage_config.load_block_n * layout.block_k * c10::elementSize(desc.b_dtype);
+        // W4: B weight is INT4, halved smem
+        const int smem_b_per_stage = storage_config.load_block_n * layout.block_k * c10::elementSize(desc.b_dtype) / weight_ratio;
 
         // Calculate SF A/B per stages
+        // W4 RS-mode: SFA slot stores weight scales (compute_m = block_n), not activation scales
+        const int compute_m = desc.is_w4 ? layout.block_n : layout.block_m;
         const int smem_sfa_per_stage = desc.kernel_type == KernelType::KernelNoSF ?
-            0 : align(layout.block_m * static_cast<int>(sizeof(float)), 128);
+            0 : align(compute_m * static_cast<int>(sizeof(float)), 128);
         const int smem_sfb_per_stage = desc.kernel_type != KernelType::Kernel1D1D ?
             0 : align(layout.block_n * static_cast<int>(sizeof(float)), 128);
 
-        // Extra SFB sizes for 1D2D kernels
+        // Extra SFB sizes for 1D2D kernels (W4 has no extra SFB — per-tensor scale)
         const int use_uniform_sfb = layout.block_k % layout.block_n == 0 ? 1 : 2;
-        const int smem_extra_sfb = desc.kernel_type != KernelType::Kernel1D2D ?
+        const int smem_extra_sfb = (desc.kernel_type != KernelType::Kernel1D2D or desc.is_w4) ?
             0 : align<int>(ceil_div(desc.k, layout.block_k) * static_cast<int>(sizeof(float)) * use_uniform_sfb, 8);
 
         // Extra tensormap for 1D1D kernels
@@ -188,7 +219,9 @@ struct SM90ArchSpec {
 
     static LaunchConfig get_launch_config(const GemmDesc& desc, const Layout& layout) {
         const int num_tma_threads = 128;
-        const int num_math_threads = layout.block_m <= 64 ? 128 : 256;
+        // W4 RS-mode: block_n is compute_m after swap
+        const int compute_m = desc.is_w4 ? layout.block_n : layout.block_m;
+        const int num_math_threads = compute_m <= 64 ? 128 : 256;
         return {
             desc.num_sms,
             layout.get_cluster_size(),
@@ -211,27 +244,46 @@ struct SM90ArchSpec {
         const int l2_bandwidth_per_cycle = std::min(64. * desc.num_sms, 8e6 / (1.3e3)); // B/cycle
         const int l1_bandwidth_per_cycle = 128 * desc.num_sms; // B/cycle
         const int wgmma_m = 64;
-        const int elem_size_ab = c10::elementSize(desc.a_dtype);
+        const int elem_size_a = c10::elementSize(desc.a_dtype);
         const int elem_size_cd = c10::elementSize(desc.cd_dtype);
-        DG_HOST_ASSERT(desc.a_dtype == desc.b_dtype);
+        // W4: B is INT4 packed — use 2x scale factor to avoid integer truncation.
+        // All byte counts are computed at 2x scale (bandwidth terms cancel out).
+        const int scale = desc.is_w4 ? 2 : 1;
+        const int elem_size_a_s  = elem_size_a * scale;
+        // W4: c10::elementSize(FP8)=1, times scale=2 divided by weight_ratio=2 → 1. No truncation.
+        const int weight_ratio   = desc.is_w4 ? 2 : 1;
+        const int elem_size_b_s  = c10::elementSize(desc.b_dtype) * scale / weight_ratio;
+        const int elem_size_cd_s = elem_size_cd * scale;
 
-        // Data movement per block
+        // Data movement per block (at 2x scale for W4, 1x for FP8)
         int64_t expected_k = desc.get_expected_k();
-        int64_t num_bytes_l2_ab = expected_k * (layout.block_m / layout.cluster_n + layout.block_n / layout.cluster_m) * elem_size_ab;
-        int64_t num_bytes_l1_ab = expected_k * (layout.block_m + layout.block_n) * elem_size_ab;
-        int64_t num_bytes_l1_tc = expected_k * (std::max(wgmma_m, layout.block_m) + layout.block_n) * elem_size_ab
-                                  + layout.block_m * layout.block_n * elem_size_cd;
-        int64_t num_bytes_l1_l2_cd = layout.block_m * layout.block_n * elem_size_cd * (desc.with_accumulation ? 2 : 1);
+        int64_t num_bytes_l2_ab = expected_k * (layout.block_m / layout.cluster_n * elem_size_a_s + layout.block_n / layout.cluster_m * elem_size_b_s);
+        int64_t num_bytes_l1_ab = expected_k * (layout.block_m * elem_size_a_s + layout.block_n * elem_size_b_s);
+        int64_t num_bytes_l1_tc = expected_k * (std::max(wgmma_m, layout.block_m) * elem_size_a_s + layout.block_n * elem_size_b_s)
+                                  + layout.block_m * layout.block_n * elem_size_cd_s;
+        int64_t num_bytes_l1_l2_cd = layout.block_m * layout.block_n * elem_size_cd_s * (desc.with_accumulation ? 2 : 1);
 
         // HBM bandwidth and total compute (Tensor/CUDA cores) are constant across configs
         // We only model L1/L2 cycles as they are the primary variables between configs
+        // Scale factor cancels in the ratio (bytes * scale) / (bandwidth * scale) when scale is uniform
         int64_t num_l2_cycles = (num_bytes_l2_ab + num_bytes_l1_l2_cd) * num_blocks / l2_bandwidth_per_cycle;
         int64_t num_l1_cycles = (num_bytes_l1_ab + num_bytes_l1_tc + num_bytes_l1_l2_cd) * num_blocks / l1_bandwidth_per_cycle;
         float wave_efficiency = static_cast<float>(num_blocks) / (num_waves * desc.num_sms);
         int64_t num_cycles = std::max(num_l1_cycles, num_l2_cycles) / wave_efficiency;
 
-        // Disable multicasting if only one wave exists
+        // Disable multicasting if only one wave exists: cluster sync overhead
+        // outweighs bandwidth savings when all SMs are already utilized.
+        // NOTE: For W4 masked GEMM small-m, cluster_n=2 (weight multicast) was
+        // tested and found NOT beneficial — L2 working set fits within 50MB cache,
+        // so no DRAM savings, only added cluster sync overhead.
         if (layout.cluster_n * layout.cluster_m > 1 and num_waves <= 1)
+            num_cycles = std::numeric_limits<int64_t>::max();
+
+        // For masked GEMM: disable all multicast when expected_m ≤ block_m
+        // (each group has only 1 M-block, cluster sync overhead outweighs savings).
+        if (layout.cluster_n * layout.cluster_m > 1 and
+            desc.gemm_type == GemmType::MGroupedMasked and
+            desc.get_expected_m() <= layout.block_m)
             num_cycles = std::numeric_limits<int64_t>::max();
 
         return {num_waves, last_wave_util, num_cycles, layout};

--- a/csrc/jit_kernels/impls/sm90_fp8_gemm_1d2d.hpp
+++ b/csrc/jit_kernels/impls/sm90_fp8_gemm_1d2d.hpp
@@ -32,6 +32,13 @@ public:
     };
 
     static std::string generate_impl(const Args& args) {
+        const bool is_w4 = args.gemm_desc.is_w4;
+
+        // W4 small-m Normal: compile SHAPE_M for MMA_N selection
+        const bool should_compile_m = is_w4
+                                      and (args.gemm_desc.gemm_type == GemmType::Normal)
+                                      and (args.gemm_desc.m > 0 and args.gemm_desc.m <= 56);
+
         return fmt::format(R"(
 #include <deep_gemm/impls/sm90_fp8_gemm_1d2d.cuh>
 
@@ -48,13 +55,14 @@ static void __instantiate_kernel() {{
         {}, {},
         {}, {},
         {}, {},
+        {},
         {}
     >);
 }};
 )",
         // TODO: add CD dtype
         to_string(args.major_sfb),
-        get_compiled_dim(args.gemm_desc.m, 'm', args.gemm_desc.compiled_dims),
+        should_compile_m ? align(args.gemm_desc.m, 8) : get_compiled_dim(args.gemm_desc.m, 'm', args.gemm_desc.compiled_dims),
         get_compiled_dim(args.gemm_desc.n, 'n', args.gemm_desc.compiled_dims),
         get_compiled_dim(args.gemm_desc.k, 'k', args.gemm_desc.compiled_dims),
         args.gemm_desc.num_groups,
@@ -64,7 +72,8 @@ static void __instantiate_kernel() {{
         args.gemm_config.launch_config.num_tma_threads, args.gemm_config.launch_config.num_math_threads,
         args.gemm_config.layout.get_cluster_size(), args.gemm_config.layout.cluster_n > 1,
         args.gemm_config.launch_config.num_sms, to_string(args.gemm_desc.gemm_type),
-        get_default_epilogue_type(args.epilogue_type));
+        get_default_epilogue_type(args.epilogue_type),
+        is_w4);
     }
 
     static void launch_impl(const KernelHandle& kernel, const LaunchConfigHandle& config, Args args) {
@@ -88,6 +97,9 @@ static void sm90_fp8_gemm_1d2d(const torch::Tensor& a, const torch::Tensor& sfa,
     DG_HOST_ASSERT(not c.has_value() and d.scalar_type() == torch::kBFloat16);
     DG_HOST_ASSERT(major_a == cute::UMMA::Major::K and major_b == cute::UMMA::Major::K);
 
+    const bool is_w4 = a.size(-1) != b.size(-1);
+    const int weight_ratio = is_w4 ? 2 : 1;
+
     const auto desc = GemmDesc {
         .gemm_type = GemmType::Normal,
         .kernel_type = KernelType::Kernel1D2D,
@@ -97,21 +109,22 @@ static void sm90_fp8_gemm_1d2d(const torch::Tensor& a, const torch::Tensor& sfa,
         .major_a = major_a, .major_b = major_b,
         .with_accumulation = c.has_value(),
         .num_sms = device_runtime->get_num_sms(),
-        .tc_util = device_runtime->get_tc_util(), .compiled_dims = compiled_dims
+        .tc_util = device_runtime->get_tc_util(), .compiled_dims = compiled_dims,
+        .is_w4 = is_w4
     };
     const auto config = get_best_config<SM90ArchSpec>(desc);
 
     // Requires no TMA splits
     DG_HOST_ASSERT(config.storage_config.swizzle_a_mode == config.layout.block_k);
-    DG_HOST_ASSERT(config.storage_config.swizzle_b_mode == config.layout.block_k);
+    DG_HOST_ASSERT(config.storage_config.swizzle_b_mode == config.layout.block_k / weight_ratio);
     const auto tensor_map_a = make_tma_a_desc(major_a, a, m, k,
                                               config.storage_config.load_block_m,
                                               config.layout.block_k,
                                               static_cast<int>(a.stride(get_non_contiguous_dim(major_a))), 1,
                                               config.storage_config.swizzle_a_mode);
-    const auto tensor_map_b = make_tma_b_desc(major_b, b, n, k,
+    const auto tensor_map_b = make_tma_b_desc(major_b, b, n, k / weight_ratio,
                                               config.storage_config.load_block_n,
-                                              config.layout.block_k,
+                                              config.layout.block_k / weight_ratio,
                                               static_cast<int>(b.stride(get_non_contiguous_dim(major_b))), 1,
                                               config.storage_config.swizzle_b_mode);
     const auto tensor_map_d = make_tma_cd_desc(d, m, static_cast<int>(d.size(-1)),
@@ -119,8 +132,11 @@ static void sm90_fp8_gemm_1d2d(const torch::Tensor& a, const torch::Tensor& sfa,
                                                config.storage_config.store_block_n,
                                                static_cast<int>(d.stride(-2)), 1,
                                                config.storage_config.swizzle_cd_mode);
-    const auto tensor_map_sfa = make_tma_sf_desc(cute::UMMA::Major::MN, sfa, m, k,
-                                                 config.layout.block_m, config.layout.block_k, 1, 0);
+    // W4: SFA slot carries weight scales (sfb tensor, block_n dim)
+    const auto tensor_map_sfa = is_w4 ? make_tma_sf_desc(cute::UMMA::Major::MN, sfb, n, k,
+                                                         config.layout.block_n, config.layout.block_k, 1, 0)
+                                      : make_tma_sf_desc(cute::UMMA::Major::MN, sfa, m, k,
+                                                         config.layout.block_m, config.layout.block_k, 1, 0);
 
     // Launch
     const SM90FP8Gemm1D2DRuntime::Args& args = {
@@ -131,7 +147,7 @@ static void sm90_fp8_gemm_1d2d(const torch::Tensor& a, const torch::Tensor& sfa,
                                   config.layout.get_cluster_size()),
         .epilogue_type = epilogue_type,
         .major_sfb = major_sfb,
-        .sfb = sfb.data_ptr(),
+        .sfb = is_w4 ? sfa.data_ptr() : sfb.data_ptr(),
         .grouped_layout = nullptr,
         .tensor_map_a = tensor_map_a,
         .tensor_map_b = tensor_map_b,
@@ -155,6 +171,9 @@ static void sm90_m_grouped_fp8_gemm_contiguous_1d2d(const torch::Tensor& a, cons
     DG_HOST_ASSERT(d.scalar_type() == torch::kBFloat16);
     DG_HOST_ASSERT(major_a == cute::UMMA::Major::K and major_b == cute::UMMA::Major::K);
 
+    const bool is_w4 = a.size(-1) != b.size(-1);
+    const int weight_ratio = is_w4 ? 2 : 1;
+
     const auto gemm_type = use_psum_layout ?
         GemmType::MGroupedContiguousWithPsumLayout : GemmType::MGroupedContiguous;
 
@@ -172,6 +191,7 @@ static void sm90_m_grouped_fp8_gemm_contiguous_1d2d(const torch::Tensor& a, cons
         .with_accumulation = false,
         .num_sms = device_runtime->get_num_sms(),
         .tc_util = device_runtime->get_tc_util(), .compiled_dims = compiled_dims,
+        .is_w4 = is_w4,
         .expected_m = expected_m_for_psum_layout.value_or(m),
         .expected_n = n, .expected_k = k,
         .expected_num_groups = expected_m_for_psum_layout.has_value() ? num_groups : 1
@@ -180,15 +200,15 @@ static void sm90_m_grouped_fp8_gemm_contiguous_1d2d(const torch::Tensor& a, cons
 
     // Requires no TMA splits
     DG_HOST_ASSERT(config.storage_config.swizzle_a_mode == config.layout.block_k);
-    DG_HOST_ASSERT(config.storage_config.swizzle_b_mode == config.layout.block_k);
+    DG_HOST_ASSERT(config.storage_config.swizzle_b_mode == config.layout.block_k / weight_ratio);
     const auto tensor_map_a = make_tma_a_desc(major_a, a, m, k,
                                               config.storage_config.load_block_m,
                                               config.layout.block_k,
                                               static_cast<int>(a.stride(get_non_contiguous_dim(major_a))), 1,
                                               config.storage_config.swizzle_a_mode);
-    const auto tensor_map_b = make_tma_b_desc(major_b, b, n, k,
+    const auto tensor_map_b = make_tma_b_desc(major_b, b, n, k / weight_ratio,
                                               config.storage_config.load_block_n,
-                                              config.layout.block_k,
+                                              config.layout.block_k / weight_ratio,
                                               static_cast<int>(b.stride(get_non_contiguous_dim(major_b))), num_groups,
                                               config.storage_config.swizzle_b_mode);
     const auto tensor_map_d = make_tma_cd_desc(d, m, n,
@@ -196,8 +216,11 @@ static void sm90_m_grouped_fp8_gemm_contiguous_1d2d(const torch::Tensor& a, cons
                                                config.storage_config.store_block_n,
                                                static_cast<int>(d.stride(-2)), 1,
                                                config.storage_config.swizzle_cd_mode);
-    const auto tensor_map_sfa = make_tma_sf_desc(cute::UMMA::Major::MN, sfa, m, k,
-                                                 config.layout.block_m, config.layout.block_k, 1, 0);
+    // W4: SFA slot carries weight scales (sfb tensor, block_n dim, with num_groups)
+    const auto tensor_map_sfa = is_w4 ? make_tma_sf_desc(cute::UMMA::Major::MN, sfb, n, k,
+                                                         config.layout.block_n, config.layout.block_k, num_groups, 0)
+                                      : make_tma_sf_desc(cute::UMMA::Major::MN, sfa, m, k,
+                                                         config.layout.block_m, config.layout.block_k, 1, 0);
 
     // Launch
     const SM90FP8Gemm1D2DRuntime::Args& args = {
@@ -208,7 +231,7 @@ static void sm90_m_grouped_fp8_gemm_contiguous_1d2d(const torch::Tensor& a, cons
                                   config.layout.get_cluster_size()),
         .epilogue_type = std::nullopt,
         .major_sfb = major_sfb,
-        .sfb = sfb.data_ptr(),
+        .sfb = is_w4 ? sfa.data_ptr() : sfb.data_ptr(),
         .grouped_layout = m_indices.data_ptr(),
         .tensor_map_a = tensor_map_a,
         .tensor_map_b = tensor_map_b,
@@ -231,6 +254,9 @@ static void sm90_m_grouped_fp8_gemm_masked_1d2d(const torch::Tensor& a, const to
     DG_HOST_ASSERT(d.scalar_type() == torch::kBFloat16);
     DG_HOST_ASSERT(major_a == cute::UMMA::Major::K and major_b == cute::UMMA::Major::K);
 
+    const bool is_w4 = a.size(-1) != b.size(-1);
+    const int weight_ratio = is_w4 ? 2 : 1;
+
     const auto desc = GemmDesc {
         .gemm_type = GemmType::MGroupedMasked,
         .kernel_type = KernelType::Kernel1D2D,
@@ -241,21 +267,22 @@ static void sm90_m_grouped_fp8_gemm_masked_1d2d(const torch::Tensor& a, const to
         .with_accumulation = false,
         .num_sms = device_runtime->get_num_sms(),
         .tc_util = device_runtime->get_tc_util(), .compiled_dims = compiled_dims,
+        .is_w4 = is_w4,
         .expected_m = expected_m, .expected_n = n, .expected_k = k, .expected_num_groups = num_groups
     };
     const auto config = get_best_config<SM90ArchSpec>(desc);
 
     // Requires no TMA splits
     DG_HOST_ASSERT(config.storage_config.swizzle_a_mode == config.layout.block_k);
-    DG_HOST_ASSERT(config.storage_config.swizzle_b_mode == config.layout.block_k);
+    DG_HOST_ASSERT(config.storage_config.swizzle_b_mode == config.layout.block_k / weight_ratio);
     const auto tensor_map_a = make_tma_a_desc(major_a, a, m, k,
                                               config.storage_config.load_block_m,
                                               config.layout.block_k,
                                               static_cast<int>(a.stride(get_non_contiguous_dim(major_a))), num_groups,
                                               config.storage_config.swizzle_a_mode);
-    const auto tensor_map_b = make_tma_b_desc(major_b, b, n, k,
+    const auto tensor_map_b = make_tma_b_desc(major_b, b, n, k / weight_ratio,
                                               config.storage_config.load_block_n,
-                                              config.layout.block_k,
+                                              config.layout.block_k / weight_ratio,
                                               static_cast<int>(b.stride(get_non_contiguous_dim(major_b))), num_groups,
                                               config.storage_config.swizzle_b_mode);
     const auto tensor_map_d = make_tma_cd_desc(d, m, n,
@@ -263,8 +290,11 @@ static void sm90_m_grouped_fp8_gemm_masked_1d2d(const torch::Tensor& a, const to
                                                config.storage_config.store_block_n,
                                                static_cast<int>(d.stride(-2)), num_groups,
                                                config.storage_config.swizzle_cd_mode);
-    const auto tensor_map_sfa = make_tma_sf_desc(cute::UMMA::Major::MN, sfa, m, k,
-                                                 config.layout.block_m, config.layout.block_k, num_groups, 0);
+    // W4: SFA slot carries weight scales (sfb tensor, block_n dim, with num_groups)
+    const auto tensor_map_sfa = is_w4 ? make_tma_sf_desc(cute::UMMA::Major::MN, sfb, n, k,
+                                                         config.layout.block_n, config.layout.block_k, num_groups, 0)
+                                      : make_tma_sf_desc(cute::UMMA::Major::MN, sfa, m, k,
+                                                         config.layout.block_m, config.layout.block_k, num_groups, 0);
 
     // Launch
     const SM90FP8Gemm1D2DRuntime::Args& args = {
@@ -275,7 +305,7 @@ static void sm90_m_grouped_fp8_gemm_masked_1d2d(const torch::Tensor& a, const to
                                   config.layout.get_cluster_size()),
         .epilogue_type = std::nullopt,
         .major_sfb = major_sfb,
-        .sfb = sfb.data_ptr(),
+        .sfb = is_w4 ? sfa.data_ptr() : sfb.data_ptr(),
         .grouped_layout = masked_m.data_ptr(),
         .tensor_map_a = tensor_map_a,
         .tensor_map_b = tensor_map_b,

--- a/csrc/utils/layout.hpp
+++ b/csrc/utils/layout.hpp
@@ -95,7 +95,8 @@ static torch::Tensor check_sf_layout(const torch::Tensor& sf,
     if (num_groups.has_value())
         DG_HOST_ASSERT(sf.size(-3) == num_groups.value());
     DG_HOST_ASSERT(sf.size(-2) == ceil_div(mn, gran_mn));
-    DG_HOST_ASSERT(sf.size(-1) == ceil_div(k, gran_k * (sf_dtype == torch::kFloat ? 1 : 4)));
+    DG_HOST_ASSERT(sf.size(-1) == ceil_div(k, gran_k * (sf_dtype == torch::kFloat ? 1 : 4))
+                   or sf.size(-1) == 1);
 
     // TMA stride checks: TMA aligned and MN-major
     if (tma_stride_check) {

--- a/deep_gemm/__init__.py
+++ b/deep_gemm/__init__.py
@@ -40,6 +40,10 @@ try:
         m_grouped_fp8_fp4_gemm_nt_contiguous,
         m_grouped_fp8_fp4_gemm_nn_contiguous,
         m_grouped_fp8_fp4_gemm_nt_masked,
+        # SM90 W4AFP8 GEMMs
+        sm90_w4afp8_gemm_nt,
+        sm90_m_grouped_w4afp8_gemm_nt_contiguous,
+        sm90_m_grouped_w4afp8_gemm_nt_masked,
         # FP8 GEMMs
         fp8_gemm_nt, fp8_gemm_nn,
         fp8_gemm_tn, fp8_gemm_tt,

--- a/deep_gemm/include/deep_gemm/impls/sm90_fp8_gemm_1d2d.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm90_fp8_gemm_1d2d.cuh
@@ -43,7 +43,8 @@ template <cute::UMMA::Major kMajorSFB,
           uint32_t kNumTMAThreads, uint32_t kNumMathThreads,
           uint32_t kNumTMAMulticast, bool kIsTMAMulticastOnA,
           uint32_t kNumSMs, GemmType kGemmType,
-          typename epilogue_type_t>
+          typename epilogue_type_t,
+          bool kIsW4 = false>
 CUTLASS_GLOBAL __launch_bounds__(kNumTMAThreads + kNumMathThreads, 1) void
 sm90_fp8_gemm_1d2d_impl(float* sfb, int* grouped_layout,
                         uint32_t shape_m, uint32_t shape_n, uint32_t shape_k,
@@ -59,9 +60,19 @@ sm90_fp8_gemm_1d2d_impl(float* sfb, int* grouped_layout,
         (math::constexpr_gcd(BLOCK_N, BLOCK_K) == BLOCK_N - BLOCK_K), "Too much B scales in a single block");
 
     // Types
-    using WGMMA = typename mma::sm90::FP8MMASelector<BLOCK_N>::type;
+    constexpr int WEIGHT_RATIO = kIsW4 ? 2 : 1;
+    // W4 RS-mode swaps layout↔compute dimensions: WGMMA M=64 tiles along BLOCK_N, MMA_N=BLOCK_M
+    constexpr uint32_t COMPUTE_M = kIsW4 ? BLOCK_N : BLOCK_M;
+    constexpr uint32_t COMPUTE_N = kIsW4 ? BLOCK_M : BLOCK_N;
+    constexpr int MMA_N = kIsW4 ? (SHAPE_M != 0 ? SHAPE_M : COMPUTE_N) : COMPUTE_N;
+    using WGMMA = typename mma::sm90::FP8MMASelector<MMA_N>::type;
     using Barrier = cutlass::arch::ClusterTransactionBarrier;
-    DG_STATIC_ASSERT(BLOCK_M % WGMMA::M == 0 or BLOCK_M < WGMMA::M, "Invalid block size");
+    if constexpr (kIsW4) {
+        DG_STATIC_ASSERT(BLOCK_M <= 256, "keep BLOCK_M <= 256, if use w4afp8.");
+        DG_STATIC_ASSERT(BLOCK_N % WGMMA::M == 0, "keep BLOCK_N % WGMMA::M == 0, if use w4afp8.");
+    } else {
+        DG_STATIC_ASSERT(BLOCK_M % WGMMA::M == 0 or BLOCK_M < WGMMA::M, "Invalid block size");
+    }
 
     // Overwrite shape constants if the compiler gives
     shape_m = SHAPE_M != 0 ? SHAPE_M : shape_m;
@@ -69,15 +80,15 @@ sm90_fp8_gemm_1d2d_impl(float* sfb, int* grouped_layout,
     shape_k = SHAPE_K != 0 ? SHAPE_K : shape_k;
 
     // Shared memory
-    static constexpr bool kMustUseUniformedScaleB = (BLOCK_K % BLOCK_N == 0);
+    static constexpr bool kMustUseUniformedScaleB = kIsW4 ? true : (BLOCK_K % BLOCK_N == 0);
     static constexpr uint32_t SMEM_D_SIZE = math::constexpr_align(BLOCK_M * BLOCK_N * static_cast<uint32_t>(sizeof(__nv_bfloat16)), 1024u);
     static constexpr uint32_t SMEM_A_SIZE_PER_STAGE = BLOCK_M * BLOCK_K * sizeof(__nv_fp8_e4m3);
-    static constexpr uint32_t SMEM_B_SIZE_PER_STAGE = BLOCK_N * BLOCK_K * sizeof(__nv_fp8_e4m3);
-    static constexpr uint32_t SMEM_SFA_SIZE_PER_STAGE = BLOCK_M * sizeof(float);
+    static constexpr uint32_t SMEM_B_SIZE_PER_STAGE = BLOCK_N * BLOCK_K * sizeof(__nv_fp8_e4m3) / WEIGHT_RATIO;
+    static constexpr uint32_t SMEM_SFA_SIZE_PER_STAGE = COMPUTE_M * sizeof(float);
     static constexpr uint32_t ALIGNED_SMEM_SFA_SIZE_PER_STAGE = math::constexpr_align(SMEM_SFA_SIZE_PER_STAGE, 128u);
     const uint32_t shape_k_scales = math::ceil_div(shape_k, BLOCK_K);
     const uint32_t shape_n_sfb = math::ceil_div(shape_n, BLOCK_K);
-    const uint32_t smem_sfb_size = math::align<uint32_t>(shape_k_scales * (kMustUseUniformedScaleB ? 1 : 2) * sizeof(float), sizeof(Barrier));
+    const uint32_t smem_sfb_size = kIsW4 ? 0 : math::align<uint32_t>(shape_k_scales * (kMustUseUniformedScaleB ? 1 : 2) * sizeof(float), sizeof(Barrier));
 
     // NOTES: Make sure we have enough shared memory for WGMMA padding
     static constexpr uint32_t WGMMA_A_SIZE_PER_STAGE = WGMMA::M * BLOCK_K * sizeof(__nv_fp8_e4m3);
@@ -189,13 +200,18 @@ sm90_fp8_gemm_1d2d_impl(float* sfb, int* grouped_layout,
                     tma::copy<BLOCK_K, BLOCK_M, kSwizzleAMode, __nv_fp8_e4m3, kIsBatchedMM>(&tensor_map_a, &full_barrier,
                              smem_a[stage_idx], k_idx, scheduler.get_global_idx<kWithGroupOffsetA>(shape_m, BLOCK_M, m_block_idx),
                              num_tma_multicast_a, batch_idx);
-                    tma::copy<BLOCK_M, BLOCK_K, 0>(&tensor_map_sfa, &full_barrier,
-                             smem_sfa[stage_idx], m_block_idx * BLOCK_M, scheduler.template get_global_idx<kWithGroupOffsetA, sched::IndexType::SF_K>(shape_k_scales, 1, k_block_idx),
-                             num_tma_multicast_a);
+                    // W4: SFA slot carries weight scales (block_n dim, indexed by n_block_idx)
+                    tma::copy<COMPUTE_M, BLOCK_K, 0>(&tensor_map_sfa, &full_barrier,
+                             smem_sfa[stage_idx], kIsW4 ? (n_block_idx * BLOCK_N) : (m_block_idx * BLOCK_M),
+                             scheduler.template get_global_idx<kIsW4 or kWithGroupOffsetA, sched::IndexType::SF_K>(shape_k_scales,
+                                                                                  1,
+                                                                                  k_block_idx,
+                                                                                  (kGemmType == GemmType::MGroupedContiguous) ? m_block_idx : 0),
+                             kIsW4 ? num_tma_multicast_b : num_tma_multicast_a);
 
                     // Issue TMA B
-                    tma::copy<BLOCK_K, BLOCK_N, kSwizzleBMode, __nv_fp8_e4m3, kIsBatchedMM>(&tensor_map_b, &full_barrier,
-                             smem_b[stage_idx], k_idx, scheduler.get_global_idx<true>(shape_n, BLOCK_N, n_block_idx, m_block_idx),
+                    tma::copy<BLOCK_K / WEIGHT_RATIO, BLOCK_N, kSwizzleBMode, __nv_fp8_e4m3, kIsBatchedMM>(&tensor_map_b, &full_barrier,
+                             smem_b[stage_idx], k_idx / WEIGHT_RATIO, scheduler.get_global_idx<true>(shape_n, BLOCK_N, n_block_idx, m_block_idx),
                              num_tma_multicast_b, batch_idx);
                     full_barrier.arrive_and_expect_tx(SMEM_A_SIZE_PER_STAGE + SMEM_B_SIZE_PER_STAGE + SMEM_SFA_SIZE_PER_STAGE);
                 }
@@ -213,12 +229,21 @@ sm90_fp8_gemm_1d2d_impl(float* sfb, int* grouped_layout,
 
         // NOTES: use `__shfl_sync` to encourage NVCC to use unified registers
         const auto math_wg_idx = __shfl_sync(0xffffffff, threadIdx.x / 128, 0);
-        const auto r_0 = warp_idx * 16 + lane_idx / 4, r_1 = r_0 + 8;
 
-        auto a_desc = mma::sm90::make_smem_desc(smem_a[0] + math_wg_idx * WGMMA::M * BLOCK_K, 1);
-        auto b_desc = mma::sm90::make_smem_desc(smem_b[0], 1);
+        const auto r_0 = warp_idx * 16 + lane_idx / 4;
+        const auto r_1 = r_0 + 8;
+
+        auto a_desc = mma::sm90::make_smem_desc(smem_a[0] + (kIsW4 ? 0 : math_wg_idx * WGMMA::M * BLOCK_K), 1);
+        auto b_desc = mma::sm90::make_smem_desc(smem_b[0] + (kIsW4 ? math_wg_idx * WGMMA::M * BLOCK_K : 0), 1);
         const uint32_t a_desc_lo = __shfl_sync(0xffffffff, a_desc.reg32_[0], 0);
         const uint32_t b_desc_lo = __shfl_sync(0xffffffff, b_desc.reg32_[0], 0);
+
+        // W4: Precompute thread-invariant values for ldmatrix (hoisted out of k-loop)
+        constexpr uint32_t NV = 16 / sizeof(__nv_fp8_e4m3);
+        const uint32_t tidG = threadIdx.x % 128;
+        const uint32_t tRow = (tidG & 15) | ((tidG >> 5) << 4);
+        const uint32_t tCol = ((tidG >> 4) & 1) * NV;
+        const uint32_t sRow = math_wg_idx * WGMMA::M + tRow;
 
         // Persistently schedule over blocks
         while (scheduler.get_next_block(m_block_idx, n_block_idx)) {
@@ -231,27 +256,34 @@ sm90_fp8_gemm_1d2d_impl(float* sfb, int* grouped_layout,
             }
             uint32_t num_sfb = shape_k_scales * (num_former_iters >= num_full_iters ? 1 : 2);
 
-            // Load B scales with math warp-groups
-            // NOTES: except the first warp, we want to overlap loading B scales with TMA stores between tasks
-            if (threadIdx.x >= 32) {
-                auto previous_group_offset = scheduler.template get_global_idx<true, sched::IndexType::SF_K>(shape_n_sfb * shape_k_scales, 0, 0, m_block_idx);
-                const uint32_t stride_n_sfb = kMajorSFB == cute::UMMA::Major::MN ? 1 : shape_k_scales;
-                const uint32_t stride_k_sfb = kMajorSFB == cute::UMMA::Major::MN ? shape_n_sfb : 1;
-                auto local_sfb = sfb + previous_group_offset + ((n_block_idx * BLOCK_N) / BLOCK_K) * stride_n_sfb;
+            // W4: sfb is mounted on sfa (per-tensor scale), skip global SFB loading
+            if constexpr (not kIsW4) {
+                // Load B scales with math warp-groups
+                // NOTES: except the first warp, we want to overlap loading B scales with TMA stores between tasks
+                if (threadIdx.x >= 32) {
+                    auto previous_group_offset = scheduler.template get_global_idx<true, sched::IndexType::SF_K>(shape_n_sfb * shape_k_scales, 0, 0, m_block_idx);
+                    const uint32_t stride_n_sfb = kMajorSFB == cute::UMMA::Major::MN ? 1 : shape_k_scales;
+                    const uint32_t stride_k_sfb = kMajorSFB == cute::UMMA::Major::MN ? shape_n_sfb : 1;
+                    auto local_sfb = sfb + previous_group_offset + ((n_block_idx * BLOCK_N) / BLOCK_K) * stride_n_sfb;
 
-                #pragma unroll
-                for (uint32_t i = threadIdx.x - 32; i < num_sfb; i += kNumMathThreads - 32)
-                    ptx::st_shared(smem_sfb + i, i < shape_k_scales ? local_sfb[i * stride_k_sfb] : local_sfb[(i - shape_k_scales) * stride_k_sfb + stride_n_sfb]);
+                    #pragma unroll
+                    for (uint32_t i = threadIdx.x - 32; i < num_sfb; i += kNumMathThreads - 32)
+                        ptx::st_shared(smem_sfb + i, i < shape_k_scales ? local_sfb[i * stride_k_sfb] : local_sfb[(i - shape_k_scales) * stride_k_sfb + stride_n_sfb]);
+                }
+                cutlass::arch::NamedBarrier::sync(kNumMathThreads, 0);
             }
-            cutlass::arch::NamedBarrier::sync(kNumMathThreads, 0);
 
             // Accumulation for WGMMA or CUDA promotion
-            constexpr uint32_t WAVE_BLOCK_M = BLOCK_M <= WGMMA::M ? BLOCK_M : WGMMA::M * 2;
-            DG_STATIC_ASSERT(BLOCK_M % WAVE_BLOCK_M == 0, "Invalid block sizes");
-            float accum[WGMMA::kNumAccum], final_accum[WGMMA::kNumAccum * (BLOCK_M / WAVE_BLOCK_M)] = {0};
-            
+            constexpr uint32_t WAVE_BLOCK_M = COMPUTE_M <= WGMMA::M
+                                              ? COMPUTE_M
+                                              : WGMMA::M * 2;
+            DG_STATIC_ASSERT(COMPUTE_M % WAVE_BLOCK_M == 0, "Invalid block sizes");
+
+            constexpr int WAVE_WGMMA = COMPUTE_M / WAVE_BLOCK_M;
+            float accum[WGMMA::kNumAccum], final_accum[WGMMA::kNumAccum * WAVE_WGMMA] = {0};
+
             // Pick threads whose WGMMA results are to be stored in shared memory
-            DG_STATIC_ASSERT(BLOCK_M >= 64 or kNumMathThreads == 128, "Only one math warp group for `BLOCK_M < 64`");
+            DG_STATIC_ASSERT(COMPUTE_M >= 64 or kNumMathThreads == 128, "Only one math warp group for `BLOCK_M < 64`");
             constexpr uint32_t kNumWGMMAStoreThreads = WAVE_BLOCK_M * (128 / WGMMA::M);
             const bool do_wgmma_store = BLOCK_M >= WGMMA::M or warp_idx < kNumWGMMAStoreThreads / 32;
 
@@ -266,7 +298,7 @@ sm90_fp8_gemm_1d2d_impl(float* sfb, int* grouped_layout,
             };
 
             // Skip useless computations
-            if (scheduler.is_computation_valid(m_block_idx, math_wg_idx * WGMMA::M)) {
+            if (scheduler.is_computation_valid(m_block_idx, kIsW4 ? 0 : math_wg_idx * WGMMA::M)) {
                 // The compiler must know the dynamic variable `num_former_iters`'s real value
                 constexpr bool kShouldOptimize = BLOCK_K / math::constexpr_gcd(BLOCK_K, BLOCK_N) <= 4 and not kMustUseUniformedScaleB;
                 constexpr uint32_t kGap = math::constexpr_gcd(BLOCK_K, BLOCK_N) / 8;
@@ -279,36 +311,95 @@ sm90_fp8_gemm_1d2d_impl(float* sfb, int* grouped_layout,
                         const auto a_desc_base_lo = a_desc_lo + stage_idx * (SMEM_A_SIZE_PER_STAGE / 16);
                         const auto b_desc_base_lo = b_desc_lo + stage_idx * (SMEM_B_SIZE_PER_STAGE / 16);
 
-                        // Read B scales
-                        float scale_b_0 = ptx::ld_shared(smem_sfb + k_block_idx), scale_b_1;
-                        // NOTES: even some blocks do not need to read the second row, but we still load one to align with other blocks
-                        if constexpr (not kMustUseUniformedScaleB)
-                            scale_b_1 = ptx::ld_shared(smem_sfb + k_block_idx + shape_k_scales);
+                        float scale_b_0;
+                        float scale_b_1;
+
+                        if constexpr (not kIsW4) {
+                            // Read B scales
+                            scale_b_0 = ptx::ld_shared(smem_sfb + k_block_idx);
+                            // NOTES: even some blocks do not need to read the second row, but we still load one to align with other blocks
+                            if constexpr (not kMustUseUniformedScaleB)
+                                scale_b_1 = ptx::ld_shared(smem_sfb + k_block_idx + shape_k_scales);
+                        }
 
                         // Wait TMA arrivals
                         full_barriers[stage_idx]->wait(phase);
 
                         // TODO: remove some useless computation for unaligned Ms
                         #pragma unroll
-                        for (uint32_t local_idx = 0; local_idx < BLOCK_M / WAVE_BLOCK_M; ++ local_idx) {
+                        for (uint32_t local_idx = 0; local_idx < WAVE_WGMMA; ++ local_idx) {
                             auto m_offset = local_idx * WAVE_BLOCK_M;
 
-                            // Read A scales
+                            // Read A scales (or weight scales for W4)
                             // NOTES: all shared memory read must be prior to `warpgroup_arrive` to avoid next scheduled block polluting the results
-                            auto scale_a_0 = do_wgmma_store ? ptx::ld_shared(smem_sfa[stage_idx] + r_0 + m_offset) : 0;
-                            auto scale_a_1 = do_wgmma_store ? ptx::ld_shared(smem_sfa[stage_idx] + r_1 + m_offset) : 0;
+                            float scale_a_0;
+                            float scale_a_1;
+
+                            if constexpr (kIsW4) {
+                                scale_b_0 = ptx::ld_shared(smem_sfa[stage_idx] + r_0 + m_offset);
+                                scale_b_1 = ptx::ld_shared(smem_sfa[stage_idx] + r_1 + m_offset);
+                            } else {
+                                scale_a_0 = do_wgmma_store ? ptx::ld_shared(smem_sfa[stage_idx] + r_0 + m_offset) : 0;
+                                scale_a_1 = do_wgmma_store ? ptx::ld_shared(smem_sfa[stage_idx] + r_1 + m_offset) : 0;
+                            }
 
                             // Commit WGMMA instructions
                             #pragma unroll
                             for (uint32_t i = 0; i < WGMMA::kNumAccum; ++ i)
                                 ptx::warpgroup_fence_operand(accum[i]);
                             ptx::warpgroup_arrive();
-                            #pragma unroll
-                            for (uint32_t k = 0; k < BLOCK_K / WGMMA::K; ++ k) {
-                                a_desc.reg32_[0] = a_desc_base_lo + (m_offset * BLOCK_K + k * WGMMA::K) / 16;
-                                b_desc.reg32_[0] = b_desc_base_lo + k * WGMMA::K / 16;
-                                WGMMA::wgmma(a_desc, b_desc, accum, k);
+
+                            if constexpr (kIsW4) {
+                                using WGMMARS = typename mma::sm90::FP8MMASelectorRS<MMA_N>::type;
+
+                                uint32_t fragB[std::min(BLOCK_K / WGMMA::K, 2U)][4];
+                                uint32_t unpackB[std::min(BLOCK_K / WGMMA::K, 2U)][8];
+
+                                const __nv_fp8_e4m3* smem_b_w4_ptr = smem_b[stage_idx] + (sRow + m_offset) * (BLOCK_K / 2);
+
+                                // Prologue: ldmatrix + dequant for k=0
+                                const uint32_t pCol = ptx::permute_col<BLOCK_K / 2 * sizeof(__nv_fp8_e4m3), NV>(tRow, 0 * WGMMA::K / 2 + tCol);
+                                ptx::SM90_U32x4_LDSM_N::copy(fragB[0][0], fragB[0][1], fragB[0][2], fragB[0][3], (void*)(smem_b_w4_ptr + pCol));
+
+                                ptx::fast_int4_to_fp8_convert(unpackB[0] + 0, fragB[0][0]);
+                                ptx::fast_int4_to_fp8_convert(unpackB[0] + 2, fragB[0][1]);
+                                ptx::fast_int4_to_fp8_convert(unpackB[0] + 4, fragB[0][2]);
+                                ptx::fast_int4_to_fp8_convert(unpackB[0] + 6, fragB[0][3]);
+
+                                DG_STATIC_ASSERT((BLOCK_K / WGMMA::K) % 2 == 0, "Invalid unroll for w4 dequant.");
+
+                                #pragma unroll
+                                for (uint32_t k = 2; k < BLOCK_K / WGMMA::K; k += 2) {
+                                    const uint32_t pCol = ptx::permute_col<BLOCK_K / 2 * sizeof(__nv_fp8_e4m3), NV>(tRow, k * WGMMA::K / 2 + tCol);
+                                    ptx::SM90_U32x4_LDSM_N::copy(fragB[(k / 2) % 2][0], fragB[(k / 2) % 2][1], fragB[(k / 2) % 2][2], fragB[(k / 2) % 2][3], (void*)(smem_b_w4_ptr + pCol));
+
+                                    ptx::fast_int4_to_fp8_convert(unpackB[(k / 2) % 2] + 0, fragB[(k / 2) % 2][0]);
+                                    ptx::fast_int4_to_fp8_convert(unpackB[(k / 2) % 2] + 2, fragB[(k / 2) % 2][1]);
+                                    ptx::fast_int4_to_fp8_convert(unpackB[(k / 2) % 2] + 4, fragB[(k / 2) % 2][2]);
+                                    ptx::fast_int4_to_fp8_convert(unpackB[(k / 2) % 2] + 6, fragB[(k / 2) % 2][3]);
+
+                                    #pragma unroll
+                                    for (int j = 0; j < 2; ++j) {
+                                        a_desc.reg32_[0] = a_desc_base_lo + (k - 2 + j) * WGMMA::K / 16;
+                                        WGMMARS::wgmma(unpackB[((k - 2) / 2) % 2] + j * 4, a_desc, accum, k - 2 + j);
+                                    }
+                                }
+
+                                // Epilogue: last batch of wgmma
+                                #pragma unroll
+                                for (int j = 0; j < 2; ++j) {
+                                    a_desc.reg32_[0] = a_desc_base_lo + (BLOCK_K / WGMMA::K - 2 + j) * WGMMA::K / 16;
+                                    WGMMARS::wgmma(unpackB[std::max(BLOCK_K / WGMMA::K - 1, 1U) % 2] + j * 4, a_desc, accum, BLOCK_K / WGMMA::K - 2 + j);
+                                }
+                            } else {
+                                #pragma unroll
+                                for (uint32_t k = 0; k < BLOCK_K / WGMMA::K; ++ k) {
+                                    a_desc.reg32_[0] = a_desc_base_lo + (m_offset * BLOCK_K + k * WGMMA::K) / 16;
+                                    b_desc.reg32_[0] = b_desc_base_lo + k * WGMMA::K / 16;
+                                    WGMMA::wgmma(a_desc, b_desc, accum, k);
+                                }
                             }
+
                             ptx::warpgroup_commit_batch();
                             #pragma unroll
                             for (uint32_t i = 0; i < WGMMA::kNumAccum; ++ i)
@@ -316,7 +407,7 @@ sm90_fp8_gemm_1d2d_impl(float* sfb, int* grouped_layout,
                             ptx::warpgroup_wait<0>();
 
                             // Notify barrier arrival at the last warpgroup wave
-                            if (local_idx == BLOCK_M / WAVE_BLOCK_M - 1)
+                            if (local_idx == WAVE_WGMMA - 1)
                                 empty_barrier_arrive();
 
                             // Skip promotion for the unfilled parts
@@ -325,20 +416,32 @@ sm90_fp8_gemm_1d2d_impl(float* sfb, int* grouped_layout,
 
                             // Promote with scales
                             // NOTES: making it as predicates is very important for performance, comparing to two loops
-                            float scale_0_0 = scale_a_0 * scale_b_0, scale_1_0 = scale_a_1 * scale_b_0;
-                            float scale_0_1, scale_1_1;
-                            if constexpr (not kMustUseUniformedScaleB)
-                                scale_0_1 = scale_a_0 * scale_b_1, scale_1_1 = scale_a_1 * scale_b_1;
+                            if constexpr (kIsW4) {
+                                auto shifted_accum = final_accum + WGMMA::kNumAccum * local_idx;
 
-                            auto shifted_accum = final_accum + WGMMA::kNumAccum * local_idx;
-                            #pragma unroll
-                            for (uint32_t i = 0; i < WGMMA::kNumAccum / 4; ++ i) {
-                                // NOTES: for unrolled `num_former_iters` cases, we expect the compiler to automatically make it a constant
-                                const bool predicate = kMustUseUniformedScaleB or i < num_former_iters;
-                                shifted_accum[i * 4 + 0] += (predicate ? scale_0_0 : scale_0_1) * accum[i * 4 + 0];
-                                shifted_accum[i * 4 + 1] += (predicate ? scale_0_0 : scale_0_1) * accum[i * 4 + 1];
-                                shifted_accum[i * 4 + 2] += (predicate ? scale_1_0 : scale_1_1) * accum[i * 4 + 2];
-                                shifted_accum[i * 4 + 3] += (predicate ? scale_1_0 : scale_1_1) * accum[i * 4 + 3];
+                                #pragma unroll
+                                for (uint32_t i = 0; i < WGMMA::kNumAccum / 4; ++i) {
+                                    shifted_accum[i * 4 + 0] += scale_b_0 * accum[i * 4 + 0];
+                                    shifted_accum[i * 4 + 1] += scale_b_0 * accum[i * 4 + 1];
+                                    shifted_accum[i * 4 + 2] += scale_b_1 * accum[i * 4 + 2];
+                                    shifted_accum[i * 4 + 3] += scale_b_1 * accum[i * 4 + 3];
+                                }
+                            } else {
+                                float scale_0_0 = scale_a_0 * scale_b_0, scale_1_0 = scale_a_1 * scale_b_0;
+                                float scale_0_1, scale_1_1;
+                                if constexpr (not kMustUseUniformedScaleB)
+                                    scale_0_1 = scale_a_0 * scale_b_1, scale_1_1 = scale_a_1 * scale_b_1;
+
+                                auto shifted_accum = final_accum + WGMMA::kNumAccum * local_idx;
+                                #pragma unroll
+                                for (uint32_t i = 0; i < WGMMA::kNumAccum / 4; ++ i) {
+                                    // NOTES: for unrolled `num_former_iters` cases, we expect the compiler to automatically make it a constant
+                                    const bool predicate = kMustUseUniformedScaleB or i < num_former_iters;
+                                    shifted_accum[i * 4 + 0] += (predicate ? scale_0_0 : scale_0_1) * accum[i * 4 + 0];
+                                    shifted_accum[i * 4 + 1] += (predicate ? scale_0_0 : scale_0_1) * accum[i * 4 + 1];
+                                    shifted_accum[i * 4 + 2] += (predicate ? scale_1_0 : scale_1_1) * accum[i * 4 + 2];
+                                    shifted_accum[i * 4 + 3] += (predicate ? scale_1_0 : scale_1_1) * accum[i * 4 + 3];
+                                }
                             }
                         }
                     }
@@ -372,7 +475,7 @@ sm90_fp8_gemm_1d2d_impl(float* sfb, int* grouped_layout,
             // Write back to shared memory using STSM and issue TMA stores
             DG_STATIC_ASSERT(WGMMA::kNumAccum % 4 == 0, "Invalid STSM x2 vectorization");
             #pragma unroll
-            for (uint32_t local_idx = 0; local_idx < BLOCK_M / WAVE_BLOCK_M; ++ local_idx) {
+            for (uint32_t local_idx = 0; local_idx < WAVE_WGMMA; ++ local_idx) {
                 auto m_offset = local_idx * WAVE_BLOCK_M;
                 auto shifted_accum = final_accum + WGMMA::kNumAccum * local_idx;
                 #pragma unroll
@@ -380,35 +483,62 @@ sm90_fp8_gemm_1d2d_impl(float* sfb, int* grouped_layout,
                     // Swizzle or padding into the correct address
                     uint8_t* smem_ptr = nullptr;
                     if constexpr (kSwizzleDMode > 0) {
-                        // Calculate the swizzling atom offset and in-atom offset
                         constexpr uint32_t kNumBankGroupBytes = 16;
-                        auto atom_offset = i / (TMA_D_BLOCK_N / 8), in_atom_offset = i % (TMA_D_BLOCK_N / 8);
 
-                        // Calculate the index of the bank group to be written in the atom
-                        auto bank_group_index = in_atom_offset + lane_idx * (kSwizzleDMode / kNumBankGroupBytes);
+                        if constexpr (kIsW4) {
+                            auto row = i * 8 + lane_idx % 8;
+                            auto col = (warp_idx % 4) * 2 + lane_idx / 8;
+                            col ^= row % (kSwizzleDMode / 16);
 
-                        // Reshape the atom in another view and swizzle
-                        //  - original: `(BLOCK_M, kSwizzleDMode / kNumBankGroupBytes)`
-                        //  - new: `(BLOCK_M * kSwizzleDMode / kNumBankGroupBytes / 8, 8)`
-                        constexpr bool kHasShortcut = (kSwizzleDMode / kNumBankGroupBytes) == 8;
-                        auto row = kHasShortcut ? (in_atom_offset / 8 + lane_idx) : (bank_group_index / 8);
-                        auto col = kHasShortcut ? (in_atom_offset) : (bank_group_index % 8);
-                        col ^= row % (kSwizzleDMode / 16);
+                            auto n_atom_idx = m_offset / WGMMA::M + math_wg_idx;
+                            smem_ptr = reinterpret_cast<uint8_t*>(smem_d) +
+                                    n_atom_idx * BLOCK_M * kSwizzleDMode +
+                                    row * (kNumBankGroupBytes * 8) + col * kNumBankGroupBytes;
+                        } else {
+                            // Calculate the swizzling atom offset and in-atom offset
+                            auto atom_offset = i / (TMA_D_BLOCK_N / 8), in_atom_offset = i % (TMA_D_BLOCK_N / 8);
 
-                        // Add back into the base pointer
-                        // NOTES: think twice before modifying this, as changes may affect the number of instructions
-                        smem_ptr = reinterpret_cast<uint8_t*>(smem_d) +                // Base pointer
-                            warp_idx * (WGMMA_M_PER_WARP * kSwizzleDMode) +            // Warp offset
-                            m_offset * kSwizzleDMode +                                 // Wave offset
-                            atom_offset * BLOCK_M * kSwizzleDMode +                    // Swizzle atom offset (constants)
-                            row * (kNumBankGroupBytes * 8) + col * kNumBankGroupBytes; // In-atom offset
+                            // Calculate the index of the bank group to be written in the atom
+                            auto bank_group_index = in_atom_offset + lane_idx * (kSwizzleDMode / kNumBankGroupBytes);
+
+                            // Reshape the atom in another view and swizzle
+                            //  - original: `(BLOCK_M, kSwizzleDMode / kNumBankGroupBytes)`
+                            //  - new: `(BLOCK_M * kSwizzleDMode / kNumBankGroupBytes / 8, 8)`
+                            constexpr bool kHasShortcut = (kSwizzleDMode / kNumBankGroupBytes) == 8;
+                            auto row = kHasShortcut ? (in_atom_offset / 8 + lane_idx) : (bank_group_index / 8);
+                            auto col = kHasShortcut ? (in_atom_offset) : (bank_group_index % 8);
+                            col ^= row % (kSwizzleDMode / 16);
+
+                            // Add back into the base pointer
+                            // NOTES: think twice before modifying this, as changes may affect the number of instructions
+                            smem_ptr = reinterpret_cast<uint8_t*>(smem_d) +                // Base pointer
+                                warp_idx * (WGMMA_M_PER_WARP * kSwizzleDMode) +            // Warp offset
+                                m_offset * kSwizzleDMode +                                 // Wave offset
+                                atom_offset * BLOCK_M * kSwizzleDMode +                    // Swizzle atom offset (constants)
+                                row * (kNumBankGroupBytes * 8) + col * kNumBankGroupBytes; // In-atom offset
+                        }
                     } else {
-                        // No swizzling, just padding
-                        smem_ptr = reinterpret_cast<uint8_t*>(smem_d + (m_offset + warp_idx * WGMMA_M_PER_WARP + lane_idx) * BLOCK_N + i * 8);
+                        if constexpr (kIsW4) {
+                            smem_ptr = reinterpret_cast<uint8_t*>(smem_d +
+                                                                  m_offset +
+                                                                  warp_idx * WGMMA_M_PER_WARP +
+                                                                  lane_idx / 8 * 8 + (lane_idx % 8) * BLOCK_N +
+                                                                  BLOCK_N * i * 8);
+                        } else {
+                            // No swizzling, just padding
+                            smem_ptr = reinterpret_cast<uint8_t*>(smem_d + (m_offset + warp_idx * WGMMA_M_PER_WARP + lane_idx) * BLOCK_N + i * 8);
+                        }
+                    }
+
+                    if constexpr (kIsW4) {
+                        shifted_accum[i * 4 + 0] *= sfb[0];
+                        shifted_accum[i * 4 + 1] *= sfb[0];
+                        shifted_accum[i * 4 + 2] *= sfb[0];
+                        shifted_accum[i * 4 + 3] *= sfb[0];
                     }
 
                     // NOTES: only 16 lanes' addresses are used
-                    ptx::SM90_U32x2_STSM_N<nv_bfloat162>::copy(
+                    ptx::SM90_U32x2_STSM_N<nv_bfloat162>::template copy<kIsW4>(
                         __float22bfloat162_rn({shifted_accum[i * 4 + 0], shifted_accum[i * 4 + 1]}),
                         __float22bfloat162_rn({shifted_accum[i * 4 + 2], shifted_accum[i * 4 + 3]}),
                         smem_ptr

--- a/deep_gemm/include/deep_gemm/mma/sm90.cuh
+++ b/deep_gemm/include/deep_gemm/mma/sm90.cuh
@@ -74,6 +74,71 @@ struct FP8MMASelector {
     using type = decltype(select_type());
 };
 
+/// RS-mode FP8 MMA (register source A, shared memory descriptor B)
+template <int N_, typename MMA>
+struct FP8MMARS {
+    template <size_t ...Idx>
+    CUTLASS_DEVICE static void call_fma_impl(uint32_t const* a, uint64_t const& desc_b, float* d, bool scale_d,
+        cute::index_sequence<Idx...>) {
+        using namespace cute::SM90::GMMA;
+        MMA::fma(a[0], a[1], a[2], a[3], desc_b, d[Idx]..., (scale_d ? ScaleOut::One : ScaleOut::Zero));
+    }
+
+    CUTLASS_DEVICE static void wgmma(uint32_t const* a, uint64_t const& desc_b, float* d, bool scale_d) {
+        call_fma_impl(a, desc_b, d, scale_d, cute::make_index_sequence<N_ / 2>{});
+    }
+
+    static constexpr int M = 64;
+    static constexpr int N = N_;
+    static constexpr int K = 32;
+    static constexpr int kNumAccum = M * N / 128;
+};
+
+template <int N>
+struct FP8MMASelectorRS {
+    static constexpr auto select_mma() {
+        using namespace cute::SM90::GMMA;
+        if constexpr (N == 8) return MMA_64x8x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 16) return MMA_64x16x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 24) return MMA_64x24x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 32) return MMA_64x32x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 40) return MMA_64x40x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 48) return MMA_64x48x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 56) return MMA_64x56x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 64) return MMA_64x64x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 72) return MMA_64x72x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 80) return MMA_64x80x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 88) return MMA_64x88x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 96) return MMA_64x96x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 104) return MMA_64x104x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 112) return MMA_64x112x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 120) return MMA_64x120x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 128) return MMA_64x128x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 136) return MMA_64x136x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 144) return MMA_64x144x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 152) return MMA_64x152x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 160) return MMA_64x160x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 168) return MMA_64x168x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 176) return MMA_64x176x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 184) return MMA_64x184x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 192) return MMA_64x192x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 200) return MMA_64x200x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 208) return MMA_64x208x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 216) return MMA_64x216x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 224) return MMA_64x224x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 232) return MMA_64x232x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 240) return MMA_64x240x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 248) return MMA_64x248x32_F32E4M3E4M3_RS_TN();
+        if constexpr (N == 256) return MMA_64x256x32_F32E4M3E4M3_RS_TN();
+    }
+
+    static constexpr auto select_type() {
+        return FP8MMARS<N, decltype(select_mma())>();
+    }
+
+    using type = decltype(select_type());
+};
+
 template <int N_, typename MMA>
 struct BF16MMA {
     template <size_t ...Idx>

--- a/deep_gemm/include/deep_gemm/ptx/ld_st.cuh
+++ b/deep_gemm/include/deep_gemm/ptx/ld_st.cuh
@@ -17,6 +17,47 @@ CUTLASS_HOST_DEVICE longlong4_t make_longlong4_t(
 }
 #endif
 
+/// W4AFP8 helpers: permute_col, fast_int4_to_fp8_convert
+template <uint32_t COL_BYTES, uint32_t NV>
+CUTLASS_DEVICE auto permute_col(const uint32_t sRow, const uint32_t sCol) {
+    constexpr uint32_t strd = 128 / std::min(uint32_t(128), COL_BYTES);
+    const uint32_t pCol = (sCol / NV) ^ (sRow % 8 / strd);
+    return pCol * NV;
+}
+
+CUTLASS_DEVICE void fast_int4_to_fp8_convert(uint32_t outputs[2], uint32_t input) {
+    constexpr uint32_t neg0 = 0xcaccced0;
+    constexpr uint32_t neg1 = 0xb8c0c4c8;
+    constexpr uint32_t pos0 = 0x44403800;
+    constexpr uint32_t pos1 = 0x4e4c4a48;
+
+    constexpr uint32_t immLut = (0xf0 & 0xcc) | 0xaa;
+    uint32_t sign;
+    asm volatile(
+        "{\n"
+        "  lop3.b32 %0, %1, %2, %3, %4;\n"
+        "}\n"
+        : "=r"(sign)
+        : "r"(input), "n"(0x88888888), "n"(0x64206420), "n"(immLut));
+    sign = sign >> 1;
+
+    uint32_t lut_idx = input & 0x77777777;
+
+    #pragma unroll
+    for (int i = 0; i < 2; ++i, lut_idx >>= 16, sign >>= 16)
+    {
+        asm volatile(
+            "{\n"
+            "  .reg .b32 pos, neg                    ;\n"
+            "  prmt .b32 neg, %3, %4, %1             ;\n"
+            "  prmt .b32 pos, %5, %6, %1             ;\n"
+            "  prmt .b32 %0, pos, neg, %2            ;\n"
+            "}\n"
+            : "=r"(outputs[i])
+            : "r"(lut_idx), "r"(sign), "r"(neg0), "r"(neg1), "r"(pos0),"r"(pos1));
+    }
+}
+
 /// LD/ST matrix
 // TODO: remove `struct`
 struct SM90_U32x2_LDSM_N {
@@ -39,12 +80,18 @@ struct SM90_U32x4_LDSM_N {
 
 template <typename dtype_t>
 struct SM90_U32x2_STSM_N {
+    template<bool kIsW4 = false>
     CUTLASS_DEVICE static void
     copy(dtype_t src_0, dtype_t src_1, void* smem_dst) {
         DG_STATIC_ASSERT(sizeof(dtype_t) == sizeof(uint32_t), "Invalid dtype");
         const uint32_t src[2] = {*reinterpret_cast<uint32_t*>(&src_0), *reinterpret_cast<uint32_t*>(&src_1)};
-        asm volatile("stmatrix.sync.aligned.x2.m8n8.shared.b16 [%0], {%1, %2};\n"
-                     :: "l"(__cvta_generic_to_shared(smem_dst)), "r"(src[0]), "r"(src[1]));
+        if constexpr (kIsW4) {
+            asm volatile("stmatrix.sync.aligned.x2.m8n8.shared.b16.trans [%0], {%1, %2};\n"
+                         :: "l"(__cvta_generic_to_shared(smem_dst)), "r"(src[0]), "r"(src[1]));
+        } else {
+            asm volatile("stmatrix.sync.aligned.x2.m8n8.shared.b16 [%0], {%1, %2};\n"
+                         :: "l"(__cvta_generic_to_shared(smem_dst)), "r"(src[0]), "r"(src[1]));
+        }
     }
 };
 

--- a/deep_gemm/testing/bench.py
+++ b/deep_gemm/testing/bench.py
@@ -95,6 +95,13 @@ def bench_kineto(fn, kernel_names, num_tests: int = 30,
     # For some auto-tuning kernels with prints
     fn()
 
+    # Ensure kineto/CUPTI is initialized before real profiling
+    if not getattr(bench_kineto, '_kineto_initialized', False):
+        with torch.profiler.profile(activities=[torch.profiler.ProfilerActivity.CUDA]):
+            fn()
+        torch.cuda.synchronize()
+        bench_kineto._kineto_initialized = True
+
     # Profile
     suppress = suppress_stdout_stderr if suppress_kineto_output else empty_suppress
     with suppress():

--- a/tests/generators.py
+++ b/tests/generators.py
@@ -405,3 +405,170 @@ def generate_k_grouped_contiguous(num_groups: int, m: int, n: int, major_a: Majo
         assert (major_a, major_b) == (MajorTypeAB.MNMajor, MajorTypeAB.MNMajor)
 
     return k, a_fp8, b_fp8, c, d, ref_d
+
+
+## ====================
+## W4AFP8 generators
+## ====================
+def per_tensor_quant_fp8(x: torch.Tensor):
+    FP8_E4M3_MAX = 448
+
+    amax = x.abs().max()
+    s = amax / FP8_E4M3_MAX
+    eps = torch.finfo(torch.float).tiny
+    s = torch.clamp(s, min=eps)
+
+    q_fp8 = torch.clamp(x / s, min=-FP8_E4M3_MAX, max=FP8_E4M3_MAX).to(torch.float8_e4m3fn)
+
+    return q_fp8, s.to(torch.float)
+
+
+w4_group_size = 128
+
+
+def convert_fp8_to_int4(b):
+    assert b.dim() == 2
+    n, k = b.shape
+
+    b_int8 = b.to(torch.int8)
+
+    b_int8_1 = b_int8.reshape(n // 16, 16, k // 32, 32).permute(0, 2, 1, 3)
+    b_int8_2 = b_int8_1.reshape(n // 16, k // 32, 2, 8, 2, 4, 4).permute(0, 1, 4, 3, 5, 2, 6)
+    b_int8_permuted = b_int8_2.reshape(n // 16, k // 32, 16, 32).permute(0, 2, 1, 3).reshape(n, k)
+
+    b_uint8_view = b_int8_permuted.view(torch.uint8)
+    b_int4 = (b_uint8_view[:, 1::2] << 4) | \
+             (b_uint8_view[:, 0::2] & 0x0F)
+    b_q = b_int4.view(torch.float8_e4m3fn)
+
+    b_s_dim = (1, w4_group_size)
+    debug = False
+    affine_coeff = 0.005
+
+    if debug:
+        b_s = torch.ones((ceil_div(n, b_s_dim[0]), ceil_div(k, b_s_dim[1])), device=b_q.device, dtype=torch.float) * affine_coeff
+    else:
+        b_s = torch.randn(ceil_div(n, b_s_dim[0]), ceil_div(k, b_s_dim[1]),  device=b_q.device, dtype=torch.float) * affine_coeff
+
+    return b_q, b_s
+
+
+def enumerate_normal_w4() -> Generator:
+    m_list = [1, 128, 4096]
+    nk_list = [(2112, 7168), (576, 7168), (24576, 1536), (32768, 512), (7168, 16384), (4096, 7168), (7168, 2048)]
+    reset_seed()
+    for m in m_list:
+        for n, k in nk_list:
+            yield m, n, k
+
+
+def enumerate_m_grouped_contiguous_w4() -> Generator:
+    group_list = [4, 8, 16]
+    n_k_list = [(4096, 7168), (7168, 2048)]
+    expected_m_per_group_list = [128, 256, 512, 1024]
+
+    reset_seed()
+    for num_groups in group_list:
+        for n, k in n_k_list:
+            for expected_m_per_group in expected_m_per_group_list:
+                yield num_groups, expected_m_per_group, n, k
+
+
+def enumerate_m_grouped_masked_w4() -> Generator:
+    max_m = 4096
+    group_list = [8, 16]
+    m_list = [16, 24, 32, 40, 48, 56, 64]
+    n_k_list = [(4096, 7168), (7168, 2048)]
+
+    reset_seed()
+    for num_groups in group_list:
+        for n, k in n_k_list:
+            for m in m_list:
+                yield num_groups, max_m, m, n, k
+
+
+def generate_normal_w4(m: int, n: int, k: int, accumulate: bool, out_dtype: torch.dtype):
+    a = torch.randn((m, k), device='cuda', dtype=torch.bfloat16)
+    b = torch.empty((n, k), device='cuda', dtype=torch.bfloat16).uniform_(-8.0, 8.0).to(torch.int8)
+    d = torch.randn((m, n), device='cuda', dtype=out_dtype) * 32 if accumulate else \
+        torch.empty((m, n), device='cuda', dtype=out_dtype)
+    c = d if accumulate else None
+
+    b_q, b_s = convert_fp8_to_int4(b)
+
+    a_q, a_s = per_tensor_quant_fp8(a)
+    a_fp32 = a_q.float() * a_s.item()
+
+    b_dequant = (b.float().reshape(-1, w4_group_size) * b_s.reshape(-1, 1)).reshape(n, k)
+    ref_d = (a_fp32 @ b_dequant.t() + (c if accumulate else 0)).to(out_dtype)
+
+    a_fp8 = (a_q, a_s)
+    b_fp8 = (b_q, b_s)
+    return a_fp8, b_fp8, c, d, ref_d
+
+
+def generate_m_grouped_contiguous_w4(num_groups: int, expected_m_per_group: int, n: int, k: int):
+    actual_ms = [int(expected_m_per_group * random.uniform(0.7, 1.3)) for _ in range(num_groups)]
+    aligned_ms = [align(actual_m, get_mk_alignment_for_contiguous_layout()) for actual_m in actual_ms]
+    m = sum(aligned_ms)
+
+    a = torch.randn((m, k), device='cuda', dtype=torch.bfloat16)
+    b = torch.empty((num_groups, n, k), device='cuda', dtype=torch.bfloat16).uniform_(-8.0, 8.0).to(torch.int8)
+
+    a_q, a_s = per_tensor_quant_fp8(a)
+    a_fp8 = (a_q, a_s)
+
+    b_fp8 = (torch.empty((num_groups, n, k // 2), device='cuda', dtype=torch.float8_e4m3fn),
+             torch.empty((num_groups, n, ceil_div(k, w4_group_size)), device='cuda', dtype=torch.float))
+
+    m_indices = torch.empty(m, device='cuda', dtype=torch.int32)
+    d = torch.empty((m, n), device='cuda', dtype=torch.bfloat16)
+    ref_d = torch.randn((m, n), device='cuda', dtype=torch.bfloat16)
+
+    start = 0
+    for i, (actual_m, aligned_m) in enumerate(zip(actual_ms, aligned_ms)):
+        actual_end = start + actual_m
+        aligned_end = start + aligned_m
+        m_indices[start: actual_end] = i
+        m_indices[actual_end: aligned_end] = -1
+        a[actual_end: aligned_end] = 0
+
+        b_fp8[0][i], b_fp8[1][i] = convert_fp8_to_int4(b[i])
+        b_dequant = (b[i].float().reshape(-1, w4_group_size) * b_fp8[1][i].reshape(-1, 1)).reshape(n, k)
+
+        a_fp32 = a_q[start:aligned_end].float() * a_s.item()
+        ref_d[start:aligned_end] = (a_fp32 @ b_dequant.t()).to(torch.bfloat16)
+        start = aligned_end
+
+    ref_d = torch.where((m_indices == -1).unsqueeze(1), torch.zeros_like(ref_d), ref_d)
+    return m, a_fp8, b_fp8, m_indices, d, ref_d
+
+
+def generate_m_grouped_masked_w4(num_groups: int, max_m: int, expected_m_per_group: int, n: int, k: int):
+    a = torch.randn((num_groups, max_m, k), device='cuda', dtype=torch.bfloat16)
+    b = torch.empty((num_groups, n, k), device='cuda', dtype=torch.bfloat16).uniform_(-8.0, 8.0).to(torch.int8)
+    d = torch.empty((num_groups, max_m, n), device='cuda', dtype=torch.bfloat16)
+    d.fill_(-1)
+    ref_d = torch.empty_like(d)
+
+    masked_m = torch.empty((num_groups, ), device='cuda', dtype=torch.int)
+    psum_m = torch.empty((num_groups, ), device='cuda', dtype=torch.int)
+    for j in range(num_groups):
+        masked_m[j] = int(expected_m_per_group * random.uniform(0.7, 1.3))
+        psum_m[j] = (0 if j == 0 else align(psum_m[j - 1], 128)) + masked_m[j]
+    assert masked_m.amax().item() <= max_m
+
+    b_fp8 = (torch.empty((num_groups, n, k // 2), device='cuda', dtype=torch.float8_e4m3fn),
+             torch.empty((num_groups, n, ceil_div(k, w4_group_size)), device='cuda', dtype=torch.float))
+
+    a_q, a_s = per_tensor_quant_fp8(a)
+    a_fp8 = (a_q, a_s)
+
+    for i in range(num_groups):
+        b_fp8[0][i], b_fp8[1][i] = convert_fp8_to_int4(b[i])
+        b_dequant = (b[i].float().reshape(-1, w4_group_size) * b_fp8[1][i].reshape(-1, 1)).reshape(n, k)
+
+        a_fp32 = a_q[i].float() * a_s.item()
+        ref_d[i] = (a_fp32 @ b_dequant.t()).to(torch.bfloat16)
+
+    return a_fp8, b_fp8, masked_m, d, ref_d

--- a/tests/test_w4afp8.py
+++ b/tests/test_w4afp8.py
@@ -1,0 +1,104 @@
+import random
+import torch
+
+import deep_gemm
+from deep_gemm.testing import (
+    bench_kineto,
+    calc_diff, count_bytes,
+    ignore_env, get_arch_major
+)
+
+from generators import (
+    enumerate_normal_w4, enumerate_m_grouped_contiguous_w4, enumerate_m_grouped_masked_w4,
+    generate_normal_w4, generate_m_grouped_contiguous_w4, generate_m_grouped_masked_w4,
+)
+
+
+@ignore_env('DG_JIT_PTXAS_CHECK', lambda: get_arch_major() == 9)
+def test_gemm() -> None:
+    print('Testing SM90 W4AFP8 GEMM:')
+    for m, n, k in enumerate_normal_w4():
+        accumulate = False
+        out_dtype = torch.bfloat16
+
+        a, b, c, d, ref_d = generate_normal_w4(m, n, k, accumulate, out_dtype)
+        deep_gemm.sm90_w4afp8_gemm_nt(a, b, d, c=c)
+        diff = calc_diff(d, ref_d)
+        assert diff < 0.001, (f'{m=}, {n=}, {k=}, {out_dtype=}, {diff:.5f}')
+
+        def test_func():
+            deep_gemm.sm90_w4afp8_gemm_nt(a, b, d, c=c)
+
+        # Test performance
+        t = bench_kineto(test_func, 'fp8_gemm', suppress_kineto_output=True)
+        print(f' > Perf (m={m:6}, n={n:6}, k={k:6}): '
+              f'{t * 1e6:6.1f} us | '
+              f'{2 * m * n * k / t / 1e12:4.0f} TFLOPS | '
+              f'{count_bytes(a, b, d) / 1e9 / t:4.0f} GB/s')
+    print()
+
+
+def test_m_grouped_gemm_contiguous() -> None:
+    print('Testing SM90 W4AFP8 m-grouped contiguous GEMM:')
+
+    for num_groups, expected_m_per_group, n, k in enumerate_m_grouped_contiguous_w4():
+        m, a, b, m_indices, d, ref_d = generate_m_grouped_contiguous_w4(num_groups, expected_m_per_group, n, k)
+        deep_gemm.sm90_m_grouped_w4afp8_gemm_nt_contiguous(a, b, d, m_indices)
+        d = torch.where((m_indices == -1).unsqueeze(1), torch.zeros_like(d), d)
+        diff = calc_diff(d, ref_d)
+        assert diff < 0.001, f'{m=}, {n=}, {k=}, {diff:.5f}'
+
+        m, a, b, m_indices, d, ref_d = generate_m_grouped_contiguous_w4(num_groups, expected_m_per_group, n, k)
+
+        # noinspection PyShadowingNames
+        def test_func():
+            deep_gemm.sm90_m_grouped_w4afp8_gemm_nt_contiguous(a, b, d, m_indices)
+
+        t = bench_kineto(test_func, 'fp8_gemm', suppress_kineto_output=True)
+        print(f' > Perf ({num_groups=}, m={m:5}, n={n:5}, k={k:5}): '
+              f'{t * 1e6:4.0f} us | '
+              f'{2 * m * n * k / t / 1e12:4.0f} TFLOPS | '
+              f'{count_bytes(a, b, d) / 1e9 / t:4.0f} GB/s')
+    print()
+
+
+def test_m_grouped_gemm_masked() -> None:
+    print('Testing SM90 W4AFP8 m-grouped masked GEMM:')
+
+    for num_groups, max_m, expected_m_per_group, n, k in enumerate_m_grouped_masked_w4():
+        # Test correctness
+        for i in range(10):
+            a, b, masked_m, d, ref_d = generate_m_grouped_masked_w4(num_groups, max_m, expected_m_per_group, n, k)
+            deep_gemm.sm90_m_grouped_w4afp8_gemm_nt_masked(a, b, d, masked_m, expected_m_per_group)
+            for j in range(num_groups):
+                if masked_m[j].item() == 0:
+                    continue
+                diff = calc_diff(d[j, :masked_m[j].item()], ref_d[j, :masked_m[j].item()])
+                assert diff < 0.001, f'{max_m=}, {n=}, {k=}, {j=}, masked_m={masked_m[j]}, {num_groups=}, {diff:.5f}'
+
+        # Test performance
+        a, b, masked_m, d, ref_d = generate_m_grouped_masked_w4(num_groups, max_m, expected_m_per_group, n, k)
+
+        # noinspection PyShadowingNames
+        def test_func():
+            deep_gemm.sm90_m_grouped_w4afp8_gemm_nt_masked(a, b, d, masked_m, expected_m_per_group)
+
+        valid_m = masked_m.sum().item()
+        t = bench_kineto(test_func, 'fp8_gemm', suppress_kineto_output=True)
+        print(f' > Perf ({num_groups=}, expected_m_per_group={expected_m_per_group:4}, n={n:4}, k={k:4}): '
+              f'{t * 1e6:4.0f} us | '
+              f'{2 * valid_m * n * k / t / 1e12:4.0f} TFLOPS | '
+              f'{(count_bytes(a, d) * valid_m / (max_m * num_groups) + count_bytes(b)) / 1e9 / t:4.0f} GB/s')
+    print()
+
+
+if __name__ == '__main__':
+    torch.manual_seed(0)
+    random.seed(0)
+
+    print('Library path:')
+    print(f' > {deep_gemm.__path__}\n')
+
+    # test_gemm()
+    test_m_grouped_gemm_contiguous()
+    test_m_grouped_gemm_masked()


### PR DESCRIPTION
Hi, from [novita.ai](https:novita.ai) team.

- Algorithm compatible with https://huggingface.co/Barrrrry/DeepSeek-R1-W4AFP8, but uses a custom weight layout (see `convert_fp8_to_int4` in `tests/generators.py`).

test perf(W4Afp8 vs FP8)  on H200. nvcc: 13.0.

| groups | m/grp | n | k | W4 us | W4 GB/s | FP8 us | FP8 GB/s | Speedup |
|-------:|------:|-----:|-----:|------:|--------:|------:|---------:|--------:|
| 8 | 16 | 4096 | 7168 | 48 | 2649 | 68 | 3477 | **1.42x** |
| 8 | 24 | 4096 | 7168 | 48 | 2667 | 68 | 3493 | **1.42x** |
| 8 | 32 | 4096 | 7168 | 48 | 2685 | 68 | 3500 | **1.42x** |
| 8 | 40 | 4096 | 7168 | 48 | 2727 | 68 | 3516 | **1.42x** |
| 8 | 48 | 4096 | 7168 | 48 | 2721 | 68 | 3530 | **1.42x** |
| 8 | 56 | 4096 | 7168 | 62 | 2115 | 72 | 3368 | **1.16x** |
| 8 | 64 | 4096 | 7168 | 62 | 2122 | 72 | 3393 | **1.16x** |
| 8 | 16 | 7168 | 2048 | 32 | 2029 | 40 | 3012 | **1.25x** |
| 8 | 24 | 7168 | 2048 | 31 | 2071 | 40 | 3034 | **1.29x** |
| 8 | 32 | 7168 | 2048 | 32 | 2096 | 40 | 3061 | **1.25x** |
| 8 | 40 | 7168 | 2048 | 31 | 2149 | 40 | 3085 | **1.29x** |
| 8 | 48 | 7168 | 2048 | 31 | 2187 | 40 | 3118 | **1.29x** |
| 8 | 56 | 7168 | 2048 | 31 | 2259 | 42 | 2991 | **1.35x** |
| 8 | 64 | 7168 | 2048 | 42 | 1657 | 42 | 2981 | 1.00x |
| 16 | 16 | 4096 | 7168 | 93 | 2724 | 127 | 3741 | **1.37x** |
| 16 | 24 | 4096 | 7168 | 93 | 2748 | 127 | 3760 | **1.37x** |
| 16 | 32 | 4096 | 7168 | 93 | 2758 | 127 | 3772 | **1.37x** |
| 16 | 40 | 4096 | 7168 | 93 | 2793 | 127 | 3794 | **1.37x** |
| 16 | 48 | 4096 | 7168 | 93 | 2797 | 127 | 3806 | **1.37x** |
| 16 | 56 | 4096 | 7168 | 131 | 2010 | 137 | 3542 | **1.05x** |
| 16 | 64 | 4096 | 7168 | 130 | 2036 | 138 | 3527 | **1.06x** |
| 16 | 16 | 7168 | 2048 | 57 | 2262 | 71 | 3362 | **1.25x** |
| 16 | 24 | 7168 | 2048 | 57 | 2317 | 71 | 3394 | **1.25x** |
| 16 | 32 | 7168 | 2048 | 57 | 2344 | 71 | 3420 | **1.25x** |
| 16 | 40 | 7168 | 2048 | 56 | 2392 | 71 | 3462 | **1.27x** |
| 16 | 48 | 7168 | 2048 | 57 | 2420 | 71 | 3486 | **1.25x** |
| 16 | 56 | 7168 | 2048 | 68 | 2062 | 75 | 3307 | **1.10x** |
| 16 | 64 | 7168 | 2048 | 69 | 2048 | 76 | 3292 | **1.10x** |