### PR TITLE
fix: correct operator precedence in pack_ue8m0_to_int assertion

### DIFF
--- a/deep_gemm/utils/math.py
+++ b/deep_gemm/utils/math.py
@@ -18,7 +18,7 @@ def ceil_to_ue8m0(x: torch.Tensor):
 
 def pack_ue8m0_to_int(x: torch.Tensor):
     assert x.dtype == torch.float and x.size(-1) % 4 == 0
-    assert (x.view(torch.int) & ((1 << 23) - 1) == 0).all()
+    assert ((x.view(torch.int) & ((1 << 23) - 1)) == 0).all()
     return (x.view(torch.int) >> 23).to(torch.uint8).view(torch.int)
 
 


### PR DESCRIPTION
Closes #309

## Problem

In `deep_gemm/utils/math.py`, the `pack_ue8m0_to_int` function has an operator precedence bug in its assertion:

```python
assert (x.view(torch.int) & ((1 << 23) - 1) == 0).all()
```

In Python, the `==` operator has **higher precedence** than `&`. So this is actually parsed as:

```python
assert (x.view(torch.int) & (((1 << 23) - 1) == 0)).all()
```

`((1 << 23) - 1) == 0` evaluates to `False` (i.e., `0`), so `x.view(torch.int) & 0` produces a tensor of all zeros. `.all()` on all zeros returns `True`.

**The assertion always passes**, never catching cases where mantissa bits are non-zero.

## Fix

Added parentheses to ensure `&` is applied before `==`:

```python
assert ((x.view(torch.int) & ((1 << 23) - 1)) == 0).all()
```

This correctly verifies that the lower 23 mantissa bits are all zero, which is required for valid UE8M0 format floats.