### PR TITLE
Add SM90 FP8 paged MQA logits support for next_n=3

### DIFF
--- a/csrc/jit_kernels/impls/sm90_fp8_mqa_logits.hpp
+++ b/csrc/jit_kernels/impls/sm90_fp8_mqa_logits.hpp
@@ -159,6 +159,7 @@ public:
         int aligned_batch_size;
         int split_kv;
         int num_sms;
+        int num_next_n_atoms;
         bool is_varlen;
 
         int batch_size;
@@ -179,10 +180,11 @@ using namespace deep_gemm;
 
 static void __instantiate_kernel() {{
     auto ptr = reinterpret_cast<void*>(&sched::sm90_paged_mqa_logits_metadata<
-        {}, {}, {}, {}
+        {}, {}, {}, {}, {}
     >);
 }};
-)", args.aligned_batch_size, args.split_kv, args.num_sms, args.is_varlen ? "true" : "false");
+)", args.aligned_batch_size, args.split_kv, args.num_sms, args.num_next_n_atoms,
+    args.is_varlen ? "true" : "false");
     }
 
     static void launch_impl(const KernelHandle& kernel, const LaunchConfigHandle& config, Args args) {
@@ -206,6 +208,9 @@ static void sm90_paged_mqa_logits_metadata(const torch::Tensor& context_lens,
     constexpr int split_kv = 256;
     constexpr int num_threads = 32;
     const int aligned_batch_size = align(batch_size, 32);
+    const int next_n_atom = (is_varlen or next_n >= 2) ? 2 : 1;
+    const int num_next_n_atoms = (next_n == 3 and not is_varlen)
+        ? 1 : ceil_div(next_n, next_n_atom);
     DG_HOST_ASSERT(split_kv % block_kv == 0);
 
     const int num_smem_ints = is_varlen ? 3 * aligned_batch_size + 1 : aligned_batch_size;
@@ -216,6 +221,7 @@ static void sm90_paged_mqa_logits_metadata(const torch::Tensor& context_lens,
         .aligned_batch_size = aligned_batch_size,
         .split_kv = split_kv,
         .num_sms = num_sms,
+        .num_next_n_atoms = num_next_n_atoms,
         .is_varlen = is_varlen,
         .batch_size = batch_size,
         .next_n = next_n,
@@ -329,7 +335,8 @@ static void sm90_fp8_paged_mqa_logits(const torch::Tensor& q,
     constexpr int mma_m = 64;
     const int num_math_warp_groups = split_kv / mma_m;
     const int num_math_threads = num_math_warp_groups * 128;
-    constexpr int num_q_stages = 3, num_kv_stages = 3;
+    const int num_q_stages = (next_n == 3 and not is_varlen) ? 4 : 3;
+    constexpr int num_kv_stages = 3;
     DG_HOST_ASSERT(device_runtime->get_arch_major() == 9);
     DG_HOST_ASSERT(split_kv % mma_m == 0 and logits_stride % split_kv == 0);
 
@@ -351,8 +358,8 @@ static void sm90_fp8_paged_mqa_logits(const torch::Tensor& q,
                                                      static_cast<int>(weights.stride(0)), 0);
 
     const int swizzle_alignment = head_dim * 8;
-    const int smem_q_size_per_stage = next_n * num_heads * head_dim * static_cast<int>(q.element_size());
-    const int aligned_smem_weight_size_per_stage = align(next_n * num_heads * static_cast<int>(weights.element_size()), swizzle_alignment);
+    const int smem_q_size_per_stage = next_n_atom * num_heads * head_dim * static_cast<int>(q.element_size());
+    const int aligned_smem_weight_size_per_stage = align(next_n_atom * num_heads * static_cast<int>(weights.element_size()), swizzle_alignment);
     const int smem_q_pipe_size = num_q_stages * (smem_q_size_per_stage + aligned_smem_weight_size_per_stage) + align(num_q_stages * 8 * 2, swizzle_alignment);
     const int smem_kv_size_per_stage = block_kv * head_dim * static_cast<int>(kv_cache.element_size());
     const int aligned_smem_kv_scale_size_per_stage = align(block_kv * static_cast<int>(kv_cache_scales.element_size()), swizzle_alignment);
@@ -361,7 +368,7 @@ static void sm90_fp8_paged_mqa_logits(const torch::Tensor& q,
     const int smem_tmem_ptr = 4;
     const int smem_size = smem_q_pipe_size + num_math_warp_groups * smem_kv_pipe_size + smem_umma_barriers + smem_tmem_ptr;
     DG_HOST_ASSERT(smem_size <= SM90ArchSpec::smem_capacity);
-    DG_HOST_ASSERT(next_n == 1 or next_n == 2);
+    DG_HOST_ASSERT(next_n == 1 or next_n == 2 or next_n == 3);
 
     const SM90FP8PagedMQALogitsRuntime::Args args = {
         .batch_size = batch_size,

--- a/deep_gemm/include/deep_gemm/impls/sm90_fp8_paged_mqa_logits.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm90_fp8_paged_mqa_logits.cuh
@@ -39,8 +39,14 @@ void sm90_fp8_paged_mqa_logits(const uint32_t batch_size,
     DG_STATIC_ASSERT(not kIsVarlen, "Varlen is not supported for SM90 paged MQA logits");
 
     // Types
-    using WGMMA = typename mma::sm90::FP8MMASelector<kNextN * kNumHeads>::type;
+    static constexpr bool kHasTail = kNextN == 3;
+    static constexpr uint32_t kNextNAtom = (kIsVarlen or kNextN >= 2) ? 2 : 1;
+    static constexpr uint32_t kNumNextNAtoms = kHasTail ? 1 : math::constexpr_ceil_div(kNextN, kNextNAtom);
+    using WGMMA = typename mma::sm90::FP8MMASelector<kNextNAtom * kNumHeads>::type;
+    using TailWGMMA = typename mma::sm90::FP8MMASelector<kNumHeads>::type;
     using Barrier = cutlass::arch::ClusterTransactionBarrier;
+    DG_STATIC_ASSERT(kNextN >= 1 and kNextN <= 3, "Unsupported next_n");
+    DG_STATIC_ASSERT(not kHasTail or kNumQStages >= 4, "NextN=3 requires at least four Q stages");
 
     // NOTES: use `__shfl_sync` to encourage NVCC to use unified registers
     const auto warp_idx = __shfl_sync(0xffffffff, threadIdx.x / 32, 0);
@@ -61,8 +67,8 @@ void sm90_fp8_paged_mqa_logits(const uint32_t batch_size,
 
     // Shared memory configs
     static constexpr uint32_t kSwizzleAlignment = kHeadDim * 8;
-    static constexpr uint32_t SMEM_Q_SIZE_PER_STAGE = kNextN * kNumHeads * kHeadDim * sizeof(__nv_fp8_e4m3);
-    static constexpr uint32_t SMEM_WEIGHT_SIZE_PER_STAGE = kNextN * kNumHeads * sizeof(float);
+    static constexpr uint32_t SMEM_Q_SIZE_PER_STAGE = kNextNAtom * kNumHeads * kHeadDim * sizeof(__nv_fp8_e4m3);
+    static constexpr uint32_t SMEM_WEIGHT_SIZE_PER_STAGE = kNextNAtom * kNumHeads * sizeof(float);
     static constexpr uint32_t ALIGNED_SMEM_WEIGHT_SIZE_PER_STAGE = math::constexpr_align(SMEM_WEIGHT_SIZE_PER_STAGE, kSwizzleAlignment);
     static constexpr uint32_t SMEM_Q_PIPE_SIZE = kNumQStages * (SMEM_Q_SIZE_PER_STAGE + ALIGNED_SMEM_WEIGHT_SIZE_PER_STAGE) +
                                                  math::constexpr_align(kNumQStages * 8 * 2, kSwizzleAlignment);
@@ -135,8 +141,9 @@ void sm90_fp8_paged_mqa_logits(const uint32_t batch_size,
     cudaGridDependencySynchronize();
 
     // Scheduler
-    auto scheduler = sched::SM90PagedMQALogitsScheduler<kNextN, kIsContextLens2D, kIsVarlen, BLOCK_KV, kNumMathWarpGroups, 1>(
-        blockIdx.x, batch_size, context_lens, schedule_meta, indices);
+    using Scheduler = sched::SM90PagedMQALogitsScheduler<kNextN, kIsContextLens2D, kIsVarlen,
+                                                        BLOCK_KV, kNumMathWarpGroups, kNumNextNAtoms>;
+    auto scheduler = Scheduler(blockIdx.x, batch_size, context_lens, schedule_meta, indices);
     DG_STATIC_ASSERT(SPLIT_KV % BLOCK_KV == 0, "Unaligned SPLIT_KV");
 
     // Q and KV pipeline
@@ -154,46 +161,72 @@ void sm90_fp8_paged_mqa_logits(const uint32_t batch_size,
         if (kv_group_idx >= kNumMathWarpGroups)
             return;
 
-        const auto issue_tma_q = [&](const uint32_t& stage_idx, const uint32_t& q_idx) {
+        const auto issue_tma_q = [&](const uint32_t& stage_idx, const uint32_t& q_atom_idx) {
             if (kv_group_idx == 0 and cute::elect_one_sync()) {
-                tma::copy<kHeadDim, kNextN * kNumHeads, kHeadDim>(&tensor_map_q, full_q_barriers[stage_idx], smem_q[stage_idx], 0, q_idx * kNextN * kNumHeads);
-                tma::copy<kNextN * kNumHeads, 1, 0>(&tensor_map_weights, full_q_barriers[stage_idx], smem_weights[stage_idx], 0, q_idx * kNextN);
+                const auto q_token_idx = Scheduler::atom_to_token_idx(q_atom_idx);
+                tma::copy<kHeadDim, kNextNAtom * kNumHeads, kHeadDim>(&tensor_map_q, full_q_barriers[stage_idx], smem_q[stage_idx], 0, q_token_idx * kNumHeads);
+                tma::copy<kNextNAtom * kNumHeads, 1, 0>(&tensor_map_weights, full_q_barriers[stage_idx], smem_weights[stage_idx], 0, q_token_idx);
                 full_q_barriers[stage_idx]->arrive_and_expect_tx(SMEM_Q_SIZE_PER_STAGE + SMEM_WEIGHT_SIZE_PER_STAGE);
             }
         };
+        const auto issue_tma_q_with_tail = [&](const uint32_t& stage_idx, const uint32_t& tail_stage_idx, const uint32_t& q_atom_idx) {
+            if (kv_group_idx == 0 and cute::elect_one_sync()) {
+                const auto q_token_idx = Scheduler::atom_to_token_idx(q_atom_idx);
+                tma::copy<kHeadDim, kNextNAtom * kNumHeads, kHeadDim>(&tensor_map_q, full_q_barriers[stage_idx], smem_q[stage_idx], 0, q_token_idx * kNumHeads);
+                tma::copy<kNextNAtom * kNumHeads, 1, 0>(&tensor_map_weights, full_q_barriers[stage_idx], smem_weights[stage_idx], 0, q_token_idx);
+                full_q_barriers[stage_idx]->arrive_and_expect_tx(SMEM_Q_SIZE_PER_STAGE + SMEM_WEIGHT_SIZE_PER_STAGE);
+                // The 2-token TMA box zero-fills the unused row after the 1-token tail.
+                tma::copy<kHeadDim, kNextNAtom * kNumHeads, kHeadDim>(&tensor_map_q, full_q_barriers[tail_stage_idx], smem_q[tail_stage_idx], 0, (q_token_idx + 2) * kNumHeads);
+                tma::copy<kNextNAtom * kNumHeads, 1, 0>(&tensor_map_weights, full_q_barriers[tail_stage_idx], smem_weights[tail_stage_idx], 0, q_token_idx + 2);
+                full_q_barriers[tail_stage_idx]->arrive_and_expect_tx(SMEM_Q_SIZE_PER_STAGE + SMEM_WEIGHT_SIZE_PER_STAGE);
+            }
+        };
 
-        // Initialize `q_idx` outside `[0, batch_size)` to indicate it was none
-        uint32_t q_idx = batch_size, kv_idx, num_kv;
-        uint32_t next_q_idx, next_kv_idx, next_num_kv;
+        // Initialize `q_atom_idx` outside the valid range to indicate it was none
+        uint32_t q_atom_idx = batch_size * kNumNextNAtoms, kv_idx, num_kv;
+        uint32_t next_q_atom_idx, next_kv_idx, next_num_kv;
         bool fetched_next_task;
 
-        // Prefetch the first Q
-        if ((fetched_next_task = scheduler.fetch_next_task(next_q_idx, next_kv_idx, next_num_kv)))
-            issue_tma_q(0, next_q_idx), q_iter_idx = 1;
+        // Prefetch the first Q atom
+        if ((fetched_next_task = scheduler.fetch_next_task(next_q_atom_idx, next_kv_idx, next_num_kv))) {
+            if constexpr (kHasTail)
+                issue_tma_q_with_tail(0, 1, next_q_atom_idx), q_iter_idx = 2;
+            else
+                issue_tma_q(0, next_q_atom_idx), q_iter_idx = 1;
+        }
 
         int kv_block_idx_ptr = 32;
         uint32_t kv_block_idx_storage;
 
         while (fetched_next_task) {
-            // Prefetch next Q when current Q changes
-            bool prefetch_q = (q_idx != next_q_idx and scheduler.exist_q_atom_idx(next_q_idx + 1));
-            q_idx = next_q_idx;
+            // Prefetch next Q when current atom changes
+            bool prefetch_q = (q_atom_idx != next_q_atom_idx and scheduler.exist_q_atom_idx(next_q_atom_idx + 1));
+            q_atom_idx = next_q_atom_idx;
             kv_idx = next_kv_idx;
             num_kv = next_num_kv;
 
             // Wait Q consumer release and issue TMA Q
             if (prefetch_q) {
-                CUTE_TIE_DECL(get_q_pipeline(q_iter_idx ++), q_stage_idx, q_phase);
-                empty_q_barriers[q_stage_idx]->wait(q_phase ^ 1);
-                issue_tma_q(q_stage_idx, q_idx + 1);
+                if constexpr (kHasTail) {
+                    CUTE_TIE_DECL(get_q_pipeline(q_iter_idx ++), q_stage_idx, q_phase);
+                    CUTE_TIE_DECL(get_q_pipeline(q_iter_idx ++), q_tail_stage_idx, q_tail_phase);
+                    empty_q_barriers[q_stage_idx]->wait(q_phase ^ 1);
+                    empty_q_barriers[q_tail_stage_idx]->wait(q_tail_phase ^ 1);
+                    issue_tma_q_with_tail(q_stage_idx, q_tail_stage_idx, q_atom_idx + 1);
+                } else {
+                    CUTE_TIE_DECL(get_q_pipeline(q_iter_idx ++), q_stage_idx, q_phase);
+                    empty_q_barriers[q_stage_idx]->wait(q_phase ^ 1);
+                    issue_tma_q(q_stage_idx, q_atom_idx + 1);
+                }
             }
 
             // Read KV block index
             // TODO: deal with `-1`?
             if (kv_idx == 0 or kv_block_idx_ptr == 32) {
                 kv_block_idx_ptr = 0;
+                const auto block_table_offset = Scheduler::atom_to_block_table_row(q_atom_idx) * static_cast<uint64_t>(block_table_stride);
                 kv_block_idx_storage = (kv_idx + kv_group_idx + lane_idx * kNumMathWarpGroups < num_kv ?
-                    block_table[q_idx * static_cast<uint64_t>(block_table_stride) + (kv_idx + kv_group_idx + lane_idx * kNumMathWarpGroups)] : 0);
+                    block_table[block_table_offset + (kv_idx + kv_group_idx + lane_idx * kNumMathWarpGroups)] : 0);
             }
             const auto kv_block_idx = __shfl_sync(0xffffffff, kv_block_idx_storage, kv_block_idx_ptr ++);
 
@@ -211,121 +244,174 @@ void sm90_fp8_paged_mqa_logits(const uint32_t batch_size,
             }
 
             // Fetch next task
-            fetched_next_task = scheduler.fetch_next_task(next_q_idx, next_kv_idx, next_num_kv);
+            fetched_next_task = scheduler.fetch_next_task(next_q_atom_idx, next_kv_idx, next_num_kv);
         }
     } else {
         // Math warp-groups for WGMMA
         cutlass::arch::warpgroup_reg_alloc<kNumMathRegisters>();
 
-        float accum[WGMMA::kNumAccum], weights[kNextN][kNumHeads / 4];
+        float accum[WGMMA::kNumAccum], weights[kNextNAtom][kNumHeads / 4], tail_weights[kNextNAtom][kNumHeads / 4];
         const auto sub_warp_offset = (warp_idx % 4) * 16;
         const auto v_0_offset = lane_idx / 4 + 0;
         const auto v_1_offset = lane_idx / 4 + 8;
 
-        // Initialize `q_idx` outside `[0, batch_size)` to indicate it was none
-        uint32_t q_idx = batch_size, kv_idx;
-        uint32_t next_q_idx, next_kv_idx, next_num_kv;
-        uint32_t q_stage_idx, q_phase;
+        // Initialize `q_atom_idx` outside the valid range to indicate it was none
+        uint32_t q_atom_idx = batch_size * kNumNextNAtoms, kv_idx;
+        uint32_t next_q_atom_idx, next_kv_idx, next_num_kv;
+        uint32_t q_stage_idx, q_phase, q_tail_stage_idx, q_tail_phase;
 
-        while (scheduler.fetch_next_task(next_q_idx, next_kv_idx, next_num_kv)) {
-            // Current Q changes
-            if (q_idx != next_q_idx) {
+        while (scheduler.fetch_next_task(next_q_atom_idx, next_kv_idx, next_num_kv)) {
+            // Current Q atom changes
+            if (q_atom_idx != next_q_atom_idx) {
                 // Release Last Q empty
-                if (q_iter_idx > 0)
-                    empty_q_barriers[(q_iter_idx - 1) % kNumQStages]->arrive();
+                if (q_iter_idx > 0) {
+                    if constexpr (kHasTail) {
+                        empty_q_barriers[(q_iter_idx - 2) % kNumQStages]->arrive();
+                        empty_q_barriers[(q_iter_idx - 1) % kNumQStages]->arrive();
+                    } else {
+                        empty_q_barriers[(q_iter_idx - 1) % kNumQStages]->arrive();
+                    }
+                }
 
                 // Wait TMA Q arrival
                 CUTE_TIE(get_q_pipeline(q_iter_idx ++), q_stage_idx, q_phase);
                 full_q_barriers[q_stage_idx]->wait(q_phase);
+                if constexpr (kHasTail) {
+                    CUTE_TIE(get_q_pipeline(q_iter_idx ++), q_tail_stage_idx, q_tail_phase);
+                    full_q_barriers[q_tail_stage_idx]->wait(q_tail_phase);
+                }
 
                 // Read weights
                 #pragma unroll
-                for (uint32_t i = 0; i < kNextN; ++ i) {
+                for (uint32_t i = 0; i < kNextNAtom; ++ i) {
                     #pragma unroll
                     for (uint32_t j = 0; j < kNumHeads / 4; ++ j)
                         weights[i][j] = ptx::ld_shared(smem_weights[q_stage_idx] + i * kNumHeads + (j / 2) * 8 + (j & 1) + (lane_idx % 4) * 2);
                 }
+                if constexpr (kHasTail) {
+                    #pragma unroll
+                    for (uint32_t i = 0; i < kNextNAtom; ++ i) {
+                        #pragma unroll
+                        for (uint32_t j = 0; j < kNumHeads / 4; ++ j)
+                            tail_weights[i][j] = ptx::ld_shared(smem_weights[q_tail_stage_idx] + i * kNumHeads + (j / 2) * 8 + (j & 1) + (lane_idx % 4) * 2);
+                    }
+                }
             }
 
-            // Get current Q and KV index
-            q_idx = next_q_idx;
+            // Get current Q atom and KV index
+            q_atom_idx = next_q_atom_idx;
             kv_idx = next_kv_idx;
 
             // Calculate KV offset in advance
-            auto kv_offset = q_idx * kNextN * static_cast<uint64_t>(logits_stride) + ((kv_idx + kv_group_idx) * BLOCK_KV + sub_warp_offset);
+            auto kv_offset = Scheduler::atom_to_token_idx(q_atom_idx) * static_cast<uint64_t>(logits_stride) + ((kv_idx + kv_group_idx) * BLOCK_KV + sub_warp_offset);
 
-            // Compute `[kNextN * kNumHeads, kHeadDim] @ [BLOCK_KV, kHeadDim] -> [kNextN, BLOCK_KV]`
+            // Compute `[kNextNAtom * kNumHeads, kHeadDim] @ [BLOCK_KV, kHeadDim] -> [kNextNAtom, BLOCK_KV]`
             // Wait TMA KV arrival
             CUTE_TIE_DECL(get_kv_pipeline(kv_iter_idx ++), kv_stage_idx, kv_phase);
             full_kv_barriers[kv_stage_idx]->wait(kv_phase);
 
-            // Issue WGMMA
             DG_STATIC_ASSERT(BLOCK_KV == 64, "Invalid block size");
             DG_STATIC_ASSERT(kHeadDim % WGMMA::K == 0, "Invalid head dim");
-            #pragma unroll
-            for (uint32_t i = 0; i < WGMMA::kNumAccum; ++ i)
-                ptx::warpgroup_fence_operand(accum[i]);
-            ptx::warpgroup_arrive();
-            #pragma unroll
-            for (uint32_t k = 0; k < kHeadDim / WGMMA::K; ++ k) {
-                auto desc_a = mma::sm90::make_smem_desc(
-                    smem_kv[kv_stage_idx] + k * WGMMA::K,
-                    mma::sm90::to_swizzle_cute_type<kHeadDim>(), 0, kHeadDim * 8);
-                auto desc_b = mma::sm90::make_smem_desc(
-                    smem_q[q_stage_idx] + k * WGMMA::K,
-                    mma::sm90::to_swizzle_cute_type<kHeadDim>(), 0, kHeadDim * 8);
-                WGMMA::wgmma(desc_a, desc_b, accum, k);
-            }
-            ptx::warpgroup_commit_batch();
-            #pragma unroll
-            for (uint32_t i = 0; i < WGMMA::kNumAccum; ++ i)
-                ptx::warpgroup_fence_operand(accum[i]);
+            static constexpr uint32_t kNumAccumPerReduce = kNumHeads / 2;
+            DG_STATIC_ASSERT(WGMMA::kNumAccum % kNumAccumPerReduce == 0, "Invalid accumulation");
+            DG_STATIC_ASSERT(WGMMA::kNumAccum / kNumAccumPerReduce == kNextNAtom, "Invalid accumulation");
+            DG_STATIC_ASSERT(TailWGMMA::kNumAccum == kNumAccumPerReduce, "Invalid tail accumulation");
+            DG_STATIC_ASSERT(kNumHeads % 8 == 0, "Invalid head");
+
+            const auto issue_wgmma = [&](const uint32_t& active_q_stage_idx) {
+                #pragma unroll
+                for (uint32_t i = 0; i < WGMMA::kNumAccum; ++ i)
+                    ptx::warpgroup_fence_operand(accum[i]);
+                ptx::warpgroup_arrive();
+                #pragma unroll
+                for (uint32_t k = 0; k < kHeadDim / WGMMA::K; ++ k) {
+                    auto desc_a = mma::sm90::make_smem_desc(
+                        smem_kv[kv_stage_idx] + k * WGMMA::K,
+                        mma::sm90::to_swizzle_cute_type<kHeadDim>(), 0, kHeadDim * 8);
+                    auto desc_b = mma::sm90::make_smem_desc(
+                        smem_q[active_q_stage_idx] + k * WGMMA::K,
+                        mma::sm90::to_swizzle_cute_type<kHeadDim>(), 0, kHeadDim * 8);
+                    WGMMA::wgmma(desc_a, desc_b, accum, k);
+                }
+                ptx::warpgroup_commit_batch();
+                #pragma unroll
+                for (uint32_t i = 0; i < WGMMA::kNumAccum; ++ i)
+                    ptx::warpgroup_fence_operand(accum[i]);
+            };
+            const auto issue_tail_wgmma = [&](const uint32_t& active_q_stage_idx) {
+                #pragma unroll
+                for (uint32_t i = 0; i < TailWGMMA::kNumAccum; ++ i)
+                    ptx::warpgroup_fence_operand(accum[i]);
+                ptx::warpgroup_arrive();
+                #pragma unroll
+                for (uint32_t k = 0; k < kHeadDim / TailWGMMA::K; ++ k) {
+                    auto desc_a = mma::sm90::make_smem_desc(
+                        smem_kv[kv_stage_idx] + k * TailWGMMA::K,
+                        mma::sm90::to_swizzle_cute_type<kHeadDim>(), 0, kHeadDim * 8);
+                    auto desc_b = mma::sm90::make_smem_desc(
+                        smem_q[active_q_stage_idx] + k * TailWGMMA::K,
+                        mma::sm90::to_swizzle_cute_type<kHeadDim>(), 0, kHeadDim * 8);
+                    TailWGMMA::wgmma(desc_a, desc_b, accum, k);
+                }
+                ptx::warpgroup_commit_batch();
+                #pragma unroll
+                for (uint32_t i = 0; i < TailWGMMA::kNumAccum; ++ i)
+                    ptx::warpgroup_fence_operand(accum[i]);
+            };
 
             // Read per-KV scales
             float scale_kv_0 = ptx::ld_shared(smem_kv_scales[kv_stage_idx] + sub_warp_offset + v_0_offset);
             float scale_kv_1 = ptx::ld_shared(smem_kv_scales[kv_stage_idx] + sub_warp_offset + v_1_offset);
 
-            // Wait WGMMA
-            ptx::warpgroup_wait<0>();
-
-            // Release KV empty
-            empty_kv_barriers[kv_stage_idx]->arrive();
-
-            // Reduce over the head dim and store
-            static constexpr uint32_t kNumAccumPerReduce = kNumHeads / 2;
-            DG_STATIC_ASSERT(WGMMA::kNumAccum % kNumAccumPerReduce == 0, "Invalid accumulation");
-            DG_STATIC_ASSERT(WGMMA::kNumAccum / kNumAccumPerReduce == kNextN, "Invalid accumulation");
-            DG_STATIC_ASSERT(kNumHeads % 8 == 0, "Invalid head");
-            #pragma unroll
-            for (uint32_t i = 0; i < kNextN; ++ i) {
-                auto shifted_accum = accum + i * kNumAccumPerReduce;
-                const auto transform = [&](const uint32_t& j) {
-                    return fmaxf(shifted_accum[j], 0) * weights[i][(j / 4) * 2 + (j & 1)];
-                };
-
-                // Intra-thread reduction
-                float sum[4] = {transform(0), transform(1), transform(2), transform(3)};
+            const auto reduce_and_store = [&](auto num_iters_c, const auto& active_weights, const uint64_t& active_kv_offset) {
+                constexpr uint32_t kNumIters = decltype(num_iters_c)::value;
                 #pragma unroll
-                for (uint32_t j = 1; j < kNumHeads / 8; ++ j) {
+                for (uint32_t i = 0; i < kNumIters; ++ i) {
+                    auto shifted_accum = accum + i * kNumAccumPerReduce;
+                    const auto transform = [&](const uint32_t& j) {
+                        return fmaxf(shifted_accum[j], 0) * active_weights[i][(j / 4) * 2 + (j & 1)];
+                    };
+
+                    // Intra-thread reduction
+                    float sum[4] = {transform(0), transform(1), transform(2), transform(3)};
                     #pragma unroll
-                    for (uint32_t k = 0; k < 4; k ++)
-                        sum[k] += transform(j * 4 + k);
-                }
-                float v_0 = (sum[0] + sum[1]) * scale_kv_0;
-                float v_1 = (sum[2] + sum[3]) * scale_kv_1;
+                    for (uint32_t j = 1; j < kNumHeads / 8; ++ j) {
+                        #pragma unroll
+                        for (uint32_t k = 0; k < 4; k ++)
+                            sum[k] += transform(j * 4 + k);
+                    }
+                    float v_0 = (sum[0] + sum[1]) * scale_kv_0;
+                    float v_1 = (sum[2] + sum[3]) * scale_kv_1;
 
-                // Inter-thread reduction
-                #pragma unroll
-                for (uint32_t j = 0; j < 2; ++ j) {
-                    const auto offset = static_cast<int>(1u << j);
-                    v_0 += __shfl_xor_sync(0xffffffffu, v_0, offset);
-                    v_1 += __shfl_xor_sync(0xffffffffu, v_1, offset);
-                }
+                    // Inter-thread reduction
+                    #pragma unroll
+                    for (uint32_t j = 0; j < 2; ++ j) {
+                        const auto offset = static_cast<int>(1u << j);
+                        v_0 += __shfl_xor_sync(0xffffffffu, v_0, offset);
+                        v_1 += __shfl_xor_sync(0xffffffffu, v_1, offset);
+                    }
 
-                // Store into the global memory
-                // NOTES: we have redundant writes here, consider more carefully
-                logits[kv_offset + i * static_cast<uint64_t>(logits_stride) + v_0_offset] = static_cast<logits_dtype_t>(v_0);
-                logits[kv_offset + i * static_cast<uint64_t>(logits_stride) + v_1_offset] = static_cast<logits_dtype_t>(v_1);
+                    // Store into the global memory
+                    // NOTES: we have redundant writes here, consider more carefully
+                    logits[active_kv_offset + i * static_cast<uint64_t>(logits_stride) + v_0_offset] = static_cast<logits_dtype_t>(v_0);
+                    logits[active_kv_offset + i * static_cast<uint64_t>(logits_stride) + v_1_offset] = static_cast<logits_dtype_t>(v_1);
+                }
+            };
+
+            if constexpr (kHasTail) {
+                issue_wgmma(q_stage_idx);
+                ptx::warpgroup_wait<0>();
+                reduce_and_store(cute::Int<kNextNAtom>{}, weights, kv_offset);
+
+                issue_tail_wgmma(q_tail_stage_idx);
+                ptx::warpgroup_wait<0>();
+                empty_kv_barriers[kv_stage_idx]->arrive();
+                reduce_and_store(cute::Int<1>{}, tail_weights, kv_offset + 2 * static_cast<uint64_t>(logits_stride));
+            } else {
+                issue_wgmma(q_stage_idx);
+                ptx::warpgroup_wait<0>();
+                empty_kv_barriers[kv_stage_idx]->arrive();
+                reduce_and_store(cute::Int<kNextNAtom>{}, weights, kv_offset);
             }
         }
     }

--- a/deep_gemm/include/deep_gemm/scheduler/sm90_paged_mqa_logits.cuh
+++ b/deep_gemm/include/deep_gemm/scheduler/sm90_paged_mqa_logits.cuh
@@ -6,7 +6,8 @@
 
 namespace deep_gemm::sched {
 
-template <uint32_t kAlignedBatchSize, uint32_t SPLIT_KV, uint32_t kNumSMs, bool kIsVarlen = false>
+template <uint32_t kAlignedBatchSize, uint32_t SPLIT_KV, uint32_t kNumSMs,
+          uint32_t kNumNextNAtoms, bool kIsVarlen = false>
 CUTLASS_GLOBAL __launch_bounds__(32, 1)
 void sm90_paged_mqa_logits_metadata(const uint32_t batch_size, const uint32_t next_n, const bool is_context_lens_2d,
                                     const uint32_t* context_lens, const uint32_t* indices, uint32_t* schedule_metadata) {
@@ -94,8 +95,7 @@ void sm90_paged_mqa_logits_metadata(const uint32_t batch_size, const uint32_t ne
             schedule_metadata[sm_idx * 2 + 1] = kv_split_idx;
         }
     } else {
-        const uint32_t next_n_atom = (next_n >= 2) ? 2 : 1;
-        const uint32_t num_next_n_atoms = math::ceil_div(next_n, next_n_atom);
+        constexpr uint32_t num_next_n_atoms = kNumNextNAtoms;
         const uint32_t total = sum * num_next_n_atoms;
         const uint32_t q = total / kNumSMs, r = total % kNumSMs;
         const uint32_t pivot = kNumSMs - r;

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -336,7 +336,7 @@ def test_paged_mqa_logits():
                         for block_kv in ((128, 32, 64, ) if arch_major == 10 else (64, )):
                             for use_2d_context_lens, clean_logits in [(True, False)]:
                                 for batch_size in (256, 4096):
-                                    for next_n in ((1, ) if is_varlen else ((1, 6) if arch_major == 10 else (1, 2))):
+                                    for next_n in ((1, ) if is_varlen else ((1, 6) if arch_major == 10 else (1, 2, 3))):
                                         for max_tokens_per_batch in ((6, 10) if is_varlen else (1, )):
                                             heads = (8, 16, 32, 64) if arch_major == 10 else (32, 64)
                                             head_dims = (64, 128) if is_mxfp4 else ((32, 64, 128) if arch_major == 10 else (128, ))


### PR DESCRIPTION
## Summary

This PR adds SM90/Hopper support for FP8 paged MQA logits with `next_n=3`,
which is required by vLLM MTP speculative decoding when
`num_speculative_tokens=2`. The unmodified SM90 path rejects this case with
the existing `next_n == 1 or next_n == 2` assertion.

The change is limited to the SM90 non-varlen path. Existing `next_n=1/2`,
SM100 behavior, and the public Python API remain unchanged.

Related issue: https://github.com/vllm-project/vllm/issues/43457

## Implementation

The SM90 kernel uses a two-token WGMMA atom. `next_n=3` is implemented as a
pair plus a single-token tail instead of introducing a three-token WGMMA shape:

```text
tokens 0 and 1 -> existing two-token WGMMA path
token 2        -> single-token TailWGMMA path
```

- Metadata treats the three tokens as one logical scheduler atom, so the pair
  and tail computations reuse each loaded KV tile.
- A four-stage Q pipeline prefetches the pair and tail TMA stages while keeping
  the existing producer/consumer barrier lifecycle.
- The tail uses a two-token TMA box with the unused row zero-filled, but only
  the valid third-token row is reduced and stored.
- Scheduler helpers retain the original batch row for block-table lookup and
  map the atom to the correct output token offset.

SM90 varlen `next_n=3` and `next_n>3` remain out of scope.

## Validation

```text
GPU: NVIDIA H20 96 GB (SM90)
CUDA toolkit / NVCC: 12.9
PyTorch: 2.8.0+cu129
Baseline: 559d79fb6994a58b8a15b4b93bf13ccc16edf247
Candidate: 8ceef6bad7b4359234cecf87a48c63b6f0c8c0db
```

- Unmodified main reproduces the expected assertion for `next_n=3`.
- The patched kernel passes `B=16,17,256,257`, `H=64`, `D=128`, `L=512`,
  FP32 logits, and 20 repeated calls per shape. Repeated outputs are bitwise
  identical; simulated-reference differences are `7.73e-9` to `8.21e-9`.
- `tests/test_attention.py::test_paged_mqa_logits` passes all 36/36 SM90 cases:
  `next_n=1/2/3`, FP32/BF16 logits, `H=32/64`, `D=128`, `B=256/4096`, and
  average KV lengths `8192/65536` subject to the test's 32M-token cap.
- `compute-sanitizer --tool memcheck` reports `0 errors` for
  `B=16,17,32,33`, `next_n=3`, `L=512`, with three repeated calls.

## Standalone Performance

CUDA-event benchmark: `B=256`, `H=64`, `D=128`, `BLOCK_KV=64`, FP32 logits,
20 warmups, 100 timed iterations, five repeats. Values are median milliseconds
per call; JIT compilation is excluded.

| L | next_n | Upstream main | Patched | Change vs main |
|---:|---:|---:|---:|---:|
| 4096 | 1 | 0.06982 ms | 0.06994 ms | +0.16% |
| 4096 | 2 | 0.13241 ms | 0.13172 ms | -0.53% |
| 4096 | 3 | unsupported | 0.19984 ms | N/A |
| 8192 | 1 | 0.13204 ms | 0.13155 ms | -0.37% |
| 8192 | 2 | 0.25780 ms | 0.25631 ms | -0.58% |
| 8192 | 3 | unsupported | 0.38742 ms | N/A |

`T(next_n=3) / T(next_n=2)` is `1.517x` at `L=4096` and `1.512x` at
`L=8192`; existing `next_n=1/2` performance remains within 1% of upstream.

## NCU Profile

A separate same-machine comparison used one H20, CUDA 12.8,
PyTorch 2.11.0+cu128, and Nsight Compute 2025.1. The table reports FP32 NCU
Duration and patched `next_n=3` hardware metrics.

| L | main n2 | patched n2 | n2 change | patched n3 | n3/n2 | SM | DRAM | Occupancy |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 8192 | 0.279840 ms | 0.278016 ms | -0.65% | 0.421952 ms | 1.518x | 94.80% | 18.91% | 31.01% |
| 32768 | 1.079552 ms | 1.068640 ms | -1.01% | 1.604800 ms | 1.502x | 97.50% | 19.10% | 31.16% |

For `next_n=3`, NCU reports 96 registers/thread and 185.4 KB dynamic shared
memory per block. The kernel is compute/pipeline-bound rather than DRAM-bound;
its occupancy, eligible-warps, and barrier-stall profile matches the prior
implementation. Same-run main-versus-patched ratios are used here because
absolute NCU durations from different profiler or toolchain configurations are
not directly comparable. DeepGEMM recommends NVCC 12.9 or newer for best
performance; the primary CUDA-event results above use CUDA 12.9.

## Integration Context

An earlier revision was exercised end to end with vLLM on 2x H20 using TP=2
and `num_speculative_tokens=2`: the server initialized, `/v1/completions`
returned `200 OK`, no DeepGEMM `next_n` assertion occurred, and speculative
decode metrics were emitted. This is included as consumer-path validation;
the refreshed commit's correctness and performance conclusions use the
standalone results above.
