### PR TITLE
Fix Mega MoE kernel shared memory calculation error

### DIFF
--- a/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
@@ -207,7 +207,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
     constexpr uint32_t SMEM_CD_SIZE = SMEM_CD_L1_SIZE > SMEM_CD_L2_SIZE ? SMEM_CD_L1_SIZE : SMEM_CD_L2_SIZE;
     constexpr uint32_t SMEM_CD_L1_SIZE_PER_STAGE = SMEM_CD_L1_SIZE / kNumTMAStoreStages;
     constexpr uint32_t SMEM_BEFORE_BARRIER_SIZE =
-        SMEM_EXPERT_COUNT_SIZE + SMEM_SEND_BUFFER_SIZE + SMEM_CD_SIZE + kNumStages * (SMEM_A_SIZE_PER_STAGE + SMEM_B_SIZE_PER_STAGE);
+        SMEM_EXPERT_COUNT_SIZE + SMEM_SEND_BUFFER_SIZE + SMEM_CD_SIZE + kNumStages * (SMEM_A_SIZE_PER_STAGE + SMEM_B_SIZE_PER_STAGE + SMEM_SFA_SIZE_PER_STAGE + SMEM_SFB_SIZE_PER_STAGE);
     DG_STATIC_ASSERT(SMEM_CD_SIZE % kSharedMemoryAlignment == 0 and
                      SMEM_A_SIZE_PER_STAGE % kSharedMemoryAlignment == 0 and
                      SMEM_B_SIZE_PER_STAGE % kSharedMemoryAlignment == 0,


### PR DESCRIPTION
## Description

Fixes a bug in the Mega MoE kernel where `SMEM_BEFORE_BARRIER_SIZE` was missing `SMEM_SFA_SIZE_PER_STAGE` and `SMEM_SFB_SIZE_PER_STAGE` in its per-stage shared memory calculation.

## Root Cause

`SMEM_BEFORE_BARRIER_SIZE` only accounted for `SMEM_A_SIZE_PER_STAGE` and `SMEM_B_SIZE_PER_STAGE` per stage, but the scale factor (SF) buffers (`SMEM_SFA_SIZE_PER_STAGE` and `SMEM_SFB_SIZE_PER_STAGE`) were omitted. This caused the shared memory allocation before the barrier to be too small, triggering assertion failures for larger hidden sizes (e.g., hidden=8192, num_tokens=1024).

## Fix

Add the missing SF size constants to the per-stage calculation:

```diff
 constexpr uint32_t SMEM_BEFORE_BARRIER_SIZE =
-     SMEM_EXPERT_COUNT_SIZE + SMEM_SEND_BUFFER_SIZE + SMEM_CD_SIZE + kNumStages * (SMEM_A_SIZE_PER_STAGE + SMEM_B_SIZE_PER_STAGE);
+     SMEM_EXPERT_COUNT_SIZE + SMEM_SEND_BUFFER_SIZE + SMEM_CD_SIZE + kNumStages * (SMEM_A_SIZE_PER_STAGE + SMEM_B_SIZE_PER_STAGE + SMEM_SFA_SIZE_PER_STAGE + SMEM_SFB_SIZE_PER_STAGE);
```

Fixes #339

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>