### PR TITLE
Fix post-release wheel version detection

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,12 +49,44 @@ third_party_include_dirs = [
 
 # Release
 base_wheel_url = 'https://github.com/DeepSeek-AI/DeepGEMM/releases/download/{tag_name}/{wheel_name}'
+version_tag_pattern = re.compile(r'^v(?P<version>\d+\.\d+\.\d+(?:\.post\d+)?)$')
+
+
+def get_public_version():
+    with open(Path(current_dir) / 'deep_gemm' / '__init__.py', 'r') as f:
+        version_match = re.search(r'^__version__\s*=\s*(.*)$', f.read(), re.MULTILINE)
+    return ast.literal_eval(version_match.group(1))
+
+
+def get_exact_git_tag_version(public_version: str) -> str | None:
+    # Release builds check out the exact tag, so we can safely derive post-release
+    # versions from the tag even when __version__ still carries the base version.
+    try:
+        tags_output = subprocess.check_output(['git', 'tag', '--points-at', 'HEAD']).decode('ascii')
+    except Exception:
+        return None
+
+    matching_versions = []
+    for raw_tag in tags_output.splitlines():
+        match = version_tag_pattern.fullmatch(raw_tag.strip())
+        if not match:
+            continue
+
+        tag_version = match.group('version')
+        if tag_version == public_version or tag_version.startswith(f'{public_version}.post'):
+            matching_versions.append(tag_version)
+
+    if not matching_versions:
+        return None
+
+    return str(max((parse(version) for version in matching_versions), key=lambda value: value))
 
 
 def get_package_version():
-    with open(Path(current_dir) / 'deep_gemm' / '__init__.py', 'r') as f:
-        version_match = re.search(r'^__version__\s*=\s*(.*)$', f.read(), re.MULTILINE)
-    public_version = ast.literal_eval(version_match.group(1))
+    public_version = get_public_version()
+    exact_tag_version = get_exact_git_tag_version(public_version)
+    if exact_tag_version is not None:
+        public_version = exact_tag_version
 
     revision = ''
     if DG_USE_LOCAL_VERSION:

--- a/tests/test_setup_versioning.py
+++ b/tests/test_setup_versioning.py
@@ -1,0 +1,58 @@
+import importlib.util
+from pathlib import Path
+from unittest import mock
+
+
+def load_setup_module():
+    setup_path = Path(__file__).resolve().parents[1] / 'setup.py'
+    spec = importlib.util.spec_from_file_location('deepgemm_setup', setup_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_get_exact_git_tag_version_prefers_matching_post_release():
+    setup_module = load_setup_module()
+
+    with mock.patch.object(
+        setup_module.subprocess,
+        'check_output',
+        return_value=b'v2.1.1\nv2.1.1.post3\nv9.9.9\n',
+    ):
+        assert setup_module.get_exact_git_tag_version('2.1.1') == '2.1.1.post3'
+
+
+def test_get_package_version_uses_exact_post_release_tag_when_local_suffix_disabled():
+    setup_module = load_setup_module()
+
+    with (
+        mock.patch.object(setup_module, 'DG_USE_LOCAL_VERSION', False),
+        mock.patch.object(setup_module, 'get_public_version', return_value='2.1.1'),
+        mock.patch.object(
+            setup_module,
+            'get_exact_git_tag_version',
+            return_value='2.1.1.post3',
+        ),
+    ):
+        assert setup_module.get_package_version() == '2.1.1.post3'
+
+
+def test_get_package_version_appends_local_revision_after_resolving_exact_tag():
+    setup_module = load_setup_module()
+
+    with (
+        mock.patch.object(setup_module, 'DG_USE_LOCAL_VERSION', True),
+        mock.patch.object(setup_module, 'get_public_version', return_value='2.1.1'),
+        mock.patch.object(
+            setup_module,
+            'get_exact_git_tag_version',
+            return_value='2.1.1.post3',
+        ),
+        mock.patch.object(
+            setup_module.subprocess,
+            'check_output',
+            side_effect=[b'', b'abc123\n'],
+        ),
+    ):
+        assert setup_module.get_package_version() == '2.1.1.post3+abc123'


### PR DESCRIPTION
## Summary
- derive the exact package version from tags pointing at `HEAD`
- preserve `.postN` release tags when `deep_gemm/__init__.py` still carries the base version
- add regression coverage for plain and local-version post-release builds

## Testing
- python -m pytest tests/test_setup_versioning.py

Closes #228
