### PR TITLE
Sync nv_dev with upstream #347

### DIFF
--- a/csrc/apis/attention.hpp
+++ b/csrc/apis/attention.hpp
@@ -161,8 +161,8 @@ static torch::Tensor fp8_fp4_mqa_logits(const std::tuple<torch::Tensor, std::opt
     torch::Tensor logits;
     int aligned_seq_len = align(seq_len, block_q), stride_logits;
     if (max_seqlen_k == 0) {
-        // Logits stride must be 16-byte aligned
-        stride_logits = align(seq_len_kv + block_kv, 8);
+        // Logits stride must be 128-byte aligned
+        stride_logits = align(seq_len_kv + block_kv, 64);
         logits = torch::empty({aligned_seq_len, stride_logits}, q_fp.options().dtype(logits_dtype));
         logits = logits.index({torch::indexing::Slice(0, seq_len), torch::indexing::Slice(0, seq_len_kv)});
     } else {

--- a/csrc/apis/einsum.hpp
+++ b/csrc/apis/einsum.hpp
@@ -114,8 +114,7 @@ static void einsum(const std::string& expr,
     DG_HOST_ASSERT(b.scalar_type() == torch::kBFloat16);
     DG_HOST_ASSERT(d.scalar_type() == torch::kBFloat16 or d.scalar_type() == torch::kFloat);
     if (c.has_value()) {
-        DG_HOST_ASSERT(c->scalar_type() == torch::kFloat);
-        DG_HOST_ASSERT(d.scalar_type() == torch::kFloat);
+        DG_HOST_ASSERT(d.scalar_type() == c->scalar_type());
     }
 
     // Some hardcoded Einstein sum kernels

--- a/csrc/apis/gemm.hpp
+++ b/csrc/apis/gemm.hpp
@@ -26,10 +26,10 @@ static bool early_return(const int& m, const int &n, const int& k,
     const bool is_cd_same = c.has_value() and c->data_ptr() == d.data_ptr();
     if (is_cd_same)
         DG_HOST_ASSERT(c->sizes() == d.sizes() and c->strides() == d.strides());
+    DG_HOST_ASSERT(d.scalar_type() == torch::kBFloat16 or d.scalar_type() == torch::kFloat);
     if (c.has_value()) {
         check_major_type_cd(c.value());
-        DG_HOST_ASSERT(d.scalar_type() == torch::kFloat);
-        DG_HOST_ASSERT(c.value().scalar_type() == torch::kFloat);
+        DG_HOST_ASSERT(d.scalar_type() == c.value().scalar_type());
     }
 
     // No accumulation

--- a/csrc/apis/mega.hpp
+++ b/csrc/apis/mega.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <string>
 #include <pybind11/functional.h>
 
 #if DG_TENSORMAP_COMPATIBLE
@@ -22,6 +23,7 @@ get_symm_buffer_size_for_mega_moe(
     const int& hidden, const int& intermediate_hidden,
     const bool& use_fp8_dispatch, const std::string& activation) {
     DG_HOST_ASSERT(num_experts % num_ranks == 0);
+    DG_HOST_ASSERT(use_fp8_dispatch);
 
     // Workspace bytes
     const auto workspace = layout::Workspace(nullptr, num_ranks, num_experts, num_max_tokens_per_rank, num_topk);
@@ -162,14 +164,14 @@ static void fp8_fp4_mega_moe(
     DG_HOST_ASSERT(get_major_type_ab(l1_weights) == cute::UMMA::Major::K);
     DG_HOST_ASSERT(get_major_type_ab(l2_weights) == cute::UMMA::Major::K);
     const auto arch_major = device_runtime->get_arch_major();
-    const auto [num_experts_per_rank, intermediate_hidden_2, hidden] =
+    const auto [num_experts_per_rank, intermediate_hidden_before_act, hidden] =
         check_grouped_ab_fp8_fp4(l1_weights, cute::UMMA::Major::K, arch_major);
     const auto [num_experts_per_rank_, hidden_, intermediate_hidden] =
         check_grouped_ab_fp8_fp4(l2_weights, cute::UMMA::Major::K, arch_major);
     DG_HOST_ASSERT(num_tokens <= num_max_tokens_per_rank);
     DG_HOST_ASSERT(num_experts_per_rank == num_experts_per_rank_);
     DG_HOST_ASSERT(hidden == hidden_);
-    DG_HOST_ASSERT(intermediate_hidden_2 == 2 * intermediate_hidden);
+    DG_HOST_ASSERT(intermediate_hidden_before_act == 2 * intermediate_hidden);
     DG_HOST_ASSERT(l1_weights.is_contiguous() and l2_weights.is_contiguous());
 
     // Check weight SF layout for UE8M0 packing, MN-major, and TMA alignment

--- a/csrc/jit_kernels/heuristics/mega_moe.hpp
+++ b/csrc/jit_kernels/heuristics/mega_moe.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <algorithm>
+#include <cmath>
 #include <unordered_set>
 
 #include <deep_gemm/layout/mega_moe.cuh>
+#include <deep_gemm/common/types.cuh>
 
 #include "../../utils/exception.hpp"
 #include "../../utils/math.hpp"
@@ -37,6 +39,9 @@ struct MegaMoEConfig {
     // Thread layout
     int num_dispatch_threads, num_non_epilogue_threads, num_epilogue_threads;
 
+    // Dispatch pull config
+    int num_bytes_per_pull;
+
     friend std::ostream& operator << (std::ostream& os, const MegaMoEConfig& config) {
         os << "MegaMoEConfig("
            << "block_m=" << config.block_m << ", block_n=" << config.block_n << ", block_k=" << config.block_k
@@ -50,35 +55,36 @@ struct MegaMoEConfig {
            << ", num_stages=" << config.num_stages << ", smem_size=" << config.smem_size
            << ", num_dispatch_threads=" << config.num_dispatch_threads
            << ", num_non_epilogue_threads=" << config.num_non_epilogue_threads
-           << ", num_epilogue_threads=" << config.num_epilogue_threads << ")";
+           << ", num_epilogue_threads=" << config.num_epilogue_threads
+           << ", num_bytes_per_pull=" << config.num_bytes_per_pull << ")";
         return os;
     }
 };
 
-static std::tuple<int, int, int, int> get_block_config_for_mega_moe(
+static std::tuple<int, int, int, int, int> get_block_config_for_mega_moe(
     const int& num_ranks, const int& num_experts,
     const int& num_max_tokens_per_rank, const int& num_topk,
     const int& num_tokens) {
-    const auto& [cluster_size, block_m, store_block_m, num_epilogue_warpgroups] = [&]() -> std::tuple<int, int, int, int> {
+    auto [cluster_size, block_m, store_block_m, block_k, num_epilogue_warpgroups] = [&]() -> std::tuple<int, int, int, int, int> {
         float num_expected_tokens_per_expert = static_cast<float>(num_tokens) * num_ranks * num_topk / num_experts;
         if (num_expected_tokens_per_expert <= 8.5) {
-            // Really small token-per-expert (e.g. RL long-tail rollout), use the smallest block_m
-            return {2, 16, 8, 2};
+            // Really small token-per-expert (e.g. RL long-tail rollout), use the smallest block_m and larger BLOCK_K for less synchronization
+            return {2, 16, 8, 256, 2};
         } else if (num_expected_tokens_per_expert <= 16.5) {
             // Small batch size, small EP, decoding, e.g. 6/384 experts, EP8, bsz 128
-            return {2, 32, 16, 2};
+            return {2, 32, 16, 128, 2};
         } else if (num_expected_tokens_per_expert <= 32.5) {
             // Medium batch size, small EP, decoding, e.g. 6/384 experts, EP8, bsz 256
-            return {2, 64, 32, 1};
+            return {2, 64, 32, 128, 1};
         } else if (num_expected_tokens_per_expert <= 64.5) {
             // Large batch size, small EP, decoding, e.g. 6/384 experts, EP8, bsz 512
-            return {2, 96, 16, 2};
+            return {2, 96, 16, 128, 2};
         } else if (num_expected_tokens_per_expert <= 96.5) {
             // Medium batch size, Medium EP, decoding, e.g. 6/384 experts, EP16, bsz 256, or EP32, bsz128
-            return {2, 128, 32, 2};
+            return {2, 128, 32, 128, 2};
         } else {
             // Prefill, or large EP decoding
-            return {2, 192, 32, 2};
+            return {2, 192, 32, 128, 2};
         }
     }();
 
@@ -89,7 +95,7 @@ static std::tuple<int, int, int, int> get_block_config_for_mega_moe(
     );
 
     // Return configs
-    return {cluster_size, block_m, store_block_m, num_epilogue_warpgroups * 128};
+    return {cluster_size, block_m, store_block_m, block_k, num_epilogue_warpgroups * 128};
 }
 
 static int get_num_experts_per_wave_for_mega_moe(
@@ -111,22 +117,39 @@ static int get_num_experts_per_wave_for_mega_moe(
     const int num_l1_blocks_per_expert = num_m_blocks * num_n_blocks;
 
     // Pick the smallest value whose total blocks (after imbalance reduction) can keep all SMs busy
-    int num_experts_per_wave = num_l1_blocks_per_expert > 0
+    int min_num_experts_per_wave = num_l1_blocks_per_expert > 0
         ? ceil_div(kImbalanceFactor * num_sms, num_l1_blocks_per_expert) : 1;
-    num_experts_per_wave = std::min(num_experts_per_wave, num_experts_per_rank);
+    if (min_num_experts_per_wave >= num_experts_per_rank)
+        return num_experts_per_rank;
 
-    // Round up to the nearest divisor of num_experts_per_rank so every wave processes the same count
-    while (num_experts_per_wave < num_experts_per_rank and num_experts_per_rank % num_experts_per_wave != 0)
-        ++ num_experts_per_wave;
+    // When each expert nearly fills all SMs, use the smallest wave to maximize L2 cache reuse
+    if (num_l1_blocks_per_expert >= num_sms)
+        return min_num_experts_per_wave;
 
-    return num_experts_per_wave;
+    // Otherwise search [min_num_experts_per_wave, min_num_experts_per_wave * 2] for a value where the last partial
+    // wave has as many experts as possible relative to a full wave
+    const int max_num_experts_per_wave = std::min(num_experts_per_rank, min_num_experts_per_wave * 2);
+    int best_num_experts_per_wave = min_num_experts_per_wave;
+    float best_tail_ratio = -1.0f;
+
+    for (int num_experts_per_wave = min_num_experts_per_wave; num_experts_per_wave <= max_num_experts_per_wave; ++ num_experts_per_wave) {
+        int remainder = num_experts_per_rank % num_experts_per_wave;
+        float tail_ratio = (remainder == 0) ? 1.0f : static_cast<float>(remainder) / num_experts_per_wave;
+
+        if (tail_ratio > best_tail_ratio) {
+            best_tail_ratio = tail_ratio;
+            best_num_experts_per_wave = num_experts_per_wave;
+        }
+    }
+    return best_num_experts_per_wave;
 }
 
 static std::pair<int, int> get_pipeline_config_for_mega_moe(
     const int& smem_capacity,
     const int& num_experts, const int& hidden,
-    const int& block_m, const int& block_n, const int& block_k, const int& store_block_m,
-    const int& sf_block_m, const int& sf_block_n,
+    const int& block_m, const int& block_n, const int& block_k,
+    const int& num_bytes_per_pull, const int& store_block_m,
+    const int& sf_block_m, const int& sf_block_n, const int& gran_k,
     const int& num_dispatch_warps, const int& num_epilogue_warps) {
     constexpr int kSmemAlignment = 1024;
     constexpr int kNumEpilogueStages = 2;
@@ -139,7 +162,7 @@ static std::pair<int, int> get_pipeline_config_for_mega_moe(
     const int smem_expert_count_size = align(
         num_experts * static_cast<int>(sizeof(uint32_t)), kSmemAlignment);
     const int smem_send_buffers_size = align(
-        static_cast<int>(layout::Buffer(layout::Data(hidden), num_dispatch_warps, 1).get_num_bytes()),
+        static_cast<int>(layout::Buffer(layout::Data(num_bytes_per_pull), num_dispatch_warps, 1).get_num_bytes()),
         kSmemAlignment);
     const int smem_dispatch_size = smem_expert_count_size + smem_send_buffers_size;
 
@@ -147,32 +170,34 @@ static std::pair<int, int> get_pipeline_config_for_mega_moe(
     const auto num_epilogue_warpgroups = num_epilogue_warps / 4;
     const int smem_cd_l1 = num_epilogue_warpgroups * store_block_m * (block_n / 2) * kNumTMAStoreStages;
     const int smem_cd_l2 = num_epilogue_warpgroups * store_block_m * block_n * static_cast<int>(sizeof(nv_bfloat16));
-    const int smem_cd = std::max(smem_cd_l1, smem_cd_l2);
+    const int smem_cd = align(std::max(smem_cd_l1, smem_cd_l2), kSmemAlignment);
 
     // Barriers (stage-independent): dispatch + tensor memory full/empty + combine (2 per epilogue warp)
     const int smem_barriers = (num_dispatch_warps + kNumEpilogueStages * 2 + num_epilogue_warps * 2) * 8;
 
-    // Amax reduction
+    // Amax warp-pair reduction buffer
     const int smem_amax_reduction = store_block_m * num_epilogue_warps * static_cast<int>(sizeof(float));
 
     // Tensor memory pointer
     const int smem_tmem_ptr = 4;
 
     // SF is aligned to UTCCP 128-element granularity
-    const int smem_sfa_per_stage = sf_block_m * 4;
-    const int smem_sfb_per_stage = sf_block_n * 4;
+    const int smem_sfa_per_stage = sf_block_m * (block_k / gran_k);
+    const int smem_sfb_per_stage = sf_block_n * (block_k / gran_k);
 
-    // Per-stage: A tile + B tile + SFA tile + SFB tile + full/empty barriers
-    const int smem_per_stage = load_block_m * block_k + block_n * block_k + smem_sfa_per_stage + smem_sfb_per_stage + 2 * 8;
+    // Per-stage: A tile + B tile + SF tiles + full/empty barriers
+    const int smem_a_size_per_stage = load_block_m * block_k;
+    const int smem_b_size_per_stage = block_n * block_k;
+    const int smem_size_per_stage = smem_a_size_per_stage + smem_b_size_per_stage + smem_sfa_per_stage + smem_sfb_per_stage + 2 * 8;
 
     // Fixed total
     const int smem_fixed = smem_dispatch_size + smem_cd + smem_amax_reduction + smem_barriers + smem_tmem_ptr;
 
-    // Select maximum num_stages
-    const int num_stages = (smem_capacity - smem_fixed) / smem_per_stage;
+    // Select maximum number of stages
+    const int num_stages = (smem_capacity - smem_fixed) / smem_size_per_stage;
     DG_HOST_ASSERT(num_stages >= 2);
 
-    return {num_stages, smem_fixed + num_stages * smem_per_stage};
+    return {num_stages, smem_fixed + num_stages * smem_size_per_stage};
 }
 
 static MegaMoEConfig get_mega_moe_config(
@@ -180,19 +205,21 @@ static MegaMoEConfig get_mega_moe_config(
     const int& num_max_tokens_per_rank, const int& num_tokens, const int& num_topk,
     const int& hidden, const int& intermediate_hidden,
     const int& num_padded_sf_pool_tokens) {
+
     // Block config
-    const auto [cluster_size, block_m, store_block_m, num_epilogue_threads] =
+    const auto [cluster_size, block_m, store_block_m, block_k, num_epilogue_threads] =
         get_block_config_for_mega_moe(num_ranks, num_experts, num_max_tokens_per_rank, num_topk, num_tokens);
     const int block_n = 128;
-    const int block_k = 128;
     const int load_block_m = block_m / 2;
     const int load_block_n = block_n;
-    const auto [sf_block_m, sf_block_n] = SM100ArchSpec::get_sf_uttcp_aligned_block_sizes(block_m, block_n, MmaKind::MXFP8FP4);
+    const auto [sf_block_m, sf_block_n] =
+        SM100ArchSpec::get_sf_uttcp_aligned_block_sizes(block_m, block_n, MmaKind::MXFP8FP4);
     const int num_max_pool_tokens = layout::get_num_max_pool_tokens(
         num_ranks, num_max_tokens_per_rank, num_topk, num_experts_per_rank);
     // NOTES: FP8 activations and FP4 weights (unpacked to 8-bit in smem) both use 128B swizzle
     const int swizzle_acts_mode = 128;
     const int swizzle_weights_mode = 128;
+    const int gran_k = 32;
 
     // Waves
     const int num_sms = device_runtime->get_num_sms();
@@ -204,12 +231,20 @@ static MegaMoEConfig get_mega_moe_config(
     const int num_dispatch_threads = 128;
     const int num_non_epilogue_threads = 128;
 
+    // Pull: divide token bytes by 2 until <= kPullThreshold
+    constexpr int kPullThreshold = 4096;
+    int num_bytes_per_pull = hidden;
+    while (num_bytes_per_pull > kPullThreshold) {
+        DG_HOST_ASSERT(num_bytes_per_pull % 2 == 0);
+        num_bytes_per_pull /= 2;
+    }
+
     // Pipeline
     const auto [num_stages, smem_size] = get_pipeline_config_for_mega_moe(
         SM100ArchSpec::smem_capacity,
         num_experts, hidden,
-        block_m, block_n, block_k, store_block_m,
-        sf_block_m, sf_block_n,
+        block_m, block_n, block_k, num_bytes_per_pull, store_block_m,
+        sf_block_m, sf_block_n, gran_k,
         num_dispatch_threads / 32, num_epilogue_threads / 32);
 
     const auto config = MegaMoEConfig {
@@ -220,7 +255,8 @@ static MegaMoEConfig get_mega_moe_config(
         swizzle_acts_mode, swizzle_weights_mode,
         num_experts_per_wave,
         num_stages, smem_size,
-        num_dispatch_threads, num_non_epilogue_threads, num_epilogue_threads
+        num_dispatch_threads, num_non_epilogue_threads, num_epilogue_threads,
+        num_bytes_per_pull
     };
 
     // Print configs for the first time

--- a/csrc/jit_kernels/impls/runtime_utils.hpp
+++ b/csrc/jit_kernels/impls/runtime_utils.hpp
@@ -249,7 +249,8 @@ static CUtensorMap make_tma_sf_desc(const cute::UMMA::Major& major,
                                     const int& block_mn, const int& gran_k,
                                     const int& num_groups,
                                     const int& swizzle_mode, const int& swizzle_base = 0,
-                                    const bool& allow_tf32 = false) {
+                                    const bool& allow_tf32 = false,
+                                    const int& smem_outer_dim = 1) {
     DG_HOST_ASSERT(major == cute::UMMA::Major::MN);
 
     // TODO: maybe swizzle SF as well
@@ -258,7 +259,7 @@ static CUtensorMap make_tma_sf_desc(const cute::UMMA::Major& major,
     shape_mn = get_tma_aligned_size(shape_mn, static_cast<int>(t.element_size()));
     return make_tma_2d_desc(t,
                             shape_mn, ceil_div(shape_k, gran_k * (t.scalar_type() == torch::kFloat ? 1 : 4)) * num_groups,
-                            block_mn, 1,
+                            block_mn, smem_outer_dim,
                             shape_mn,
                             swizzle_mode, swizzle_base,
                             allow_tf32);

--- a/csrc/jit_kernels/impls/sm100_fp8_fp4_mega_moe.hpp
+++ b/csrc/jit_kernels/impls/sm100_fp8_fp4_mega_moe.hpp
@@ -69,6 +69,7 @@ static void __instantiate_kernel() {{
         {}, {}, {},
         {}, {},
         {},
+        {},
         {}
     >);
 }};
@@ -82,6 +83,7 @@ static void __instantiate_kernel() {{
     args.config.num_max_pool_tokens,
     args.config.num_padded_sf_pool_tokens,
     args.config.num_stages,
+    args.config.num_bytes_per_pull,
     args.config.num_dispatch_threads, args.config.num_non_epilogue_threads, args.config.num_epilogue_threads,
     args.launch_args.grid_dim.first, args.num_ranks,
     to_string(args.activation_clamp),
@@ -134,6 +136,7 @@ static void sm100_fp8_fp4_mega_moe(
 
     // Make tensormap
     constexpr int kGranK = 32;
+    const int sf_smem_outer_dim = config.block_k / (kGranK * 4);
     const auto tensor_map_l1_acts = make_tma_2d_desc(l1_acts,
                                                      hidden, config.num_max_pool_tokens,
                                                      config.block_k, config.load_block_m,
@@ -142,7 +145,8 @@ static void sm100_fp8_fp4_mega_moe(
     const auto tensor_map_l1_acts_sf = make_tma_sf_desc(cute::UMMA::Major::MN, l1_acts_sf,
                                                         config.num_padded_sf_pool_tokens, hidden,
                                                         config.sf_block_m, kGranK,
-                                                        1, 0);
+                                                        1, 0, 0, false,
+                                                        sf_smem_outer_dim);
     const auto tensor_map_l1_weights = make_tma_2d_desc(l1_weights,
                                                         hidden, num_experts_per_rank * intermediate_hidden * 2,
                                                         config.block_k, config.load_block_n,
@@ -151,10 +155,10 @@ static void sm100_fp8_fp4_mega_moe(
     const auto tensor_map_l1_weights_sf = make_tma_sf_desc(cute::UMMA::Major::MN, l1_weights_sf,
                                                            intermediate_hidden * 2, hidden,
                                                            config.block_n, kGranK,
-                                                           num_experts_per_rank, 0);
+                                                           num_experts_per_rank, 0, 0, false,
+                                                        sf_smem_outer_dim);
     // NOTES: L1 output and L2 activations are essentially the same tensor.
-    // Post-SwiGLU output has half the N width (`BLOCK_N / 2` per input tile),
-    // so the swizzle mode is also halved (128 -> 64).
+    // Post-SwiGLU output N width is `BLOCK_N / 2` per input tile.
     const auto tensor_map_l1_output = make_tma_2d_desc(l2_acts,
                                                        intermediate_hidden, config.num_max_pool_tokens,
                                                        config.block_n / 2, config.store_block_m,
@@ -168,7 +172,8 @@ static void sm100_fp8_fp4_mega_moe(
     const auto tensor_map_l2_acts_sf = make_tma_sf_desc(cute::UMMA::Major::MN, l2_acts_sf,
                                                         config.num_padded_sf_pool_tokens, intermediate_hidden,
                                                         config.sf_block_m, kGranK,
-                                                        1, 0);
+                                                        1, 0, 0, false,
+                                                        sf_smem_outer_dim);
     const auto tensor_map_l2_weights = make_tma_2d_desc(l2_weights,
                                                         intermediate_hidden, num_experts_per_rank * hidden,
                                                         config.block_k, config.load_block_n,
@@ -177,7 +182,8 @@ static void sm100_fp8_fp4_mega_moe(
     const auto tensor_map_l2_weights_sf = make_tma_sf_desc(cute::UMMA::Major::MN, l2_weights_sf,
                                                            hidden, intermediate_hidden,
                                                            config.block_n, kGranK,
-                                                           num_experts_per_rank, 0);
+                                                           num_experts_per_rank, 0, 0, false,
+                                                           sf_smem_outer_dim);
 
     // Stats can be optional
     int* cumulative_local_expert_recv_stats_ptr = nullptr;

--- a/csrc/jit_kernels/impls/sm90_fp8_gemm_1d2d.hpp
+++ b/csrc/jit_kernels/impls/sm90_fp8_gemm_1d2d.hpp
@@ -48,11 +48,11 @@ static void __instantiate_kernel() {{
         {}, {},
         {}, {},
         {}, {},
+        {},
         {}
     >);
 }};
 )",
-        // TODO: add CD dtype
         to_string(args.major_sfb),
         get_compiled_dim(args.gemm_desc.m, 'm', args.gemm_desc.compiled_dims),
         get_compiled_dim(args.gemm_desc.n, 'n', args.gemm_desc.compiled_dims),
@@ -64,6 +64,7 @@ static void __instantiate_kernel() {{
         args.gemm_config.launch_config.num_tma_threads, args.gemm_config.launch_config.num_math_threads,
         args.gemm_config.layout.get_cluster_size(), args.gemm_config.layout.cluster_n > 1,
         args.gemm_config.launch_config.num_sms, to_string(args.gemm_desc.gemm_type),
+        to_string(args.gemm_desc.cd_dtype),
         get_default_epilogue_type(args.epilogue_type));
     }
 

--- a/csrc/jit_kernels/impls/smxx_fp8_fp4_paged_mqa_logits.hpp
+++ b/csrc/jit_kernels/impls/smxx_fp8_fp4_paged_mqa_logits.hpp
@@ -63,8 +63,9 @@ static void smxx_paged_mqa_logits_metadata(const torch::Tensor& context_lens,
     const int aligned_batch_size = align(batch_size, 32);
     DG_HOST_ASSERT(split_kv % block_kv == 0);
 
-    // Shared memory: prefix_sum[kAlignedBatchSize] + varlen_atom_token_start/context_len[kAlignedBatchSize] + varlen_num_atoms
-    const int smem_size = (3 * aligned_batch_size + 1) * static_cast<int>(sizeof(int));
+    // Shared memory: prefix_sum[kAlignedBatchSize] plus varlen atom metadata when needed.
+    const int num_smem_ints = is_varlen ? 3 * aligned_batch_size + 1 : aligned_batch_size;
+    const int smem_size = num_smem_ints * static_cast<int>(sizeof(int));
     DG_HOST_ASSERT(smem_size <= SM90ArchSpec::smem_capacity);
     DG_HOST_ASSERT(smem_size <= SM100ArchSpec::smem_capacity);
 

--- a/deep_gemm/include/deep_gemm/comm/barrier.cuh
+++ b/deep_gemm/include/deep_gemm/comm/barrier.cuh
@@ -59,15 +59,15 @@ CUTLASS_DEVICE void nvlink_barrier(const layout::Workspace& workspace,
             ptx::red_add_rel_sys(sym_buffer.map(signal_ptr, thread_idx), signal_sign ? -1 : 1);
         sync_scope();
 
-        // Update status and wait arrival (with 30s timeout, at 2 GHz)
-        constexpr int64_t kNumTimeoutCycles = 30ll * 2000000000ll;
+        // Update status and wait arrival (with 300s timeout, at 2 GHz)
+        constexpr int64_t kNumTimeoutCycles = 300ll * 2000000000ll;
         if (thread_idx == 0) {
             ptx::red_add(counter_ptr, 1);
             const int target = signal_sign ? 0 : static_cast<int>(kNumRanks);
             const auto start_clock = clock64();
             while (ptx::ld_acq_sys(signal_ptr) != target) {
                 if (clock64() - start_clock >= kNumTimeoutCycles) {
-                    printf("DeepGEMM NVLink barrier timeout (30s): rank=%d, counter=%d, signal=%d, target=%d, phase=%d, sign=%d, tag=%d\n",
+                    printf("DeepGEMM NVLink barrier timeout (300s): rank=%d, counter=%d, signal=%d, target=%d, phase=%d, sign=%d, tag=%d\n",
                            sym_buffer.rank_idx, *counter_ptr, ptx::ld_acq_sys(signal_ptr), target, signal_phase, signal_sign, kTag);
                     DG_DEVICE_ASSERT(false and "NVLink barrier timeout");
                 }

--- a/deep_gemm/include/deep_gemm/impls/sm100_bf16_gemm.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_bf16_gemm.cuh
@@ -4,6 +4,7 @@
 
 #include <cutlass/arch/barrier.h>
 
+#include <deep_gemm/comm/barrier.cuh>
 #include <deep_gemm/scheduler/gemm.cuh>
 #include <deep_gemm/common/math.cuh>
 #include <deep_gemm/common/tma_copy.cuh>
@@ -49,9 +50,8 @@ sm100_bf16_gemm_impl(int* grouped_layout,
     using Barrier = cutlass::arch::ClusterTransactionBarrier;
     using Allocator = cute::conditional_t<kNumMulticast == 1, cute::TMEM::Allocator1Sm, cute::TMEM::Allocator2Sm>;
 
-    // GEMM with accumulation must have FP32 output
-    if constexpr (kWithAccumulation)
-        DG_STATIC_ASSERT(cute::is_same_v<cd_dtype_t, float>, "Invalid C/D data dtype");
+    // C/D type: BF16 and FP32 are supported, with or without accumulation
+    DG_STATIC_ASSERT(cute::is_same_v<cd_dtype_t, float> or cute::is_same_v<cd_dtype_t, cutlass::bfloat16_t>, "Invalid C/D data dtype");
 
     // MMA Configs
     constexpr uint32_t LAYOUT_AD_M = 128;
@@ -95,7 +95,7 @@ sm100_bf16_gemm_impl(int* grouped_layout,
     DG_STATIC_ASSERT(32 <= kNumTmemCols and kNumTmemCols <= 512, "Invalid tensor memory columns");
 
     // Synchronize the cluster before 2-CTA TMEM allocation
-    kNumMulticast > 1 ? cute::cluster_sync() : void();
+    kNumMulticast > 1 ? comm::cluster_sync_with_relaxed_arrive() : void();
 
     // Utils
     bool is_leader_cta = cute::block_rank_in_cluster() == 0;
@@ -165,7 +165,7 @@ sm100_bf16_gemm_impl(int* grouped_layout,
         // Allocate tensor memory
         Allocator().allocate(kNumTmemCols, tmem_ptr_in_smem);
     }
-    kNumMulticast > 1 ? cute::cluster_sync() : __syncthreads();
+    kNumMulticast > 1 ? comm::cluster_sync_with_relaxed_arrive() : __syncthreads();
 
     // Wait for primary kernel completion
     cudaGridDependencySynchronize();
@@ -420,7 +420,7 @@ sm100_bf16_gemm_impl(int* grouped_layout,
     }
 
     // TODO: Remove redundant synchronization
-    kNumMulticast > 1 ? cute::cluster_sync() : __syncthreads();
+    kNumMulticast > 1 ? comm::cluster_sync_with_relaxed_arrive() : __syncthreads();
 
     // Deallocate tensor memory
     if (warp_idx == 0)

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp4_mqa_logits.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp4_mqa_logits.cuh
@@ -238,11 +238,9 @@ void sm100_fp4_mqa_logits(const uint32_t seq_len, const uint32_t seq_len_kv,
             uint32_t values[4];
             #pragma unroll
             for (uint32_t i = 0; i < 4; ++ i)
-                values[i] = ptx::ld_shared(smem_ptr + (i ^ (lane_idx >> 3)) * 32 + lane_idx);
+                values[i] = ptx::ld_shared(smem_ptr + i * 32 + lane_idx);
             __syncwarp();
-            #pragma unroll
-            for (uint32_t i = 0; i < 4; ++ i)
-                ptx::st_shared(smem_ptr + lane_idx * 4 + (i ^ (lane_idx >> 3)), values[i]);
+            ptx::st_shared(smem_ptr + lane_idx * 4, values[0], values[1], values[2], values[3]);
         };
 
         // Make UMMA desc
@@ -349,10 +347,12 @@ void sm100_fp4_mqa_logits(const uint32_t seq_len, const uint32_t seq_len_kv,
         // Helper lambda for loading tensor memory
         auto tmem_load = [](auto num_elems_c, const uint32_t& tmem_addr, float* accum) {
             constexpr uint32_t N = decltype(num_elems_c)::value;
-            DG_STATIC_ASSERT(N == 32 or N == 64, "Unsupported TMEM load size");
-            using Loader = cute::conditional_t<N == 32,
-                cute::SM100_TMEM_LOAD_32dp32b32x,
-                cute::SM100_TMEM_LOAD_32dp32b64x>;
+            DG_STATIC_ASSERT(N == 16 or N == 32 or N == 64, "Unsupported TMEM load size");
+            using Loader = cute::conditional_t<N == 16,
+                cute::SM100_TMEM_LOAD_32dp32b16x,
+                cute::conditional_t<N == 32,
+                    cute::SM100_TMEM_LOAD_32dp32b32x,
+                    cute::SM100_TMEM_LOAD_32dp32b64x>>;
             [&]<size_t... Is>(cute::index_sequence<Is...>) {
                 Loader::copy(tmem_addr, reinterpret_cast<uint32_t*>(accum)[Is]...);
             }(cute::make_index_sequence<N>{});

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp4_paged_mqa_logits.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp4_paged_mqa_logits.cuh
@@ -272,11 +272,9 @@ void sm100_fp4_paged_mqa_logits(const uint32_t batch_size,
             uint32_t values[4];
             #pragma unroll
             for (uint32_t i = 0; i < 4; ++ i)
-                values[i] = ptx::ld_shared(smem_ptr + (i ^ (lane_idx >> 3)) * 32 + lane_idx);
+                values[i] = ptx::ld_shared(smem_ptr + i * 32 + lane_idx);
             __syncwarp();
-            #pragma unroll
-            for (uint32_t i = 0; i < 4; ++ i)
-                ptx::st_shared(smem_ptr + lane_idx * 4 + (i ^ (lane_idx >> 3)), values[i]);
+            ptx::st_shared(smem_ptr + lane_idx * 4, values[0], values[1], values[2], values[3]);
         };
 
         // Make UMMA desc
@@ -382,10 +380,12 @@ void sm100_fp4_paged_mqa_logits(const uint32_t batch_size,
         // Helper lambda for loading tensor memory
         auto tmem_load = [](auto num_elems_c, const uint32_t& tmem_addr, float* accum) {
             constexpr int N = decltype(num_elems_c)::value;
-            DG_STATIC_ASSERT(N == 32 or N == 64, "Unsupported TMEM load size");
-            using Loader = cute::conditional_t<N == 32,
-                cute::SM100_TMEM_LOAD_32dp32b32x,
-                cute::SM100_TMEM_LOAD_32dp32b64x>;
+            DG_STATIC_ASSERT(N == 16 or N == 32 or N == 64, "Unsupported TMEM load size");
+            using Loader = cute::conditional_t<N == 16,
+                cute::SM100_TMEM_LOAD_32dp32b16x,
+                cute::conditional_t<N == 32,
+                    cute::SM100_TMEM_LOAD_32dp32b32x,
+                    cute::SM100_TMEM_LOAD_32dp32b64x>>;
             [&]<size_t... Is>(cute::index_sequence<Is...>) {
                 Loader::copy(tmem_addr, reinterpret_cast<uint32_t*>(accum)[Is]...);
             }(cute::make_index_sequence<N>{});
@@ -430,7 +430,7 @@ void sm100_fp4_paged_mqa_logits(const uint32_t batch_size,
 
                 // Check if this atom pairs two tokens from the same sequence
                 if constexpr (kIsVarlen) {
-                    is_paired_atom = (scheduler.get_atom_advance(q_atom_idx, batch_size) == 2);
+                    is_paired_atom = (scheduler.get_last_advance() == 2);
                 }
             }
             last_q_atom_idx = q_atom_idx;

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_gemm_1d1d.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_gemm_1d1d.cuh
@@ -4,6 +4,7 @@
 
 #include <cutlass/arch/barrier.h>
 
+#include <deep_gemm/comm/barrier.cuh>
 #include <deep_gemm/common/math.cuh>
 #include <deep_gemm/common/tma_copy.cuh>
 #include <deep_gemm/epilogue/transform.cuh>
@@ -41,9 +42,8 @@ sm100_fp8_fp4_gemm_1d1d_impl(int* grouped_layout,
     using Barrier = cutlass::arch::ClusterTransactionBarrier;
     using Allocator = cute::conditional_t<kNumMulticast == 1, cute::TMEM::Allocator1Sm, cute::TMEM::Allocator2Sm>;
 
-    // GEMM with accumulation must have FP32 output
-    if constexpr (kWithAccumulation)
-        DG_STATIC_ASSERT(cute::is_same_v<cd_dtype_t, float>, "Invalid C/D data dtype");
+    // C/D type: BF16 and FP32 are supported, with or without accumulation
+    DG_STATIC_ASSERT(cute::is_same_v<cd_dtype_t, float> or cute::is_same_v<cd_dtype_t, cutlass::bfloat16_t>, "Invalid C/D data dtype");
 
     // MMA Configs
     constexpr uint32_t LAYOUT_AD_M = 128;
@@ -101,7 +101,7 @@ sm100_fp8_fp4_gemm_1d1d_impl(int* grouped_layout,
     DG_STATIC_ASSERT(32 <= kNumTmemCols and kNumTmemCols <= 512, "Invalid tensor memory columns");
 
     // Synchronize the cluster before 2-CTA TMEM allocation
-    kNumMulticast > 1 ? cute::cluster_sync() : void();
+    kNumMulticast > 1 ? comm::cluster_sync_with_relaxed_arrive() : void();
 
     // Utils
     const bool is_leader_cta = cute::block_rank_in_cluster() == 0;
@@ -180,7 +180,7 @@ sm100_fp8_fp4_gemm_1d1d_impl(int* grouped_layout,
         // Allocate tensor memory
         Allocator().allocate(kNumTmemCols, tmem_ptr_in_smem);
     }
-    kNumMulticast > 1 ? cute::cluster_sync() : __syncthreads();
+    kNumMulticast > 1 ? comm::cluster_sync_with_relaxed_arrive() : __syncthreads();
 
     // Wait for primary kernel completion
     cudaGridDependencySynchronize();
@@ -410,11 +410,9 @@ sm100_fp8_fp4_gemm_1d1d_impl(int* grouped_layout,
             uint32_t values[4];
             #pragma unroll
             for (uint32_t i = 0; i < 4; ++ i)
-                values[i] = ptx::ld_shared(smem_ptr + (i ^ (lane_idx >> 3)) * 32 + lane_idx);
+                values[i] = ptx::ld_shared(smem_ptr + i * 32 + lane_idx);
             __syncwarp();
-            #pragma unroll
-            for (uint32_t i = 0; i < 4; ++ i)
-                ptx::st_shared(smem_ptr + lane_idx * 4 + (i ^ (lane_idx >> 3)), values[i]);
+            ptx::st_shared(smem_ptr + lane_idx * 4, values[0], values[1], values[2], values[3]);
         };
 
         while (scheduler.get_next_block(m_block_idx, n_block_idx)) {
@@ -497,7 +495,7 @@ sm100_fp8_fp4_gemm_1d1d_impl(int* grouped_layout,
     }
 
     // TODO: Remove redundant synchronization
-    kNumMulticast > 1 ? cute::cluster_sync() : __syncthreads();
+    kNumMulticast > 1 ? comm::cluster_sync_with_relaxed_arrive() : __syncthreads();
 
     // Deallocate tensor memory
     if (warp_idx == 0)

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
@@ -29,6 +29,7 @@ template <
     uint32_t kNumMaxPoolTokens,
     uint32_t kNumPaddedSFPoolTokens,
     uint32_t kNumStages,
+    uint32_t kNumBytesPerPull,
     uint32_t kNumDispatchThreads, uint32_t kNumNonEpilogueThreads,
     uint32_t kNumEpilogueThreads,
     uint32_t kNumSMs, uint32_t kNumRanks,
@@ -168,16 +169,16 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
     constexpr uint32_t LAYOUT_AD_M = 128;
     constexpr uint32_t UMMA_M = LAYOUT_AD_M * 2;
     constexpr uint32_t UMMA_N = BLOCK_M;  // Swap AB
+    constexpr uint32_t UMMA_BLOCK_K = 128;
     constexpr uint32_t UMMA_K = 32;
     constexpr uint32_t LOAD_BLOCK_M = BLOCK_M / 2;  // Multicast on A
     constexpr uint32_t LOAD_BLOCK_N = BLOCK_N;
     DG_STATIC_ASSERT(BLOCK_M % 16 == 0, "Invalid block M");
     DG_STATIC_ASSERT(BLOCK_N == LAYOUT_AD_M, "Invalid block N");
-    DG_STATIC_ASSERT(BLOCK_K == 128, "Invalid block K");
 
     // Swizzle configs
-    constexpr uint32_t kSwizzleAMode = BLOCK_K * sizeof(a_dtype_t);
-    constexpr uint32_t kSwizzleBMode = BLOCK_K * sizeof(b_dtype_t);
+    constexpr uint32_t kSwizzleAMode = 128;
+    constexpr uint32_t kSwizzleBMode = 128;
     constexpr uint32_t kSwizzleCDMode = 128;
     DG_STATIC_ASSERT(BLOCK_N % kSwizzleCDMode == 0, "Invalid block N");
 
@@ -192,26 +193,36 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
     // Shared memory sizes
     // NOTES: FP8 CD output for L1 (2 TMA stages, BLOCK_N/2 post-SwiGLU), BF16 output for L2 (no TMA, a single stage)
     constexpr uint32_t L1_OUT_BLOCK_N = BLOCK_N / 2;
-    constexpr uint32_t SMEM_EXPERT_COUNT_SIZE =
-        math::constexpr_align<uint32_t>(kNumExperts * sizeof(uint32_t), kSharedMemoryAlignment);
-    constexpr uint32_t SMEM_SEND_BUFFER_SIZE =
-        math::constexpr_align(fp8_token_layout.get_num_bytes() * kNumDispatchWarps, kSharedMemoryAlignment);
-    constexpr uint32_t SMEM_A_SIZE_PER_STAGE = LOAD_BLOCK_M * BLOCK_K * sizeof(a_dtype_t);
-    constexpr uint32_t SMEM_B_SIZE_PER_STAGE = LOAD_BLOCK_N * BLOCK_K * sizeof(b_dtype_t);
-    constexpr uint32_t SMEM_SFA_SIZE_PER_STAGE = SF_BLOCK_M * sizeof(uint32_t);
-    constexpr uint32_t SMEM_SFB_SIZE_PER_STAGE = SF_BLOCK_N * sizeof(uint32_t);
-    constexpr uint32_t SMEM_CD_L1_SIZE =
-        kNumEpilogueWarpgroups * STORE_BLOCK_M * L1_OUT_BLOCK_N * sizeof(cutlass::float_e4m3_t) * kNumTMAStoreStages;
-    constexpr uint32_t SMEM_CD_L2_SIZE =
-        kNumEpilogueWarpgroups * STORE_BLOCK_M * BLOCK_N * sizeof(nv_bfloat16);
-    constexpr uint32_t SMEM_CD_SIZE = SMEM_CD_L1_SIZE > SMEM_CD_L2_SIZE ? SMEM_CD_L1_SIZE : SMEM_CD_L2_SIZE;
-    constexpr uint32_t SMEM_CD_L1_SIZE_PER_STAGE = SMEM_CD_L1_SIZE / kNumTMAStoreStages;
-    constexpr uint32_t SMEM_BEFORE_BARRIER_SIZE =
-        SMEM_EXPERT_COUNT_SIZE + SMEM_SEND_BUFFER_SIZE + SMEM_CD_SIZE + kNumStages * (SMEM_A_SIZE_PER_STAGE + SMEM_B_SIZE_PER_STAGE);
-    DG_STATIC_ASSERT(SMEM_CD_SIZE % kSharedMemoryAlignment == 0 and
-                     SMEM_A_SIZE_PER_STAGE % kSharedMemoryAlignment == 0 and
-                     SMEM_B_SIZE_PER_STAGE % kSharedMemoryAlignment == 0,
-                     "Shared memory of CD/A/B must be aligned to 1024 bytes");
+    constexpr uint32_t AMAX_REDUCTION_WARP_BUFFER_SIZE = STORE_BLOCK_M / 2; // float2
+
+    struct SharedStorage {
+        alignas(kSharedMemoryAlignment) uint32_t expert_token_count[kNumExperts];
+        alignas(kSharedMemoryAlignment) uint8_t dispatch_send_buffer[kNumDispatchWarps][kNumBytesPerPull];
+        union {
+            alignas(kSharedMemoryAlignment) cutlass::float_e4m3_t l1[kNumEpilogueWarpgroups][kNumTMAStoreStages][STORE_BLOCK_M * L1_OUT_BLOCK_N];
+            alignas(kSharedMemoryAlignment) nv_bfloat16 l2[kNumEpilogueWarpgroups][STORE_BLOCK_M * BLOCK_N];
+        } smem_d;
+        alignas(kSharedMemoryAlignment) a_dtype_t smem_a[kNumStages][LOAD_BLOCK_M * BLOCK_K];
+        alignas(kSharedMemoryAlignment) b_dtype_t smem_b[kNumStages][LOAD_BLOCK_N * BLOCK_K];
+        uint32_t smem_sfa[kNumStages][SF_BLOCK_M * (BLOCK_K / 128)];
+        uint32_t smem_sfb[kNumStages][SF_BLOCK_N * (BLOCK_K / 128)];
+        float2 amax_reduction[kNumEpilogueWarps][AMAX_REDUCTION_WARP_BUFFER_SIZE];
+        Barrier dispatch_barriers[kNumDispatchWarps];
+        Barrier full_barriers[kNumStages];
+        Barrier empty_barriers[kNumStages];
+        Barrier tmem_full_barriers[kNumEpilogueStages];
+        Barrier tmem_empty_barriers[kNumEpilogueStages];
+        Barrier combine_barriers[kNumEpilogueWarps * 2];
+        uint32_t tmem_ptr_in_smem;
+    };
+    constexpr uint32_t kNumReusableSmemBytes = offsetof(SharedStorage, dispatch_barriers);
+    SharedStorage &shared_storage = *reinterpret_cast<SharedStorage*>(smem_buffer);
+
+    // Send buffers
+    constexpr auto pull_layout = layout::Data(kNumBytesPerPull);
+    const auto smem_send_buffers = layout::Buffer(
+        pull_layout, kNumDispatchWarps, 1,
+        static_cast<void*>(shared_storage.dispatch_send_buffer));
 
     // Tensor memory size
     constexpr uint32_t kNumAccumTmemCols = UMMA_N * kNumEpilogueStages;
@@ -222,91 +233,49 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
     constexpr uint32_t kTmemStartColOfSFB = kNumAccumTmemCols + kNumSFATmemCols;
     DG_STATIC_ASSERT(32 <= kNumTmemCols and kNumTmemCols <= 512, "Invalid tensor memory columns");
 
-    // Assign shared memory for dispatch warps
-    const auto smem_expert_count = reinterpret_cast<uint32_t*>(smem_buffer);
-    const auto smem_send_buffers = layout::Buffer(
-        fp8_token_layout, kNumDispatchWarps, 1,
-        math::advance_ptr(smem_buffer, SMEM_EXPERT_COUNT_SIZE));
-
-    // GEMM shared memory: C/D, A, B
-    // NOTES: GEMM shared memory starts after the dispatch region, aligned to 1024 bytes
-    auto smem_gemm_base = math::advance_ptr(
-        smem_buffer, SMEM_EXPERT_COUNT_SIZE + SMEM_SEND_BUFFER_SIZE
-    );
-
-    // D/A/B shared memory
-    auto smem_cd = utils::PatternVisitor([=](const uint32_t& i) {
-        return math::advance_ptr<uint8_t>(smem_gemm_base, i * SMEM_CD_L1_SIZE_PER_STAGE);
-    });
-    auto smem_cd_l2 = smem_cd[0];
-    auto smem_a = utils::PatternVisitor([=](const uint32_t& i) {
-        return math::advance_ptr<a_dtype_t>(smem_gemm_base, SMEM_CD_SIZE + i * SMEM_A_SIZE_PER_STAGE);
-    });
-    auto smem_b = utils::PatternVisitor([=](const uint32_t& i) {
-        return math::advance_ptr<b_dtype_t>(smem_gemm_base, SMEM_CD_SIZE + kNumStages * SMEM_A_SIZE_PER_STAGE + i * SMEM_B_SIZE_PER_STAGE);
-    });
-
-    // SF shared memory: SFA and SFB per pipeline stage
-    auto sf_start_ptr = math::advance_ptr<uint8_t>(smem_gemm_base,
-        SMEM_CD_SIZE + kNumStages * (SMEM_A_SIZE_PER_STAGE + SMEM_B_SIZE_PER_STAGE));
-    auto smem_sfa = utils::PatternVisitor([=](const uint32_t& i) {
-        return reinterpret_cast<uint32_t*>(sf_start_ptr + i * SMEM_SFA_SIZE_PER_STAGE);
-    });
-    auto smem_sfb = utils::PatternVisitor([=](const uint32_t& i) {
-        return reinterpret_cast<uint32_t*>(sf_start_ptr + kNumStages * SMEM_SFA_SIZE_PER_STAGE + i * SMEM_SFB_SIZE_PER_STAGE);
-    });
-
-    // Epilogue amax reduction shared memory
-    auto smem_amax_reduction = reinterpret_cast<float2*>(smem_sfb[kNumStages]);
-
-    // Barriers and tensor memory pointer
-    auto barrier_start_ptr = reinterpret_cast<Barrier*>(smem_amax_reduction + STORE_BLOCK_M * kNumEpilogueWarps / 2);
-    auto dispatch_barriers      = utils::PatternVisitor([=](const uint32_t& i) { return barrier_start_ptr + (i); });
-    auto full_barriers          = utils::PatternVisitor([=](const uint32_t& i) { return barrier_start_ptr + (kNumDispatchWarps + i); });
-    auto empty_barriers         = utils::PatternVisitor([=](const uint32_t& i) { return barrier_start_ptr + (kNumDispatchWarps + kNumStages + i); });
-    auto tmem_full_barriers     = utils::PatternVisitor([=](const uint32_t& i) { return barrier_start_ptr + (kNumDispatchWarps + kNumStages * 2 + i); });
-    auto tmem_empty_barriers    = utils::PatternVisitor([=](const uint32_t& i) { return barrier_start_ptr + (kNumDispatchWarps + kNumStages * 2 + kNumEpilogueStages + i); });
-    auto combine_barriers       = utils::PatternVisitor([=](const uint32_t& i) { return barrier_start_ptr + (kNumDispatchWarps + kNumStages * 2 + kNumEpilogueStages * 2 + i); });
-    auto tmem_ptr_in_smem       = reinterpret_cast<uint32_t*>(barrier_start_ptr + kNumDispatchWarps + kNumStages * 2 + kNumEpilogueStages * 2 + kNumEpilogueWarps * 2);
-
     // A cluster sync is essential for 2CTA tensor memory allocation
     comm::cluster_sync_with_relaxed_arrive();
 
     // Initialization
     if (warp_idx == 0) {
         // Clean shared memory
-        if (cute::elect_one_sync())
-            ptx::st_shared_bulk(smem_expert_count, kNumExperts * sizeof(uint32_t));
+        if (cute::elect_one_sync()) {
+            // The bytes must be 8 bytes aligned
+            ptx::st_shared_bulk(
+                shared_storage.expert_token_count,
+                math::constexpr_align<uint32_t>(kNumExperts * sizeof(uint32_t), kSharedMemoryAlignment)
+            );
+        }
     } else if (warp_idx == 1) {
         // Init m-barriers for dispatch
         #pragma unroll
         for (uint32_t i = lane_idx; i < kNumDispatchWarps; i += 32)
-            dispatch_barriers[i]->init(1);
+            shared_storage.dispatch_barriers[i].init(1);
         cutlass::arch::fence_barrier_init();
     } else if (warp_idx == 2) {
         // Init GEMM barriers
         if (cute::elect_one_sync()) {
             #pragma unroll
             for (uint32_t i = 0; i < kNumStages; ++ i) {
-                // Arrive at all CTAs
-                full_barriers[i]->init(2 * 2);
-                empty_barriers[i]->init(1);
+                // Arrive at 2 CTAs, A + B
+                shared_storage.full_barriers[i].init(2 * 2);
+                shared_storage.empty_barriers[i].init(1);
             }
             #pragma unroll
             for (uint32_t i = 0; i < kNumEpilogueStages; ++ i) {
                 // Arrive at all CTAs
-                tmem_full_barriers[i]->init(1);
+                shared_storage.tmem_full_barriers[i].init(1);
                 // Arrive only at the leader CTA
-                tmem_empty_barriers[i]->init(2 * kNumEpilogueThreads);
+                shared_storage.tmem_empty_barriers[i].init(2 * kNumEpilogueThreads);
             }
             #pragma unroll
             for (uint32_t i = 0; i < kNumEpilogueWarps * 2; ++ i)
-                combine_barriers[i]->init(1);
+                shared_storage.combine_barriers[i].init(1);
         }
         cutlass::arch::fence_barrier_init();
     } else if (warp_idx == 3) {
         // Allocate tensor memory
-        Allocator().allocate(kNumTmemCols, tmem_ptr_in_smem);
+        Allocator().allocate(kNumTmemCols, &shared_storage.tmem_ptr_in_smem);
     }
     // NOTES: Using `.relaxed` is allowed here since `fence_barrier_init` is `.release.cluster`,
     // and `barrier.cluster.wait.aligned` is by default `.acquire`
@@ -343,9 +312,11 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
     constexpr uint32_t kAfterWorkspaceCleanBarrierTag = 3;
 
     // Adjust registers
-    constexpr uint32_t kNumDispatchRegisters = 48;
-    constexpr uint32_t kNumNonEpilogueRegisters = 40;
-    constexpr uint32_t kNumEpilogueRegisters = 208;
+    // NOTES: more experts per rank will cost more schedulers' registers
+    constexpr bool kUseMoreEpilogueRegisters = kNumExpertsPerRank <= 64;
+    constexpr uint32_t kNumDispatchRegisters = kUseMoreEpilogueRegisters ? 48 : 96;
+    constexpr uint32_t kNumNonEpilogueRegisters = kUseMoreEpilogueRegisters ? 40 : 88;
+    constexpr uint32_t kNumEpilogueRegisters = kUseMoreEpilogueRegisters ? 208 : 160;
     DG_STATIC_ASSERT(kNumDispatchRegisters * kNumDispatchThreads +
                      kNumNonEpilogueRegisters * kNumNonEpilogueThreads +
                      kNumEpilogueRegisters * kNumEpilogueThreads <= 64512,
@@ -384,15 +355,15 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
 
         // Count experts' tokens
         read_topk_idx([&](const uint32_t& token_topk_idx, const int& expert_idx) {
-           atomicAdd_block(smem_expert_count + expert_idx, 1);
+           atomicAdd_block(shared_storage.expert_token_count + expert_idx, 1);
         });
         ptx::sync_aligned(kNumDispatchThreads, kDispatchBarrierIdx);
 
         // Get SM offset (~6.5 us)
         #pragma unroll
         for (uint32_t i = thread_idx; i < kNumExperts; i += kNumDispatchThreads) {
-            const uint64_t send_value = (1ull << 32) | static_cast<uint64_t>(smem_expert_count[i]);
-            smem_expert_count[i] = static_cast<uint32_t>(
+            const uint64_t send_value = (1ull << 32) | static_cast<uint64_t>(shared_storage.expert_token_count[i]);
+            shared_storage.expert_token_count[i] = static_cast<uint32_t>(
                 ptx::atomic_add(workspace.get_expert_send_count_ptr(i), send_value));
         }
         ptx::sync_aligned(kNumDispatchThreads, kDispatchBarrierIdx);
@@ -400,7 +371,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
         // Write source indices (~2 us with 512 tokens)
         read_topk_idx([&](const uint32_t& token_topk_idx, const int& expert_idx) {
             const auto dst_rank_idx = expert_idx / kNumExpertsPerRank;
-            const auto dst_slot_idx = atomicAdd_block(smem_expert_count + expert_idx, 1);
+            const auto dst_slot_idx = atomicAdd_block(shared_storage.expert_token_count + expert_idx, 1);
             const auto dst_ptr = workspace.get_src_token_topk_idx_ptr(
                 expert_idx % kNumExpertsPerRank, sym_buffer.rank_idx, dst_slot_idx);
             *sym_buffer.map(dst_ptr, dst_rank_idx) = token_topk_idx;
@@ -444,7 +415,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
         // Pull token data and SF from remote ranks into local L1 buffer
         uint32_t pull_mbarrier_phase = 0;
         const auto pull_buffer = smem_send_buffers.get_rank_buffer(warp_idx).get_data_buffer(0);
-        const auto pull_mbarrier = dispatch_barriers[warp_idx];
+        const auto pull_mbarrier = &shared_storage.dispatch_barriers[warp_idx];
 
         // Cache expert token counts in registers (same pattern as scheduler)
         scheduler.fetch_expert_recv_count();
@@ -544,17 +515,39 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
             const uint32_t src_token_idx = src_token_topk_idx / kNumTopk;
             const uint32_t src_topk_idx = src_token_topk_idx % kNumTopk;
 
-            // TMA load token from remote rank into shared memory
+            // Hidden bytes are divided into chunks
+            constexpr uint32_t kNumChunks = kHidden / kNumBytesPerPull;
+            DG_STATIC_ASSERT(kNumChunks * kNumBytesPerPull == kHidden, "kNumBytesPerPull must divide hidden");
+
+            // TMA load token from remote rank and store into local
+            const uint32_t pool_token_idx = expert_pool_block_offset * BLOCK_M + token_idx_in_expert;
+            const auto src_base_ptr = sym_buffer.map(
+                input_token_buffer.get_data_buffer(src_token_idx).get_base_ptr(), current_rank_in_expert_idx);
+            const auto dst_base_ptr = l1_token_buffer.get_data_buffer(pool_token_idx).get_base_ptr();
+            const auto issue_and_wait_pull_store = [&](const uint32_t& i) {
+                ptx::mbarrier_wait_and_flip_phase(pull_mbarrier, pull_mbarrier_phase);
+                ptx::tma_store_1d(
+                    math::advance_ptr(dst_base_ptr, i * kNumBytesPerPull),
+                    pull_buffer.get_base_ptr(), kNumBytesPerPull
+                );
+                cute::tma_store_arrive();
+                ptx::tma_store_wait<0>();
+            };
             if (cute::elect_one_sync()) {
-                ptx::tma_load_1d(
-                    pull_buffer.get_base_ptr(),
-                    sym_buffer.map(input_token_buffer.get_data_buffer(src_token_idx).get_base_ptr(),
-                                   current_rank_in_expert_idx),
-                    pull_mbarrier, kHidden);
+                #pragma unroll
+                for (uint32_t i = 0; i < kNumChunks; ++ i) {
+                    ptx::tma_load_1d(
+                        pull_buffer.get_base_ptr(),
+                        math::advance_ptr(src_base_ptr, i * kNumBytesPerPull),
+                        pull_mbarrier, kNumBytesPerPull
+                    );
+                    ptx::mbarrier_arrive_and_set_tx(pull_mbarrier, kNumBytesPerPull);
+                    i != (kNumChunks - 1) ? issue_and_wait_pull_store(i) : void();
+                }
             }
             __syncwarp();
 
-            // Load and store SF (overlaps with TMA token load)
+            // Load and store SF (overlaps with last chunk's TMA load from remote)
             constexpr uint32_t kNumSFUint32 = kHidden / 128;
             DG_STATIC_ASSERT(kNumSFUint32 > 0 and kHidden % 128 == 0, "Invalid SF");
             const auto remote_sf_ptr = sym_buffer.map(
@@ -571,8 +564,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
             }
             __syncwarp();
 
-            // Store weights and token data
-            const uint32_t pool_token_idx = expert_pool_block_offset * BLOCK_M + token_idx_in_expert;
+            // Store weights and metadata
             if (cute::elect_one_sync()) {
                 // Load weights
                 const auto weight = *sym_buffer.map(
@@ -580,22 +572,12 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                     current_rank_in_expert_idx);
                 *l1_topk_weights_buffer.get_data_buffer(pool_token_idx).get_base_ptr<float>() = weight;
 
-                // Wait for TMA token load to complete
-                ptx::mbarrier_arrive_and_set_tx(pull_mbarrier, kHidden);
-                ptx::mbarrier_wait_and_flip_phase(pull_mbarrier, pull_mbarrier_phase);
-
-                // Store token to local L1 buffer via TMA
-                ptx::tma_store_1d(
-                    l1_token_buffer.get_data_buffer(pool_token_idx).get_base_ptr(),
-                    pull_buffer.get_base_ptr(), pull_buffer.get_num_bytes());
-
                 // Write source metadata for combine write-back
                 *workspace.get_token_src_metadata_ptr(pool_token_idx) =
                     {current_rank_in_expert_idx, src_token_idx, src_topk_idx};
 
-                // Wait for token TMA store to complete
-                cute::tma_store_arrive();
-                ptx::tma_store_wait<0>();
+                // Complete last chunk's store
+                issue_and_wait_pull_store(kNumChunks - 1);
                 ptx::red_add_rel(
                     workspace.get_l1_arrival_count_ptr(expert_pool_block_offset + token_idx_in_expert / BLOCK_M), 1);
             }
@@ -690,23 +672,25 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                 // guarantees L1's completion when L2 starts. So we remove it.
                 // In the future, if `num_experts_per_wave` is not large enough
                 // due to small `num_experts_per_rank`, we may need to add it back or add a switch
-                DG_STATIC_ASSERT(BLOCK_K == BLOCK_N, "Invalid block sizes");
+                DG_STATIC_ASSERT(BLOCK_K % BLOCK_N == 0, "Invalid block sizes");
                 const auto ptr = workspace.get_l2_arrival_mask_ptr(pool_block_idx);
-                // NOTES: Equivalent to `(1ull << (2 * num_k_blocks)) - 1`, but split into two shifts
-                // to avoid undefined behavior when `num_k_blocks == 32`
-                const uint64_t expected = ((1ull << num_k_blocks) << num_k_blocks) - 1;
-                while (ptx::ld_acq_gpu(ptr) != expected);
+
+                constexpr uint32_t kShiftOffset = (L2_SHAPE_K / BLOCK_N) * 2;
+                DG_STATIC_ASSERT(kShiftOffset <= 64, "Invalid shift amount");
+                constexpr uint64_t kExpectedMask = kShiftOffset == 64 ?
+                    static_cast<uint64_t>(-1) : (1ull << kShiftOffset) - 1;
+                while (ptx::ld_acq_gpu(ptr) != kExpectedMask);
             }
 
             for (uint32_t k_block_idx = 0; k_block_idx < num_k_blocks; advance_pipeline(k_block_idx)) {
                 // Wait consumer release
-                empty_barriers[stage_idx]->wait(phase ^ 1);
+                shared_storage.empty_barriers[stage_idx].wait(phase ^ 1);
 
                 // Compute token offset from pool block index
                 uint32_t m_idx = pool_block_idx * BLOCK_M;
                 uint32_t k_idx = k_block_idx * BLOCK_K;
                 uint32_t sfa_m_idx = pool_block_idx * SF_BLOCK_M;
-                uint32_t sfa_k_idx = k_block_idx;
+                uint32_t sfa_k_idx = k_block_idx * (BLOCK_K / 128);
 
                 // Add 2 CTA offsets for non-leader CTA
                 if (not is_leader_cta)
@@ -715,13 +699,13 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                 // TMA copy tokens and SFA, then arrive at full barrier
                 if (cute::elect_one_sync()) {
                     tma::copy<BLOCK_K, LOAD_BLOCK_M, kSwizzleAMode, a_dtype_t>(
-                        tensor_map_a_ptr, full_barriers[stage_idx], smem_a[stage_idx], k_idx, m_idx, 2);
+                        tensor_map_a_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_a[stage_idx], k_idx, m_idx, 2);
                     tma::copy<SF_BLOCK_M, 1, 0>(
-                        tensor_map_sfa_ptr, full_barriers[stage_idx], smem_sfa[stage_idx], sfa_m_idx, sfa_k_idx, 2);
+                        tensor_map_sfa_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_sfa[stage_idx], sfa_m_idx, sfa_k_idx, 2);
                     if (is_leader_cta) {
-                        full_barriers[stage_idx]->arrive_and_expect_tx(SMEM_A_SIZE_PER_STAGE * 2 + SF_BLOCK_M * sizeof(uint32_t) * 2);
+                        shared_storage.full_barriers[stage_idx].arrive_and_expect_tx(sizeof(SharedStorage::smem_a[0]) * 2 + sizeof(SharedStorage::smem_sfa[0]) * 2);
                     } else {
-                        full_barriers[stage_idx]->arrive(0u);
+                        shared_storage.full_barriers[stage_idx].arrive(0u);
                     }
                 }
                 __syncwarp();
@@ -747,24 +731,24 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
 
             for (uint32_t k_block_idx = 0; k_block_idx < num_k_blocks; advance_pipeline(k_block_idx)) {
                 // Wait consumer release
-                empty_barriers[stage_idx]->wait(phase ^ 1);
+                shared_storage.empty_barriers[stage_idx].wait(phase ^ 1);
 
                 // Compute weight offset
                 uint32_t n_idx = local_expert_idx * shape_n + n_block_idx * BLOCK_N;
                 uint32_t k_idx = k_block_idx * BLOCK_K;
                 uint32_t sfb_n_idx = n_block_idx * BLOCK_N;
-                uint32_t sfb_k_idx = local_expert_idx * shape_sfb_k + k_block_idx;
+                uint32_t sfb_k_idx = local_expert_idx * shape_sfb_k + k_block_idx * (BLOCK_K / 128);
 
                 // TMA copy weights with SF
                 if (cute::elect_one_sync()) {
                     tma::copy<BLOCK_K, LOAD_BLOCK_N, kSwizzleBMode, b_dtype_t>(
-                        tensor_map_b_ptr, full_barriers[stage_idx], smem_b[stage_idx], k_idx, n_idx, 2);
+                        tensor_map_b_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_b[stage_idx], k_idx, n_idx, 2);
                     tma::copy<BLOCK_N, 1, 0>(
-                        tensor_map_sfb_ptr, full_barriers[stage_idx], smem_sfb[stage_idx], sfb_n_idx, sfb_k_idx, 2);
+                        tensor_map_sfb_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_sfb[stage_idx], sfb_n_idx, sfb_k_idx, 2);
                     if (is_leader_cta) {
-                        full_barriers[stage_idx]->arrive_and_expect_tx(SMEM_B_SIZE_PER_STAGE + BLOCK_N * sizeof(uint32_t) * 2);
+                        shared_storage.full_barriers[stage_idx].arrive_and_expect_tx(sizeof(SharedStorage::smem_b[0]) + sizeof(SharedStorage::smem_sfb[0]) * 2);
                     } else {
-                        full_barriers[stage_idx]->arrive(0u);
+                        shared_storage.full_barriers[stage_idx].arrive(0u);
                     }
                 }
                 __syncwarp();
@@ -786,10 +770,10 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
             auto sf_desc = mma::sm100::make_sf_desc(nullptr);
 
             DG_STATIC_ASSERT(kNumStages <= 32, "Too many stages");
-            auto a_desc = mma::sm100::make_umma_desc<cute::UMMA::Major::K, LOAD_BLOCK_M, BLOCK_K, kSwizzleAMode>(smem_a[0], 0, 0);
-            auto b_desc = mma::sm100::make_umma_desc<cute::UMMA::Major::K, LOAD_BLOCK_N, BLOCK_K, kSwizzleBMode>(smem_b[0], 0, 0);
-            uint32_t a_desc_lo = lane_idx < kNumStages ? a_desc.lo + lane_idx * SMEM_A_SIZE_PER_STAGE / 16 : 0u;
-            uint32_t b_desc_lo = lane_idx < kNumStages ? b_desc.lo + lane_idx * SMEM_B_SIZE_PER_STAGE / 16 : 0u;
+            auto a_desc = mma::sm100::make_umma_desc<cute::UMMA::Major::K, LOAD_BLOCK_M, UMMA_BLOCK_K, kSwizzleAMode>(shared_storage.smem_a[0], 0, 0);
+            auto b_desc = mma::sm100::make_umma_desc<cute::UMMA::Major::K, LOAD_BLOCK_N, UMMA_BLOCK_K, kSwizzleBMode>(shared_storage.smem_b[0], 0, 0);
+            uint32_t a_desc_lo = lane_idx < kNumStages ? a_desc.lo + lane_idx * sizeof(SharedStorage::smem_a[0]) / 16 : 0u;
+            uint32_t b_desc_lo = lane_idx < kNumStages ? b_desc.lo + lane_idx * sizeof(SharedStorage::smem_b[0]) / 16 : 0u;
 
             // Checks for MMA instructions
             DG_STATIC_ASSERT((UMMA_M == 64  and UMMA_N %  8 == 0 and  8 <= UMMA_N and UMMA_N <= 256) or
@@ -809,7 +793,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                 // Wait tensor memory empty barrier arrival
                 const auto accum_stage_idx = current_iter_idx % kNumEpilogueStages;
                 const auto accum_phase = (current_iter_idx ++ / kNumEpilogueStages) & 1;
-                tmem_empty_barriers[accum_stage_idx]->wait(accum_phase ^ 1);
+                shared_storage.tmem_empty_barriers[accum_stage_idx].wait(accum_phase ^ 1);
                 ptx::tcgen05_after_thread_sync();
 
                 // Empty barrier arrival
@@ -818,11 +802,11 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                         constexpr uint16_t kCTAMask = (1 << 2) - 1;
                         cutlass::arch::umma_arrive_multicast_2x1SM(barrier, kCTAMask);
                     };
-                    umma_arrive(reinterpret_cast<uint64_t*>(empty_barriers[stage_idx]));
+                    umma_arrive(reinterpret_cast<uint64_t*>(&shared_storage.empty_barriers[stage_idx]));
 
                     // NOTES: the tensor memory accumulator pipeline has nothing to do with multicasting
                     if (do_tmem_full_arrive)
-                        umma_arrive(reinterpret_cast<uint64_t*>(tmem_full_barriers[accum_stage_idx]));
+                        umma_arrive(reinterpret_cast<uint64_t*>(&shared_storage.tmem_full_barriers[accum_stage_idx]));
                     __syncwarp();
                 };
 
@@ -830,40 +814,43 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                 #pragma unroll 2
                 for (uint32_t k_block_idx = 0; k_block_idx < num_k_blocks; advance_pipeline(k_block_idx)) {
                     // Wait TMA load completion
-                    full_barriers[stage_idx]->wait(phase);
+                    shared_storage.full_barriers[stage_idx].wait(phase);
                     ptx::tcgen05_after_thread_sync();
 
                     const auto a_desc_base_lo = ptx::exchange(a_desc_lo, stage_idx);
                     const auto b_desc_base_lo = ptx::exchange(b_desc_lo, stage_idx);
                     if (cute::elect_one_sync()) {
-                        // UTCCP copy SFA and SFB to TMEM
-                        using cute_utccp_t = cute::SM100_UTCCP_4x32dp128bit_2cta;
                         #pragma unroll
-                        for (uint32_t i = 0; i < SF_BLOCK_M / kNumUTCCPAlignedElems; ++ i) {
-                            auto smem_ptr = smem_sfa[stage_idx] + i * kNumUTCCPAlignedElems;
-                            mma::sm100::replace_smem_desc_addr(sf_desc, smem_ptr);
-                            cute_utccp_t::copy(sf_desc, kTmemStartColOfSFA + i * 4);
-                        }
-                        #pragma unroll
-                        for (uint32_t i = 0; i < SF_BLOCK_N / kNumUTCCPAlignedElems; ++ i) {
-                            auto smem_ptr = smem_sfb[stage_idx] + i * kNumUTCCPAlignedElems;
-                            mma::sm100::replace_smem_desc_addr(sf_desc, smem_ptr);
-                            cute_utccp_t::copy(sf_desc, kTmemStartColOfSFB + i * 4);
-                        }
+                        for (uint32_t umma_k_block_idx = 0; umma_k_block_idx < BLOCK_K / UMMA_BLOCK_K; ++ umma_k_block_idx) {
+                            // UTCCP copy SFA and SFB to TMEM
+                            using cute_utccp_t = cute::SM100_UTCCP_4x32dp128bit_2cta;
+                            #pragma unroll
+                            for (uint32_t i = 0; i < SF_BLOCK_M / kNumUTCCPAlignedElems; ++ i) {
+                                auto smem_ptr = shared_storage.smem_sfa[stage_idx] + umma_k_block_idx * SF_BLOCK_M + i * kNumUTCCPAlignedElems;
+                                mma::sm100::replace_smem_desc_addr(sf_desc, smem_ptr);
+                                cute_utccp_t::copy(sf_desc, kTmemStartColOfSFA + i * 4);
+                            }
+                            #pragma unroll
+                            for (uint32_t i = 0; i < SF_BLOCK_N / kNumUTCCPAlignedElems; ++ i) {
+                                auto smem_ptr = shared_storage.smem_sfb[stage_idx] + umma_k_block_idx * SF_BLOCK_N + i * kNumUTCCPAlignedElems;
+                                mma::sm100::replace_smem_desc_addr(sf_desc, smem_ptr);
+                                cute_utccp_t::copy(sf_desc, kTmemStartColOfSFB + i * 4);
+                            }
 
-                        // Issue UMMA
-                        #pragma unroll
-                        for (uint32_t k = 0; k < BLOCK_K / UMMA_K; ++ k) {
-                            const auto runtime_instr_desc =
-                                mma::sm100::make_runtime_instr_desc_with_sf_id(instr_desc, k, k);
-                            a_desc.lo = mma::sm100::advance_umma_desc_lo<
-                                cute::UMMA::Major::K, LOAD_BLOCK_M, kSwizzleAMode, a_dtype_t>(a_desc_base_lo, 0, k * UMMA_K);
-                            b_desc.lo = mma::sm100::advance_umma_desc_lo<
-                                cute::UMMA::Major::K, LOAD_BLOCK_N, kSwizzleBMode, b_dtype_t>(b_desc_base_lo, 0, k * UMMA_K);
-                            ptx::SM100_MMA_MXF8F6F4_2x1SM_SS::fma(
-                                b_desc, a_desc, accum_stage_idx * UMMA_N,
-                                k_block_idx > 0 or k > 0, runtime_instr_desc,
-                                kTmemStartColOfSFB, kTmemStartColOfSFA);
+                            // Issue UMMA
+                            #pragma unroll
+                            for (uint32_t k = 0; k < UMMA_BLOCK_K / UMMA_K; ++ k) {
+                                const auto runtime_instr_desc =
+                                    mma::sm100::make_runtime_instr_desc_with_sf_id(instr_desc, k, k);
+                                a_desc.lo = mma::sm100::advance_umma_desc_lo<
+                                    cute::UMMA::Major::K, LOAD_BLOCK_M, kSwizzleAMode, a_dtype_t>(a_desc_base_lo, umma_k_block_idx * UMMA_BLOCK_K * LOAD_BLOCK_M * sizeof(a_dtype_t), k * UMMA_K);
+                                b_desc.lo = mma::sm100::advance_umma_desc_lo<
+                                    cute::UMMA::Major::K, LOAD_BLOCK_N, kSwizzleBMode, b_dtype_t>(b_desc_base_lo, umma_k_block_idx * UMMA_BLOCK_K * LOAD_BLOCK_N * sizeof(b_dtype_t), k * UMMA_K);
+                                ptx::SM100_MMA_MXF8F6F4_2x1SM_SS::fma(
+                                    b_desc, a_desc, accum_stage_idx * UMMA_N,
+                                    k_block_idx > 0 or umma_k_block_idx > 0 or k > 0, runtime_instr_desc,
+                                    kTmemStartColOfSFB, kTmemStartColOfSFA);
+                            }
                         }
                     }
                     __syncwarp();
@@ -877,7 +864,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
             // To safely deconstruct barriers, we need another round of waits
             if (current_iter_idx > 0) {
                 const auto accum_phase_idx = ((current_iter_idx - 1) / kNumEpilogueStages) & 1;
-                tmem_empty_barriers[(current_iter_idx - 1) % kNumEpilogueStages]->wait(accum_phase_idx);
+                shared_storage.tmem_empty_barriers[(current_iter_idx - 1) % kNumEpilogueStages].wait(accum_phase_idx);
             }
         }
     } else if (warp_idx == kNumDispatchWarps + 3) {
@@ -891,7 +878,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
         // NOTES: tensor memory addresses are simplified, as the hardware will ignore the warp index bits,
         // i.e., no need for `tmem_ptr |= (epilogue_warp_idx * 32) << 16`.
         // NOTES: we also forbid two CTAs to share the same SM and its tensor memory
-        DG_TRAP_ONLY_DEVICE_ASSERT(ptx::ld_shared(tmem_ptr_in_smem) == 0);
+        DG_TRAP_ONLY_DEVICE_ASSERT(ptx::ld_shared(&shared_storage.tmem_ptr_in_smem) == 0);
 
         // GEMM epilogue warps
         const auto epilogue_warp_idx = warp_idx - (kNumDispatchWarps + kNumMMANonEpilogueWarps);
@@ -928,7 +915,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
             // Wait UMMA arrival
             const auto accum_stage_idx = current_iter_idx % kNumEpilogueStages;
             const auto accum_phase = (current_iter_idx ++ / kNumEpilogueStages) & 1;
-            tmem_full_barriers[accum_stage_idx]->wait(accum_phase);
+            shared_storage.tmem_full_barriers[accum_stage_idx].wait(accum_phase);
             ptx::tcgen05_after_thread_sync();
 
             // Compute offsets
@@ -941,8 +928,6 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
             if (block_phase == sched::BlockPhase::Linear1) {
                 // Unified L1 epilogue: SwiGLU in-place using granularity 8 interleaved weights
                 // With `SM100_TMEM_LOAD_16dp256b1x`, gate/up pairs are:
-                //   (values[0], values[2]), (values[1], values[3]),
-                //   (values[4], values[6]), (values[5], values[7])
                 float stored_cached_weight = 0;
 
                 #pragma unroll
@@ -950,7 +935,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                     // Early break if the entire store block is beyond the valid token range
                     if (epilogue_wg_idx * WG_BLOCK_M + s * STORE_BLOCK_M >= valid_m) {
                         ptx::tcgen05_before_thread_sync();
-                        tmem_empty_barriers[accum_stage_idx]->arrive(0u);
+                        shared_storage.tmem_empty_barriers[accum_stage_idx].arrive(0u);
                         break;
                     }
 
@@ -976,27 +961,25 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                         };
 
                         // Load from TMEM
+                        uint2 raw_values[4];
                         uint32_t tmem_addr = accum_stage_idx * UMMA_N + epilogue_wg_idx * WG_BLOCK_M + j * ATOM_M;
-                        uint32_t values[ATOM_M];
                         cute::SM100_TMEM_LOAD_16dp256b1x::copy(tmem_addr,
-                                                               values[0], values[1], values[2], values[3]);
+                                                               raw_values[0].x, raw_values[0].y, raw_values[1].x, raw_values[1].y);
                         cute::SM100_TMEM_LOAD_16dp256b1x::copy(tmem_addr | 0x00100000,
-                                                               values[4], values[5], values[6], values[7]);
+                                                               raw_values[2].x, raw_values[2].y, raw_values[3].x, raw_values[3].y);
                         cutlass::arch::fence_view_async_tmem_load();
 
                         // Signal tensor memory consumed on the last atom
                         if (j == WG_BLOCK_M / ATOM_M - 1) {
                             ptx::tcgen05_before_thread_sync();
-                            tmem_empty_barriers[accum_stage_idx]->arrive(0u);
+                            shared_storage.tmem_empty_barriers[accum_stage_idx].arrive(0u);
                         }
 
-                        // Apply SwiGLU: silu(gate) * up
-                        // Gate/up pairs: (0, 2), (1, 3), (4, 6), (5, 7)
-                        auto fp32_values = reinterpret_cast<float*>(values);
+                        auto fp32_values = reinterpret_cast<float2*>(raw_values);
                         #pragma unroll
                         for (uint32_t k = 0; k < 2; ++ k) {
-                            auto bf16_gate = __float22bfloat162_rn(make_float2(fp32_values[k * 4], fp32_values[k * 4 + 1]));
-                            auto bf16_up = __float22bfloat162_rn(make_float2(fp32_values[k * 4 + 2], fp32_values[k * 4 + 3]));
+                            auto bf16_gate = __float22bfloat162_rn(fp32_values[k * 2 + 0]);
+                            auto bf16_up =   __float22bfloat162_rn(fp32_values[k * 2 + 1]);
 
                             // Clamp
                             if constexpr (kActivationClamp != cute::numeric_limits<float>::infinity()) {
@@ -1028,12 +1011,12 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                             cute::max(cute::abs(swiglu_values[i * 2 + 0].y), cute::abs(swiglu_values[i * 2 + 1].y)),
                             math::ReduceMax<float>());
                         if (lane_idx < 4)
-                            smem_amax_reduction[epilogue_warp_idx * (STORE_BLOCK_M / 2) + i * (ATOM_M / 2) + lane_idx] = amax_values[i];
+                            shared_storage.amax_reduction[epilogue_warp_idx][i * (ATOM_M / 2) + lane_idx] = amax_values[i];
                         __syncwarp();
                     }
 
                     // Wait shared memory release from previous TMA store
-                    // And fence `smem_amax_reduction`
+                    // And fence `shared_storage.amax_reduction`
                     const uint32_t tma_stage_idx = s % kNumTMAStoreStages;
                     ptx::tma_store_wait<kNumTMAStoreStages - 1>();
                     ptx::sync_aligned(128, kEpilogueWGBarrierStartIdx + epilogue_wg_idx);
@@ -1043,7 +1026,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                     for (uint32_t i = 0; i < kNumAtomsPerStore; ++ i) {
                         // Reduce amax
                         const float2 wp_amax =
-                            smem_amax_reduction[(epilogue_warp_idx ^ 1) * (STORE_BLOCK_M / 2) + i * (ATOM_M / 2) + lane_idx % 4];
+                            shared_storage.amax_reduction[epilogue_warp_idx ^ 1][i * (ATOM_M / 2) + lane_idx % 4];
                         amax_values[i].x = cute::max(amax_values[i].x, wp_amax.x);
                         amax_values[i].y = cute::max(amax_values[i].y, wp_amax.y);
 
@@ -1059,17 +1042,18 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                         // STSM
                         uint32_t row = lane_idx;
                         uint32_t col = warp_idx_in_wg;
-                        const auto smem_ptr = smem_cd[tma_stage_idx] + epilogue_wg_idx * STORE_BLOCK_M * L1_OUT_BLOCK_N
-                                                                     + i * ATOM_M * L1_OUT_BLOCK_N
-                                                                     + row * L1_OUT_BLOCK_N
-                                                                     + (col ^ (row / 2)) * kNumBankGroupBytes;
+                        const auto smem_ptr = reinterpret_cast<uint8_t*>(shared_storage.smem_d.l1[epilogue_wg_idx][tma_stage_idx])
+                            + i * ATOM_M * L1_OUT_BLOCK_N
+                            + row * L1_OUT_BLOCK_N
+                            // Use 64B swizzle for SwiGLU, so divided by 2
+                            + (col ^ (row / 2)) * kNumBankGroupBytes;
                         ptx::SM100_U8x4_STSM_T<__nv_fp8x4_e4m3>::copy(fp8x4_values, smem_ptr);
 
                         // Store SF to `l2_sf_buffer` as UE8M0 (MN-major layout)
                         // Only one warp per pair writes (both hold the same SF after cross-warp reduce)
                         // Each lane < 4 holds SF for 2 rows (sf.x and sf.y)
                         if (warp_idx_in_wg % 2 == 0 and lane_idx < 4) {
-                            const uint32_t k_idx = n_block_idx * 2 + warp_idx_in_wg / 2;
+                            const uint32_t k_idx = n_block_idx * (BLOCK_N / kGranK / 2) + warp_idx_in_wg / 2;
                             const uint32_t k_uint_idx = k_idx / 4, byte_idx = k_idx % 4;
                             const uint32_t mn_stride = kNumPaddedSFPoolTokens * sizeof(uint32_t);
                             const auto sf_base_ptr = l2_sf_buffer.get_base_ptr<uint8_t>();
@@ -1101,7 +1085,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                         cute::tma_store_fence();
                         cute::SM90_TMA_STORE_2D::copy(
                             &tensor_map_l1_output,
-                            smem_cd[tma_stage_idx] + epilogue_wg_idx * STORE_BLOCK_M * L1_OUT_BLOCK_N,
+                            shared_storage.smem_d.l1[epilogue_wg_idx][tma_stage_idx],
                             out_n_idx,
                             m_idx + epilogue_wg_idx * WG_BLOCK_M + s * STORE_BLOCK_M);
                         cute::tma_store_arrive();
@@ -1132,7 +1116,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                     // TODO: check performance
                     if (epilogue_wg_idx * WG_BLOCK_M + s * STORE_BLOCK_M >= valid_m) {
                         ptx::tcgen05_before_thread_sync();
-                        tmem_empty_barriers[accum_stage_idx]->arrive(0u);
+                        shared_storage.tmem_empty_barriers[accum_stage_idx].arrive(0u);
                         break;
                     }
 
@@ -1156,16 +1140,14 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                         // Signal tensor memory consumed
                         if (s == WG_BLOCK_M / STORE_BLOCK_M - 1 and i == STORE_BLOCK_M / ATOM_M - 1) {
                             ptx::tcgen05_before_thread_sync();
-                            tmem_empty_barriers[accum_stage_idx]->arrive(0u);
+                            shared_storage.tmem_empty_barriers[accum_stage_idx].arrive(0u);
                         }
 
                         // Store into shared memory
-                        // NOTES: only use first 16 lanes for address
-                        // NOTES: 2 warps share a BF16 swizzle atom
+                        // NOTES: each lane provides its own address for stmatrix; 2 warps share a BF16 swizzle atom
                         uint32_t row = lane_idx % 8;
                         uint32_t col = (epilogue_warp_idx % 2) * 4 + lane_idx / 8;
-                        const auto smem_ptr = smem_cd_l2 +
-                            epilogue_wg_idx * STORE_BLOCK_M * BLOCK_N * static_cast<uint32_t>(sizeof(nv_bfloat16)) +
+                        const auto smem_ptr = reinterpret_cast<uint8_t*>(shared_storage.smem_d.l2[epilogue_wg_idx]) +
                             (warp_idx_in_wg / 2) * STORE_BLOCK_M * kSwizzleCDMode +
                             i * ATOM_M * kSwizzleCDMode +
                             row * (kNumBankGroupBytes * 8) +
@@ -1183,7 +1165,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                     ptx::sync_aligned(128, kEpilogueWGBarrierStartIdx + epilogue_wg_idx);
 
                     // Write into remote buffers
-                    // One warp per row, now the layout is different from shared memory storing
+                    // Each warp writes 2 rows (lane_idx/16 splits the warp into two halves, one per row)
                     const uint32_t row_in_atom = (warp_idx_in_wg * 2 + lane_idx / 16) % ATOM_M;
                     const uint32_t bank_group_idx = lane_idx % 8;
 
@@ -1202,8 +1184,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                         const uint32_t dst_topk_idx = src_metadata.topk_idx;
 
                         // Read from shared memory
-                        const auto smem_ptr = smem_cd_l2 +
-                            epilogue_wg_idx * STORE_BLOCK_M * BLOCK_N * static_cast<uint32_t>(sizeof(nv_bfloat16)) +
+                        const auto smem_ptr = reinterpret_cast<uint8_t*>(shared_storage.smem_d.l2[epilogue_wg_idx]) +
                             (lane_idx % 16 / 8) * STORE_BLOCK_M * kSwizzleCDMode +
                             row_in_store * kSwizzleCDMode +
                             (bank_group_idx ^ row_in_atom) * kNumBankGroupBytes;
@@ -1252,20 +1233,19 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
         // NOTES: either 1 or 2 chunks for simplicity
         // NOTES: Restrict on both smem and register
         constexpr uint32_t kNumChunks =
-            kNumChunkSlots * kNumEpilogueWarps * kNumHiddenBytes <= SMEM_BEFORE_BARRIER_SIZE and kHidden <= 32 * kNumMaxRegistersForBuffer ? 1 : 2;
+            kNumChunkSlots * kNumEpilogueWarps * kNumHiddenBytes <= kNumReusableSmemBytes and kHidden <= 32 * kNumMaxRegistersForBuffer ? 1 : 2;
         constexpr uint32_t kNumChunkBytes = kNumHiddenBytes / kNumChunks;
         constexpr uint32_t kNumChunkUint4 = kNumChunkBytes / sizeof(uint4);
         constexpr uint32_t kNumUint4PerLane = kNumChunkUint4 / 32;
         DG_STATIC_ASSERT(kHidden % kNumChunks == 0, "Hidden must be divisible by number of chunks");
-        DG_STATIC_ASSERT(kNumChunkSlots * kNumEpilogueWarps * kNumHiddenBytes / kNumChunks <= SMEM_BEFORE_BARRIER_SIZE, "Hidden is too large");
+        DG_STATIC_ASSERT(kNumChunkSlots * kNumEpilogueWarps * kNumHiddenBytes / kNumChunks <= kNumReusableSmemBytes, "Hidden is too large");
         DG_STATIC_ASSERT(kNumChunkBytes % 16 == 0, "Combine chunk must be TMA-aligned (16 bytes)");
         DG_STATIC_ASSERT(kNumChunkBytes % sizeof(uint4) == 0, "Combine chunk must be divisible by 16 bytes");
         DG_STATIC_ASSERT(kNumChunkUint4 % 32 == 0, "Combine chunk must be a multiple of 32 16-byte elements (one per lane)");
         DG_STATIC_ASSERT(kNumTopk <= 32, "Top-k must fit in a single warp");
 
         // Verify combined shared memory budget at runtime
-        DG_DEVICE_ASSERT(kNumChunkSlots * kNumEpilogueWarps * kNumChunkBytes <= static_cast<uint32_t>(
-            reinterpret_cast<uint8_t*>(barrier_start_ptr) - smem_buffer));
+        DG_DEVICE_ASSERT(kNumChunkSlots * kNumEpilogueWarps * kNumChunkBytes <= kNumReusableSmemBytes);
 
         // Per-warp buffer: 2 stage load buffers + 1 store buffer
         const auto combine_load_buffer = utils::PatternVisitor([&](const uint32_t& i) {
@@ -1275,7 +1255,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
 
         // Per-warp barriers
         auto combine_load_barriers = utils::PatternVisitor([&](const uint32_t& i) {
-            return combine_barriers[i + epilogue_warp_idx * 2];
+            return &shared_storage.combine_barriers[i + epilogue_warp_idx * 2];
         });
 
         // Iterate over all tokens

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp8_paged_mqa_logits.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp8_paged_mqa_logits.cuh
@@ -184,8 +184,7 @@ void sm100_fp8_paged_mqa_logits(const uint32_t batch_size,
 
         while (fetched_next_task) {
             // Prefetch next Q when (q, atom) changes
-            const auto next_advance = scheduler.get_atom_advance(next_q_atom_idx, batch_size);
-            bool prefetch_q = (q_atom_idx != next_q_atom_idx) and scheduler.exist_q_atom_idx(next_q_atom_idx + next_advance);
+            bool prefetch_q = (q_atom_idx != next_q_atom_idx) and scheduler.exist_q_atom_idx(next_q_atom_idx + scheduler.get_last_advance());
 
             if (q_atom_idx != next_q_atom_idx)
                 kv_block_idx_ptr = 32;
@@ -209,7 +208,7 @@ void sm100_fp8_paged_mqa_logits(const uint32_t batch_size,
             if (prefetch_q) {
                 CUTE_TIE_DECL(get_q_pipeline(q_iter_idx ++), q_stage_idx, q_phase);
                 empty_q_barriers[q_stage_idx]->wait(q_phase ^ 1);
-                issue_tma_q(q_stage_idx, q_atom_idx + next_advance);
+                issue_tma_q(q_stage_idx, next_q_atom_idx + scheduler.get_last_advance());
             }
 
             uint32_t kv_block_idx[kNumBlocksPerSplit];
@@ -347,7 +346,7 @@ void sm100_fp8_paged_mqa_logits(const uint32_t batch_size,
                 }
 
                 if constexpr (kIsVarlen) {
-                    is_paired_atom = (scheduler.get_atom_advance(next_q_atom_idx, batch_size) == 2);
+                    is_paired_atom = (scheduler.get_last_advance() == 2);
                 }
             }
 

--- a/deep_gemm/include/deep_gemm/impls/sm90_bf16_gemm.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm90_bf16_gemm.cuh
@@ -11,6 +11,7 @@
 #include <cute/arch/copy_sm90_tma.hpp>
 #include <cute/arch/mma_sm100_desc.hpp>
 
+#include <deep_gemm/comm/barrier.cuh>
 #include <deep_gemm/common/math.cuh>
 #include <deep_gemm/common/utils.cuh>
 #include <deep_gemm/common/tma_copy.cuh>
@@ -59,6 +60,9 @@ sm90_bf16_gemm_impl(int* grouped_layout,
     using WGMMA = typename mma::sm90::BF16MMASelector<BLOCK_N, kMajorA, kMajorB>::type;
     using Barrier = cutlass::arch::ClusterTransactionBarrier;
     DG_STATIC_ASSERT(BLOCK_M % WGMMA::M == 0 or BLOCK_M < WGMMA::M, "Invalid block size");
+
+    // C/D type: BF16 and FP32 are supported, with or without accumulation
+    DG_STATIC_ASSERT(cute::is_same_v<cd_dtype_t, float> or cute::is_same_v<cd_dtype_t, cutlass::bfloat16_t>, "Invalid C/D data dtype");
 
     // Overwrite shape constants if the compiler gives
     shape_m = SHAPE_M != 0 ? SHAPE_M : shape_m;
@@ -118,7 +122,7 @@ sm90_bf16_gemm_impl(int* grouped_layout,
     }
 
     // Synchronize all threads to make barrier visible in normal memory model
-    (kNumTMAMulticast > 1) ? cute::cluster_sync() : __syncthreads();
+    (kNumTMAMulticast > 1) ? comm::cluster_sync_with_relaxed_arrive() : __syncthreads();
 
     // Register reconfigurations
     constexpr uint32_t kNumTMARegisters = 48;
@@ -363,9 +367,11 @@ sm90_bf16_gemm_impl(int* grouped_layout,
                 auto in_block_n_offset = threadIdx.x * TMA_D_BLOCK_N;
                 auto smem_ptr = smem_d + in_block_n_offset * BLOCK_M;
                 if constexpr (kGemmType == GemmType::Batched) {
-                    cute::SM90_TMA_STORE_3D::copy(&tensor_map_cd, smem_ptr,
-                                                  n_block_idx * BLOCK_N + in_block_n_offset,
-                                                  m_idx, scheduler.current_group_idx);
+                    using cute_tma_t = cute::conditional_t<kWithAccumulation,
+                        cute::SM90_TMA_REDUCE_ADD_3D, cute::SM90_TMA_STORE_3D>;
+                    cute_tma_t::copy(&tensor_map_cd, smem_ptr,
+                                     n_block_idx * BLOCK_N + in_block_n_offset,
+                                     m_idx, scheduler.current_group_idx);
                 } else {
                     using cute_tma_t = cute::conditional_t<kWithAccumulation,
                         cute::SM90_TMA_REDUCE_ADD_2D, cute::SM90_TMA_STORE_2D>;

--- a/deep_gemm/include/deep_gemm/impls/sm90_fp8_gemm_1d1d.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm90_fp8_gemm_1d1d.cuh
@@ -11,6 +11,7 @@
 #include <cute/arch/copy_sm90_desc.hpp>
 #include <cute/arch/copy_sm90_tma.hpp>
 
+#include <deep_gemm/comm/barrier.cuh>
 #include <deep_gemm/common/cute_tie.cuh>
 #include <deep_gemm/common/math.cuh>
 #include <deep_gemm/common/utils.cuh>
@@ -49,8 +50,10 @@ sm90_fp8_gemm_1d1d_impl(__nv_fp8_e4m3* gmem_a_ptr, __nv_fp8_e4m3* gmem_b_ptr,
     // Scaling checks
     DG_STATIC_ASSERT(kNumTMAThreads == 128 and kNumMathThreads % 128 == 0, "Invalid Threads");
     DG_STATIC_ASSERT(BLOCK_K == 128, "Only support per-128-channel FP8 scaling");
-    DG_STATIC_ASSERT(cute::is_same_v<cd_dtype_t, float>, "Invalid C/D data dtype");
     DG_STATIC_ASSERT(kGemmType == GemmType::Normal or kGemmType == GemmType::KGroupedContiguous, "Invalid GEMM type");
+
+    // C/D type: only FP32 with accumulation
+    DG_STATIC_ASSERT(cute::is_same_v<cd_dtype_t, float>, "Invalid C/D data dtype");
 
     // Types
     using WGMMA = typename mma::sm90::FP8MMASelector<BLOCK_N>::type;
@@ -142,7 +145,7 @@ sm90_fp8_gemm_1d1d_impl(__nv_fp8_e4m3* gmem_a_ptr, __nv_fp8_e4m3* gmem_b_ptr,
     }
 
     // Synchronize all threads to make barrier visible in normal memory model
-    (kNumTMAMulticast > 1) ? cute::cluster_sync() : __syncthreads();
+    (kNumTMAMulticast > 1) ? comm::cluster_sync_with_relaxed_arrive() : __syncthreads();
 
     // Pipeline unroll control
     constexpr uint32_t kNumPipelineUnrolls = (kGemmType == GemmType::KGroupedContiguous ? 0 : kNumStages);

--- a/deep_gemm/include/deep_gemm/impls/sm90_fp8_gemm_1d2d.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm90_fp8_gemm_1d2d.cuh
@@ -10,6 +10,7 @@
 #include <cute/arch/copy_sm90_desc.hpp>
 #include <cute/arch/copy_sm90_tma.hpp>
 
+#include <deep_gemm/comm/barrier.cuh>
 #include <deep_gemm/common/math.cuh>
 #include <deep_gemm/common/utils.cuh>
 #include <deep_gemm/common/tma_copy.cuh>
@@ -43,6 +44,7 @@ template <cute::UMMA::Major kMajorSFB,
           uint32_t kNumTMAThreads, uint32_t kNumMathThreads,
           uint32_t kNumTMAMulticast, bool kIsTMAMulticastOnA,
           uint32_t kNumSMs, GemmType kGemmType,
+          typename cd_dtype_t,
           typename epilogue_type_t>
 CUTLASS_GLOBAL __launch_bounds__(kNumTMAThreads + kNumMathThreads, 1) void
 sm90_fp8_gemm_1d2d_impl(float* sfb, int* grouped_layout,
@@ -57,6 +59,9 @@ sm90_fp8_gemm_1d2d_impl(float* sfb, int* grouped_layout,
     DG_STATIC_ASSERT(
         math::constexpr_ceil_div(BLOCK_N, BLOCK_K) == 1 or
         (math::constexpr_gcd(BLOCK_N, BLOCK_K) == BLOCK_N - BLOCK_K), "Too much B scales in a single block");
+
+    // C/D type: only BF16 without accumulation
+    DG_STATIC_ASSERT(cute::is_same_v<cd_dtype_t, cutlass::bfloat16_t>, "Invalid C/D data dtype");
 
     // Types
     using WGMMA = typename mma::sm90::FP8MMASelector<BLOCK_N>::type;
@@ -136,7 +141,7 @@ sm90_fp8_gemm_1d2d_impl(float* sfb, int* grouped_layout,
     }
 
     // Synchronize all threads to make barrier visible in normal memory model
-    (kNumTMAMulticast > 1) ? cute::cluster_sync() : __syncthreads();
+    (kNumTMAMulticast > 1) ? comm::cluster_sync_with_relaxed_arrive() : __syncthreads();
 
     // Register reconfigurations
     constexpr uint32_t kNumTMARegisters = 40;

--- a/deep_gemm/include/deep_gemm/layout/sym_buffer.cuh
+++ b/deep_gemm/include/deep_gemm/layout/sym_buffer.cuh
@@ -32,6 +32,9 @@ struct SymBuffer {
 
     template <typename ptr_t>
     CUTLASS_DEVICE ptr_t map(const ptr_t& ptr, const uint32_t& dst_rank_idx) const {
+        if constexpr (kNumRanks == 1)
+            return ptr;
+
         int64_t mapped_ptr = offsets[dst_rank_idx] + reinterpret_cast<int64_t>(ptr);
         return *reinterpret_cast<ptr_t*>(&mapped_ptr);
     }

--- a/deep_gemm/include/deep_gemm/ptx/ld_st.cuh
+++ b/deep_gemm/include/deep_gemm/ptx/ld_st.cuh
@@ -3,6 +3,8 @@
 #include <cuda/std/cstdint>
 #include <cuda_bf16.h>
 
+#include <deep_gemm/common/exception.cuh>
+
 namespace deep_gemm::ptx {
 
 // Compatibility: 256 bits LD/ST instructions
@@ -45,6 +47,18 @@ struct SM90_U32x2_STSM_N {
         const uint32_t src[2] = {*reinterpret_cast<uint32_t*>(&src_0), *reinterpret_cast<uint32_t*>(&src_1)};
         asm volatile("stmatrix.sync.aligned.x2.m8n8.shared.b16 [%0], {%1, %2};\n"
                      :: "l"(__cvta_generic_to_shared(smem_dst)), "r"(src[0]), "r"(src[1]));
+    }
+};
+
+template <typename dtype_t>
+struct SM90_U32x2_STSM_T {
+    CUTLASS_DEVICE static void
+    copy(dtype_t src_0, dtype_t src_1, void* smem_dst) {
+        DG_STATIC_ASSERT(sizeof(dtype_t) == sizeof(uint32_t), "Invalid dtype");
+        const uint32_t src[2] = {*reinterpret_cast<uint32_t*>(&src_0), *reinterpret_cast<uint32_t*>(&src_1)};
+        asm volatile("stmatrix.sync.aligned.x2.m8n8.shared.b16.trans [%0], {%1, %2};\n"
+                     :: "l"(__cvta_generic_to_shared(smem_dst)),
+                        "r"(src[0]), "r"(src[1]));
     }
 };
 
@@ -140,6 +154,7 @@ CUTLASS_DEVICE void st_shared(const __int128_t* ptr, __int128_t val) {
 
 CUTLASS_DEVICE void st_shared_bulk(void* smem_ptr, const uint32_t& num_bytes) {
     // `size` must be 64-bit before PTX ISA 9.0
+    DG_DEVICE_ASSERT(num_bytes % 8 == 0);
     asm volatile("st.bulk.weak.shared::cta [%0], %1, 0;" ::
                  "l"(__cvta_generic_to_shared(smem_ptr)), "l"(static_cast<uint64_t>(num_bytes)));
 }

--- a/deep_gemm/include/deep_gemm/ptx/utils.cuh
+++ b/deep_gemm/include/deep_gemm/ptx/utils.cuh
@@ -50,4 +50,13 @@ CUTLASS_DEVICE void accumulate(float2& a, nv_bfloat162 b) {
 #endif
 }
 
+CUTLASS_DEVICE nv_bfloat162
+cvt_f32x2_to_bf16x2_relu(const float& a, const float& b) {
+    nv_bfloat162 result;
+    asm volatile ("cvt.rn.relu.bf16x2.f32 %0, %1, %2;\n"
+                  : "=r"(*reinterpret_cast<uint32_t*>(&result))
+                  : "f"(b), "f"(a));
+    return result;
+}
+
 } // namespace deep_gemm::ptx

--- a/deep_gemm/include/deep_gemm/scheduler/mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/scheduler/mega_moe.cuh
@@ -32,7 +32,7 @@ struct MegaMoEScheduler {
     DG_STATIC_ASSERT(L2_SHAPE_N % BLOCK_N == 0, "Invalid shape");
     DG_STATIC_ASSERT(L1_SHAPE_K % BLOCK_K == 0, "Invalid shape");
     DG_STATIC_ASSERT(L2_SHAPE_K % BLOCK_K == 0, "Invalid shape");
-    DG_STATIC_ASSERT(kNumExpertsPerRank % kNumExpertsPerWave == 0, "Invalid wave config");
+    DG_STATIC_ASSERT(kNumExpertsPerWave > 0 and kNumExpertsPerWave <= kNumExpertsPerRank, "Invalid wave config");
 
     // NOTES: N block counts must be even so that 2 adjacent CTAs in a cluster
     // always land on the same m_block_idx with n_block_idx differing by 1
@@ -63,7 +63,9 @@ struct MegaMoEScheduler {
     }
 
     CUTLASS_DEVICE uint32_t get_wave_expert_end_idx() const {
-        return math::align(current_local_expert_idx + 1, kNumExpertsPerWave);
+        // Align up to wave boundary, clamped for the last partial wave
+        const auto aligned = math::align(current_local_expert_idx + 1, kNumExpertsPerWave);
+        return cute::min(aligned, kNumExpertsPerRank);
     }
 
     CUTLASS_DEVICE uint32_t get_num_tokens(const uint32_t& expert_idx) const {

--- a/deep_gemm/include/deep_gemm/scheduler/paged_mqa_logits.cuh
+++ b/deep_gemm/include/deep_gemm/scheduler/paged_mqa_logits.cuh
@@ -16,12 +16,17 @@ void smxx_paged_mqa_logits_metadata(const uint32_t batch_size, const uint32_t ne
     // Wait for primary kernel completion
     cudaGridDependencySynchronize();
 
-    __shared__ uint32_t varlen_atom_token_start[kAlignedBatchSize];
-    __shared__ uint32_t varlen_atom_context_len[kAlignedBatchSize];
-    __shared__ uint32_t varlen_num_atoms_shared;
+    extern __shared__ uint32_t smem_buffer[];
+    const auto prefix_sum = smem_buffer;
+    const auto get_varlen_atom_token_start = [&]() { return prefix_sum + kAlignedBatchSize; };
+    const auto get_varlen_atom_context_len = [&]() { return prefix_sum + kAlignedBatchSize * 2; };
+    const auto get_varlen_num_atoms_shared = [&]() { return prefix_sum + kAlignedBatchSize * 3; };
     uint32_t num_items;
 
     if constexpr (kIsVarlen) {
+        const auto varlen_atom_token_start = get_varlen_atom_token_start();
+        const auto varlen_atom_context_len = get_varlen_atom_context_len();
+        const auto varlen_num_atoms_shared = get_varlen_num_atoms_shared();
         if (lane_idx == 0) {
             uint32_t t = 0, atom_count = 0;
             while (t < batch_size) {
@@ -31,34 +36,28 @@ void smxx_paged_mqa_logits_metadata(const uint32_t batch_size, const uint32_t ne
                 t += is_paired ? 2 : 1;
                 ++ atom_count;
             }
-            varlen_num_atoms_shared = atom_count;
+            *varlen_num_atoms_shared = atom_count;
         }
         __syncwarp();
-        num_items = varlen_num_atoms_shared;
+        num_items = *varlen_num_atoms_shared;
     } else {
         num_items = batch_size;
     }
 
     // Compute num_segs and prefix sum
-    uint32_t num_segs[kAlignedBatchSize / 32];
-    #pragma unroll
+    uint32_t sum = 0;
+    #pragma unroll 16
     for (uint32_t k = 0; k < kAlignedBatchSize / 32; ++ k) {
         const uint32_t q_idx = k * 32 + lane_idx;
         uint32_t context_len;
         if constexpr (kIsVarlen) {
+            const auto varlen_atom_context_len = get_varlen_atom_context_len();
             context_len = (q_idx < num_items ? varlen_atom_context_len[q_idx] : 0);
         } else {
             const uint32_t lens_idx = (is_context_lens_2d ? q_idx * next_n + next_n - 1 : q_idx);
             context_len = (q_idx < batch_size ? context_lens[lens_idx] : 0);
         }
-        num_segs[k] = math::ceil_div(context_len, SPLIT_KV);
-    }
-
-    __shared__ uint32_t prefix_sum[kAlignedBatchSize];
-    uint32_t sum = 0;
-    #pragma unroll
-    for (uint32_t k = 0; k < kAlignedBatchSize / 32; ++ k) {
-        uint32_t x = num_segs[k];
+        uint32_t x = math::ceil_div(context_len, SPLIT_KV);
         #pragma unroll
         for (uint32_t offset = 1; offset < 32; offset <<= 1) {
             const uint32_t y = __shfl_up_sync(0xffffffff, x, offset);
@@ -71,10 +70,14 @@ void smxx_paged_mqa_logits_metadata(const uint32_t batch_size, const uint32_t ne
 
     // SM work distribution
     if constexpr (kIsVarlen) {
+        const auto varlen_atom_token_start = get_varlen_atom_token_start();
         const uint32_t total = sum;
         const uint32_t q = total / kNumSMs, r = total % kNumSMs;
+        // NOTES: reversed allocation — first (kNumSMs - r) SMs get `q` segments, last `r` get `q + 1`.
+        // Empty SMs (when total < kNumSMs) land on atom_idx == 0, keeping `refresh_num_kv_and_advance` in-bounds.
+        const uint32_t pivot = kNumSMs - r;
         for (uint32_t sm_idx = lane_idx; sm_idx <= kNumSMs; sm_idx += 32) {
-            uint32_t seg_starts = sm_idx * q + min(sm_idx, r);
+            uint32_t seg_starts = sm_idx * q + (sm_idx > pivot ? sm_idx - pivot : 0);
             uint32_t lo = 0, hi = num_items;
             while (lo < hi) {
                 const uint32_t mid = (lo + hi) / 2;
@@ -95,8 +98,9 @@ void smxx_paged_mqa_logits_metadata(const uint32_t batch_size, const uint32_t ne
         const uint32_t num_next_n_atoms = math::ceil_div(next_n, next_n_atom);
         const uint32_t total = sum * num_next_n_atoms;
         const uint32_t q = total / kNumSMs, r = total % kNumSMs;
-        for (uint32_t sm_idx = lane_idx; sm_idx <= kNumSMs; sm_idx += 32) {
-            uint32_t seg_starts = sm_idx * q + min(sm_idx, r);
+        const uint32_t pivot = kNumSMs - r;
+        for (uint32_t sm_idx = lane_idx; sm_idx < kNumSMs; sm_idx += 32) {
+            uint32_t seg_starts = sm_idx * q + (sm_idx > pivot ? sm_idx - pivot : 0);
             uint32_t lo = 0, hi = batch_size;
             while (lo < hi) {
                 const uint32_t mid = (lo + hi) / 2;
@@ -114,6 +118,10 @@ void smxx_paged_mqa_logits_metadata(const uint32_t batch_size, const uint32_t ne
 
             schedule_metadata[sm_idx * 2] = q_atom_idx;
             schedule_metadata[sm_idx * 2 + 1] = kv_split_idx;
+        }
+        if (lane_idx == 0) {
+            schedule_metadata[kNumSMs * 2] = batch_size * num_next_n_atoms;
+            schedule_metadata[kNumSMs * 2 + 1] = 0;
         }
     }
 }
@@ -137,6 +145,8 @@ struct PagedMQALogitsScheduler : IndicesStorage<kIsVarlen> {
     uint32_t current_q_atom_idx, current_kv_idx;
     uint32_t end_q_atom_idx, end_kv_idx;
     uint32_t current_num_kv;
+    uint32_t current_advance;
+    uint32_t last_advance;
 
     CUTLASS_DEVICE static uint32_t atom_to_token_idx(const uint32_t& q_atom_idx) {
         if constexpr (kIsVarlen) {
@@ -160,16 +170,24 @@ struct PagedMQALogitsScheduler : IndicesStorage<kIsVarlen> {
         }
     }
 
-    CUTLASS_DEVICE uint32_t get_num_kv(const uint32_t& q_atom_idx) const {
+    CUTLASS_DEVICE uint32_t get_last_advance() const {
+        return last_advance;
+    }
+
+    // NOTES: varlen path reuses a single `is_paired` check to derive both `current_advance`
+    // and `current_num_kv`, so `indices` is read only once per atom boundary.
+    CUTLASS_DEVICE void refresh_num_kv_and_advance(const uint32_t& q_atom_idx) {
         if constexpr (kIsVarlen) {
             const bool is_paired = (q_atom_idx + 1 < batch_size and
                                     this->indices[q_atom_idx] == this->indices[q_atom_idx + 1]);
+            current_advance = is_paired ? 2 : 1;
             const uint32_t ctx_len = is_paired ? context_lens[q_atom_idx + 1] : context_lens[q_atom_idx];
-            return math::ceil_div(ctx_len, BLOCK_KV);
+            current_num_kv = math::ceil_div(ctx_len, BLOCK_KV);
         } else {
+            current_advance = 1;
             const uint32_t q_idx = q_atom_idx / kNumNextNAtoms;
             const auto lens_idx = (kIsContextLens2D ? q_idx * kNextN + kNextN - 1 : q_idx);
-            return math::ceil_div(context_lens[lens_idx], BLOCK_KV);
+            current_num_kv = math::ceil_div(context_lens[lens_idx], BLOCK_KV);
         }
     }
 
@@ -187,18 +205,8 @@ struct PagedMQALogitsScheduler : IndicesStorage<kIsVarlen> {
         current_q_atom_idx = current_pack.x, current_kv_idx = current_pack.y * kNumBlocksPerSplit;
         end_q_atom_idx = end_pack.x, end_kv_idx = end_pack.y * kNumBlocksPerSplit;
 
-        current_num_kv = get_num_kv(current_q_atom_idx);
-    }
-
-    // Advance step in q_atom_idx space when moving to the next atom.
-    // Varlen: 1 or 2 depending on whether consecutive tokens share the same sequence.
-    // Non-varlen: always 1 (one atom unit).
-    CUTLASS_DEVICE uint32_t get_atom_advance(const uint32_t& q_atom_idx, const uint32_t& bound) const {
-        if constexpr (kIsVarlen) {
-            return (q_atom_idx + 1 < bound and this->indices[q_atom_idx] == this->indices[q_atom_idx + 1]) ? 2 : 1;
-        } else {
-            return 1;
-        }
+        // NOTES: unconditional call is safe — reversed metadata allocation ensures `current_q_atom_idx` is always in-bounds.
+        refresh_num_kv_and_advance(current_q_atom_idx);
     }
 
     // Whether num_kv should be refreshed after advancing to q_atom_idx.
@@ -216,6 +224,7 @@ struct PagedMQALogitsScheduler : IndicesStorage<kIsVarlen> {
         q_atom_idx = current_q_atom_idx;
         kv_idx = current_kv_idx;
         num_kv = current_num_kv;
+        last_advance = current_advance;
 
         if (current_q_atom_idx == end_q_atom_idx and current_kv_idx == end_kv_idx)
             return false;
@@ -223,9 +232,9 @@ struct PagedMQALogitsScheduler : IndicesStorage<kIsVarlen> {
         current_kv_idx += kNumBlocksPerSplit;
         if (current_kv_idx >= current_num_kv) {
             current_kv_idx = 0;
-            current_q_atom_idx += get_atom_advance(current_q_atom_idx, end_q_atom_idx);
+            current_q_atom_idx += current_advance;
             if (should_refresh_num_kv(current_q_atom_idx) and exist_q_atom_idx(current_q_atom_idx)) {
-                current_num_kv = get_num_kv(current_q_atom_idx);
+                refresh_num_kv_and_advance(current_q_atom_idx);
             }
         }
         return true;

--- a/deep_gemm/mega/__init__.py
+++ b/deep_gemm/mega/__init__.py
@@ -1,4 +1,5 @@
 import torch
+import types
 from typing import Tuple, Optional
 from ..utils.math import align
 
@@ -15,7 +16,6 @@ from .. import _C
 
 class SymmBuffer:
     def __init__(self, group: dist.ProcessGroup,
-                 # MoE arguments
                  num_experts: int,
                  num_max_tokens_per_rank: int, num_topk: int,
                  hidden: int, intermediate_hidden: int,
@@ -35,8 +35,13 @@ class SymmBuffer:
             hidden, intermediate_hidden,
             use_fp8_dispatch, activation
         )
-        self.buffer = symm_mem.empty(num_bytes, dtype=torch.int8, device='cuda')
-        self.handle = symm_mem.rendezvous(self.buffer, group=group)
+        allocator = torch if group.size() == 1 else symm_mem
+        self.buffer = allocator.empty(num_bytes, dtype=torch.int8, device='cuda')
+        self.handle = (
+            types.SimpleNamespace(buffer_ptrs=[self.buffer.data_ptr()])
+            if group.size() == 1
+            else symm_mem.rendezvous(self.buffer, group=group)
+        )
         self.buffer.zero_()
         self.group.barrier()
         torch.cuda.synchronize()
@@ -72,16 +77,13 @@ def get_symm_buffer_for_mega_moe(group: dist.ProcessGroup,
     )
 
 
-def _interleave_l1_weights(l1_weights: Tuple[torch.Tensor, torch.Tensor]) -> Tuple[torch.Tensor, torch.Tensor]:
+def _interleave_weights(t: torch.Tensor, gran: int = 8) -> torch.Tensor:
     # [gate: 0..7, up: 0..7, gate: 8..15, up: 8..15, ...] instead of [gate | up]
-    def interleave(t, gran: int = 8) -> torch.Tensor:
-        g, n, *rest = t.shape
-        half = n // 2
-        gate = t[:, :half].reshape(g, half // gran, gran, *rest)
-        up = t[:, half:].reshape(g, half // gran, gran, *rest)
-        return torch.empty_like(t).copy_(torch.stack([gate, up], dim=2).reshape(g, n, *rest))
-
-    return interleave(l1_weights[0]), interleave(l1_weights[1])
+    g, n, *rest = t.shape
+    half = n // 2
+    gate = t[:, :half].reshape(g, half // gran, gran, *rest)
+    up = t[:, half:].reshape(g, half // gran, gran, *rest)
+    return torch.empty_like(t).copy_(torch.stack([gate, up], dim=2).reshape(g, n, *rest))
 
 
 def _transpose_sf_for_utccp(sf: torch.Tensor) -> torch.Tensor:
@@ -97,12 +99,14 @@ def transform_weights_for_mega_moe(
     l1_weights: Tuple[torch.Tensor, torch.Tensor],
     l2_weights: Tuple[torch.Tensor, torch.Tensor]
 ) -> Tuple[Tuple[torch.Tensor, torch.Tensor], Tuple[torch.Tensor, torch.Tensor]]:
-    # L1: interleave gate/up, then transpose SF for UTCCP
-    l1_interleaved = _interleave_l1_weights(l1_weights)
-    l1_weights = (l1_interleaved[0], _transpose_sf_for_utccp(l1_interleaved[1]))
-    # L2: only transpose SF for UTCCP
-    l2_weights = (l2_weights[0], _transpose_sf_for_utccp(l2_weights[1]))
-    return l1_weights, l2_weights
+    # L1: interleave gate/up for weight and SF, then transpose SF for UTCCP.
+    l1_w = _interleave_weights(l1_weights[0])
+    l1_sf = _transpose_sf_for_utccp(_interleave_weights(l1_weights[1]))
+    l1_transformed = (l1_w, l1_sf)
+    # L2: only transpose SF for UTCCP.
+    l2_transformed = (l2_weights[0], _transpose_sf_for_utccp(l2_weights[1]))
+    return l1_transformed, l2_transformed
+
 
 
 def fp8_fp4_mega_moe(y: torch.Tensor,

--- a/tests/generators.py
+++ b/tests/generators.py
@@ -136,6 +136,9 @@ def enumerate_normal(dtype: torch.dtype) -> Generator:
                     n, k = nk_list[i]
                     out_dtype = torch.bfloat16 if i < len(bf16_output_nk) else torch.float
                     yield kernel_type, quant_config, m, n, k, MajorTypeAB.KMajor, MajorTypeAB.KMajor, False, out_dtype
+                    # BF16 accumulation: supported on all BF16 GEMMs, and SM100 FP8/FP4 GEMMs
+                    if out_dtype == torch.bfloat16 and (dtype == torch.bfloat16 or get_arch_major() == 10):
+                        yield kernel_type, quant_config, m, n, k, MajorTypeAB.KMajor, MajorTypeAB.KMajor, True, out_dtype
 
             # Backward
             for m in m_bwd_list:

--- a/tests/test_attention.py
+++ b/tests/test_attention.py
@@ -113,7 +113,7 @@ def test_mqa_logits():
                 for compressed_logits, clean_logits in [(False, True), (True, False)]:
                     for seq_len in (2048, 4096):
                         for seq_len_kv in (4096, 8192):
-                            for num_heads, head_dim in [(64, 128)]:
+                            for num_heads, head_dim in [(64, 128), (32, 128)]:
                                 for disable_cp in (False, True):
                                     yield is_fp4, logits_dtype, compressed_logits, clean_logits, seq_len, seq_len_kv, num_heads, head_dim, disable_cp
 
@@ -224,6 +224,18 @@ def ref_paged_mqa_logits(q: torch.Tensor, kv_cache: torch.Tensor,
     return logits
 
 
+def reset_cuda_peak_memory_stats():
+    torch.cuda.synchronize()
+    torch.cuda.reset_peak_memory_stats()
+
+
+def get_cuda_peak_memory_gib():
+    torch.cuda.synchronize()
+    peak_allocated = torch.cuda.max_memory_allocated() / 1024 ** 3
+    peak_reserved = torch.cuda.max_memory_reserved() / 1024 ** 3
+    return peak_allocated, peak_reserved
+
+
 def test_paged_mqa_logits():
 
     # Helper functions
@@ -253,24 +265,30 @@ def test_paged_mqa_logits():
 
     def enumerate_paged_mqa_logits():
         arch_major = get_arch_major()
+        max_kv_pool_tokens = 32 * 1024 * 1024
+        max_varlen_tokens = 16 * 1024
         for is_varlen in ((True, False) if arch_major == 10 else (False, )):
             for is_fp4 in ((True, False) if arch_major == 10 else (False, )):
                 for logits_dtype in (torch.float, torch.bfloat16):
                     for block_kv in ((32, 64) if arch_major == 10 else (64, )):
                         for use_2d_context_lens, clean_logits in [(True, False)]:
-                            for batch_size in (256, ):
+                            for batch_size in (256, 4096):
                                 for next_n in ((1, ) if is_varlen else ((1, 2, 4, 5, 6) if arch_major == 10 else (1, 2))):
                                     for max_tokens_per_batch in ((1, 4, 10) if is_varlen else (1, )):
-                                        for num_heads, head_dim in [(64, 128)]:
+                                        for num_heads, head_dim in [(64, 128), (32, 128)]:
                                             for avg_kv in (8192, 32768):
+                                                if batch_size * avg_kv > max_kv_pool_tokens:
+                                                    continue
+                                                if is_varlen and batch_size * max_tokens_per_batch > max_varlen_tokens:
+                                                    continue
                                                 yield is_varlen, is_fp4, logits_dtype, block_kv, use_2d_context_lens, clean_logits, batch_size, next_n, max_tokens_per_batch, num_heads, head_dim, avg_kv
 
 
     print('Testing FP8/FP4 Paged MQA Logits:')
-    max_model_len = 111 * 1024
-    num_total_blocks = max_model_len * 5
 
     for is_varlen, is_fp4, logits_dtype, block_kv, use_2d_context_lens, clean_logits, batch_size, next_n, max_tokens_per_batch, num_heads, head_dim, avg_kv in enumerate_paged_mqa_logits():
+        reset_cuda_peak_memory_stats()
+
         # Varlen: flatten raw_batch_size sequences with variable tokens into (batch_size, 1, ...)
         raw_batch_size, raw_next_n = batch_size, next_n
         if is_varlen:
@@ -282,7 +300,6 @@ def test_paged_mqa_logits():
 
         # Generate random inputs
         q = torch.randn((batch_size, next_n, num_heads, head_dim), device='cuda', dtype=torch.bfloat16)
-        kv_cache = torch.randn((num_total_blocks, block_kv, 1, head_dim), device='cuda', dtype=torch.bfloat16)
         weights = torch.randn((batch_size * next_n, num_heads), device='cuda', dtype=torch.float)
         context_lens = torch.randint(int(0.7 * avg_kv), int(1.3 * avg_kv), (raw_batch_size,), device='cuda', dtype=torch.int)
 
@@ -294,7 +311,10 @@ def test_paged_mqa_logits():
         # Assign block tables (per-sequence, sized by the largest ctx_len within the sequence)
         seq_sum_lens = context_lens.sum().item()
         num_blocks_per_query = ceil_div(max_ctx_len_per_seq, block_kv)
-        block_table = torch.empty((raw_batch_size, num_blocks_per_query.max().item()), device='cuda', dtype=torch.int)
+        max_model_len = num_blocks_per_query.max().item() * block_kv
+        num_total_blocks = num_blocks_per_query.sum().item()
+        kv_cache = torch.randn((num_total_blocks, block_kv, 1, head_dim), device='cuda', dtype=torch.bfloat16)
+        block_table = torch.zeros((raw_batch_size, num_blocks_per_query.max().item()), device='cuda', dtype=torch.int)
         block_idx_pool = torch.randperm(num_total_blocks, device='cuda', dtype=torch.int)
         offset = 0
         for i, num_blocks in enumerate(num_blocks_per_query.tolist()):
@@ -311,6 +331,7 @@ def test_paged_mqa_logits():
 
         # Calculate reference logits
         ref_logits = ref_paged_mqa_logits(q, kv_cache, weights, context_lens, block_table, max_model_len, use_2d_context_lens)
+        q_weight_bytes = count_bytes(q, weights)
 
         # Quantize Q and KV cache to FP4 / FP8
         if is_fp4:
@@ -322,6 +343,7 @@ def test_paged_mqa_logits():
             q_in = q.to(torch.float8_e4m3fn), None
             q_simulated = q_in[0].to(torch.bfloat16)
             kv_in, kv_simulated = kv_cache_cast_to_fp8(kv_cache)
+        del q, kv_cache
 
         # Calculate simulated reference logits
         simulated_logits = ref_paged_mqa_logits(q_simulated, kv_simulated, weights, context_lens, block_table, max_model_len, use_2d_context_lens)
@@ -345,6 +367,9 @@ def test_paged_mqa_logits():
             ref_neginf_mask = ~(positions <= limits)
 
         # Run Kernel
+        assert block_table.min().item() >= 0
+        assert block_table.max().item() < num_total_blocks
+        assert context_lens_nextn.max().item() <= max_model_len
         kernel_kwargs = dict(
             q=q_in, kv_cache=kv_in, weights=weights,
             context_lens=context_lens_nextn, block_table=block_table,
@@ -375,14 +400,24 @@ def test_paged_mqa_logits():
         kv_bytes_per_token = head_dim / (2 if is_fp4 else 1) + 4
         # KV is read once per sequence; for varlen sum_lens overcounts (per-token), so use seq_sum_lens
         kv_sum_lens = seq_sum_lens if is_varlen else sum_lens
-        total_bytes = count_bytes(q, weights) + kv_sum_lens * kv_bytes_per_token + (sum_lens * next_n * logits_dtype.itemsize)
+        total_bytes = q_weight_bytes + kv_sum_lens * kv_bytes_per_token + (sum_lens * next_n * logits_dtype.itemsize)
 
+        peak_allocated, peak_reserved = get_cuda_peak_memory_gib()
         t, clean_t = bench_kineto(lambda: deep_gemm.fp8_fp4_paged_mqa_logits(**kernel_kwargs), ('paged_mqa_logits', 'clean_logits'))
         print(f' > FP4={is_fp4}, BF16={logits_dtype == torch.bfloat16}, BLOCK_KV={block_kv}, BSZ={raw_batch_size:3}, NextN={raw_next_n:1}, H={num_heads:2}, D={head_dim:2}, L={avg_kv:6}: '
               f'{tflops_calc / t:4.0f} TFLOPS, {t * 1e6:3.0f} us, {total_bytes / t / 1e9:4.0f} GB/s', end='')
         if is_varlen:
             print(f' | Varlen, MaxTPB={max_tokens_per_batch}, NumTokens={batch_size}', end='')
+        print(f' | mem: alloc={peak_allocated:.2f} GiB, reserved={peak_reserved:.2f} GiB', end='')
         print(f' | clean: {clean_t*1e6:3.0f} us' if clean_logits else '')
+
+        del kernel_kwargs, logits, ref_neginf_mask, positions
+        del q_in, q_simulated, kv_in, kv_simulated, weights, context_lens, context_lens_nextn, block_table
+        if is_fp4:
+            del q_fp4
+        if is_varlen:
+            del tokens_per_seq, indices, offsets_within_seq
+        torch.cuda.empty_cache()
     print()
 
 

--- a/tests/test_bf16.py
+++ b/tests/test_bf16.py
@@ -196,7 +196,9 @@ def test_cublaslt_gemm() -> None:
         a, b, c, d, ref_d = generate_normal(m, n, k, major_a, major_b, accumulate, out_dtype, kernel_type, use_bf16=True)
         deep_gemm.cublaslt_gemm_nt(a, b, d, c=c)
         diff = calc_diff(d, ref_d)
-        assert diff < 6e-7, f'{diff=}, ({m=}, {n=}, {k=}, {major_opt=}, {accumulate=}, {out_dtype=})'
+        # BF16 accumulation has lower precision than cuBLASLt's FP32 accumulation
+        threshold = 1e-5 if (accumulate and out_dtype == torch.bfloat16) else 6e-7
+        assert diff < threshold, f'{diff=}, ({m=}, {n=}, {k=}, {major_opt=}, {accumulate=}, {out_dtype=})'
 
         t_nvjet, t_gemv, t_gemm = bench_kineto(lambda: deep_gemm.cublaslt_gemm_nt(a, b, d, c=c), ('nvjet', 'gemv', 'gemm'), suppress_kineto_output=True)
         t = t_nvjet + t_gemv + t_gemm

--- a/tests/test_mega_moe.py
+++ b/tests/test_mega_moe.py
@@ -56,6 +56,16 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
         hidden, intermediate_hidden
     )
 
+    # Cast weights into FP4
+    def _cast_weights_to_fp4(bf16_weights: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        num_groups, n, k = bf16_weights.shape
+        w = torch.empty((num_groups, n, k // 2), device='cuda', dtype=torch.int8)
+        w_sf = torch.empty((num_groups, n, k // 32), device='cuda', dtype=torch.float)
+        for i in range(num_groups):
+            w[i], w_sf[i] = per_token_cast_to_fp4(bf16_weights[i], use_ue8m0=True, gran_k=32)
+        w_sf = deep_gemm.transform_sf_into_required_layout(w_sf, n, k, (1, 32), num_groups)
+        return w, w_sf
+
     # Create inputs
     # noinspection PyGlobalUndefined
     def create_inputs():
@@ -77,27 +87,12 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
             topk_idx.masked_fill_(rand_mask < args.masked_ratio, -1)
             topk_weights.masked_fill_(topk_idx < 0, 0)
 
-        # Check SF requirements
-        assert hidden % 128 == 0
-        assert intermediate_hidden % 128 == 0
-        assert l1_weights.shape[2] % 128 == 0 and l2_weights.shape[2] % 128 == 0
-
-        # Cast inputs to FP8 with per-32 UE8M0 SF
+        # Cast inputs to FP8/FP4 with per-32 UE8M0 SF
+        assert hidden % 128 == 0 and intermediate_hidden % 128 == 0
         x = per_token_cast_to_fp8(x, use_ue8m0=True, gran_k=32, use_packed_ue8m0=True)
+        l1_weights = _cast_weights_to_fp4(l1_weights)
+        l2_weights = _cast_weights_to_fp4(l2_weights)
 
-        # Cast grouped BF16 weights to FP4 with MN-major SF
-        # TODO: merge with `cast_fp8_fp4_with_major`
-        def cast_grouped_weights_to_fp4(bf16_weights: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
-            num_groups, n, k = bf16_weights.shape
-            w = torch.empty((num_groups, n, k // 2), device='cuda', dtype=torch.int8)
-            w_sf = torch.empty((num_groups, n, k // 32), device='cuda', dtype=torch.float)
-            for i in range(num_groups):
-                w[i], w_sf[i] = per_token_cast_to_fp4(bf16_weights[i], use_ue8m0=True, gran_k=32)
-            w_sf = deep_gemm.transform_sf_into_required_layout(w_sf, n, k, (1, 32), num_groups)
-            return w, w_sf
-
-        l1_weights = cast_grouped_weights_to_fp4(l1_weights)
-        l2_weights = cast_grouped_weights_to_fp4(l2_weights)
         transformed_l1_weights, transformed_l2_weights = deep_gemm.transform_weights_for_mega_moe(l1_weights, l2_weights)
 
     # Run fused mega MoE
@@ -109,15 +104,13 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
         buffer.topk_weights[:num_tokens].copy_(topk_weights)
 
         y = torch.empty((num_tokens, hidden), dtype=torch.bfloat16, device='cuda')
-        # noinspection PyTypeChecker
-        deep_gemm.fp8_fp4_mega_moe(
-            y,
-            transformed_l1_weights, transformed_l2_weights,
-            buffer,
+        kernel_kwargs = dict(
+            y=y, l1_weights=transformed_l1_weights, l2_weights=transformed_l2_weights,
+            sym_buffer=buffer,
             cumulative_local_expert_recv_stats=cumulative_local_expert_recv_stats_fused,
             activation_clamp=args.activation_clamp,
-            fast_math=bool(args.fast_math)
-        )
+            fast_math=bool(args.fast_math))
+        deep_gemm.fp8_fp4_mega_moe(**kernel_kwargs)
         return y, cumulative_local_expert_recv_stats_fused
 
     dist_print('Config:', once_in_node=True)
@@ -154,37 +147,41 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
         num_gpu_timeout_secs=10, num_cpu_timeout_secs=30
     ) if is_legacy_loaded else None
 
-    def run_baseline():
-        recv_x, _, recv_topk_weights, handle, _ = ep_buffer.dispatch(
-            x, topk_idx=topk_idx, topk_weights=topk_weights,
-            cumulative_local_expert_recv_stats=cumulative_local_expert_recv_stats_baseline,
-            num_experts=num_experts, expert_alignment=alignment,
-            do_cpu_sync=False, do_handle_copy=False,
-            do_expand=True, use_tma_aligned_col_major_sf=True,
-        )
-        n = recv_x[0].size(0)
-        l1_y = torch.empty((n, intermediate_hidden * 2), dtype=torch.bfloat16, device='cuda')
-        deep_gemm.m_grouped_fp8_fp4_gemm_nt_contiguous(
-            recv_x, l1_weights, l1_y, handle.psum_num_recv_tokens_per_expert,
-            use_psum_layout=True, recipe=(1, 1, 32))
-        # noinspection PyCallingNonCallable
-        l1_y = tilelang_ops.swiglu_apply_weight_to_fp8(
-            x=l1_y,
-            topk_weights=recv_topk_weights,
-            avail_tokens=handle.psum_num_recv_tokens_per_expert[-1],
-            num_per_channels=32,
-            use_col_major_scales=True,
-            round_scale=True,
-            ue8m0_scale=True,
-            output_bf16=False,
-            clamp_value=args.activation_clamp,
-            fast_math=bool(args.fast_math)
-        )
-        l2_y = torch.empty((n, hidden), dtype=torch.bfloat16, device='cuda')
-        deep_gemm.m_grouped_fp8_fp4_gemm_nt_contiguous(
-            l1_y, l2_weights, l2_y, handle.psum_num_recv_tokens_per_expert,
-            use_psum_layout=True, recipe=(1, 1, 32))
-        return ep_buffer.combine(l2_y, handle=handle)[0], cumulative_local_expert_recv_stats_baseline
+    if is_legacy_loaded:
+        dispatch_kwargs = {'do_cpu_sync': False, 'do_handle_copy': False,
+                           'do_expand': True, 'use_tma_aligned_col_major_sf': True}
+        gemm_fn = deep_gemm.m_grouped_fp8_fp4_gemm_nt_contiguous
+        gemm_kwargs = {'use_psum_layout': True, 'recipe': (1, 1, 32)}
+        activation_kwargs = {'round_scale': True, 'ue8m0_scale': True, 'output_bf16': False}
+        get_num_tokens = lambda recv_x: recv_x[0].size(0)
+
+        def run_baseline():
+            # Dispatch
+            recv_x, _, recv_topk_weights, handle, _ = ep_buffer.dispatch(
+                x, topk_idx=topk_idx, topk_weights=topk_weights,
+                cumulative_local_expert_recv_stats=cumulative_local_expert_recv_stats_baseline,
+                num_experts=num_experts, expert_alignment=alignment,
+                **dispatch_kwargs)
+            num_recv_tokens = get_num_tokens(recv_x)
+
+            # L1 GEMM
+            l1_y = torch.empty((num_recv_tokens, intermediate_hidden * 2), dtype=torch.bfloat16, device='cuda')
+            gemm_fn(recv_x, l1_weights, l1_y, handle.psum_num_recv_tokens_per_expert, **gemm_kwargs)
+
+            # Activation
+            l1_y = tilelang_ops.swiglu_apply_weight_to_fp8(
+                x=l1_y, topk_weights=recv_topk_weights,
+                avail_tokens=handle.psum_num_recv_tokens_per_expert[-1],
+                num_per_channels=32, use_col_major_scales=True,
+                clamp_value=args.activation_clamp, fast_math=bool(args.fast_math),
+                **activation_kwargs)
+
+            # L2 GEMM
+            l2_y = torch.empty((num_recv_tokens, hidden), dtype=torch.bfloat16, device='cuda')
+            gemm_fn(l1_y, l2_weights, l2_y, handle.psum_num_recv_tokens_per_expert, **gemm_kwargs)
+
+            # Combine
+            return ep_buffer.combine(l2_y, handle=handle)[0], cumulative_local_expert_recv_stats_baseline
 
     # Check correctness (must be bitwise identical)
     num_correctness_tests = 1 if args.num_correctness_tests is None else args.num_correctness_tests
@@ -218,15 +215,15 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     safe_div = lambda a, b: float('nan') if b == 0 else a / b
     tflops = safe_div(2 * num_recv_tokens * (hidden * intermediate_hidden * 3) / 1e12, t_fused)
 
-    # HBM bytes: weights (FP4 packed = 0.5 bytes) + activations (FP8 = 1 byte) + output (BF16 = 2 bytes)
-    num_touched_experts = torch.unique(gathered_topk_idx.flatten()).numel() - 1 # NOTES minus 1 to exclude "-1"
+    # HBM bytes: weights + activations + output
+    num_touched_experts = torch.unique(gathered_topk_idx[gathered_topk_idx >= 0]).numel()
     num_hbm_bytes = (
-        num_touched_experts * intermediate_hidden * 2 * hidden // 2 +   # L1 weights (FP4)
-        num_touched_experts * hidden * intermediate_hidden // 2 +       # L2 weights (FP4)
-        num_recv_tokens * hidden +                                      # L1 acts read (FP8)
-        num_recv_tokens * intermediate_hidden +                         # L1 output write (FP8)
-        num_recv_tokens * intermediate_hidden +                         # L2 acts read (FP8)
-        num_recv_tokens * hidden * 2                                    # L2 output write (BF16)
+        num_touched_experts * intermediate_hidden * 2 * hidden * 0.5                                 # L1 weights
+        + num_touched_experts * hidden * intermediate_hidden * 0.5                                   # L2 weights
+        + num_recv_tokens * hidden                                                                   # L1 acts read
+        + num_recv_tokens * intermediate_hidden                                                      # L1 output write
+        + num_recv_tokens * intermediate_hidden                                                      # L2 acts read
+        + num_recv_tokens * hidden * 2                                                               # L2 output write (always BF16)
     )
     hbm_gbs = safe_div(num_hbm_bytes / 1e9, t_fused)
 

--- a/tests/test_mega_moe.py
+++ b/tests/test_mega_moe.py
@@ -151,7 +151,7 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
         num_topk=num_topk, use_fp8_dispatch=True,
         explicitly_destroy=True,
         allow_multiple_reduction=False,
-        gpu_timeout_secs=10, cpu_timeout_secs=30
+        num_gpu_timeout_secs=10, num_cpu_timeout_secs=30
     ) if is_legacy_loaded else None
 
     def run_baseline():


### PR DESCRIPTION
Merges upstream `88965b0` (deepseek-ai PR #347: "Multiple updates and refactorings") into `nv_dev` (c
urrently `ac1f285` = #316 merge via PR #328 + PR #342 IMA guard). Brings PR #347's FP8/FP4 Mega MoE r
efactor, BF16 accumulation/output expansion, paged-MQA scheduler refactor, and assorted fixes. Merge
base is `891d57b`; the merge also pulls `714dd1a` ("Update test_mega_moe.py").

Topology follows the established nv_dev convention (`git merge --no-ff <upstream_sha>`, preserving th
e upstream commit as the second parent), matching PR #314 / #328.