### PR TITLE
Add shape-aware recommended alignment for SM90 small-M grouped GEMM

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ The library provides some utility functions besides the above kernels:
 - `deep_gemm.set_pdl` / `get_pdl`: enable/disable Programmatic Dependent Launch (PDL)
 - `deep_gemm.set_mk_alignment_for_contiguous_layout` / `get_mk_alignment_for_contiguous_layout`: set/get the group-level M/K alignment for contiguous layout
 - `deep_gemm.get_theoretical_mk_alignment_for_contiguous_layout`: get the theoretical minimum M/K alignment
+- `deep_gemm.get_recommended_mk_alignment_for_contiguous_layout`: get the recommended M/K alignment for a contiguous layout and target shape
 - `deep_gemm.set_ignore_compile_dims`: configure dimensions to ignore during JIT compilation
 - `deep_gemm.set_block_size_multiple_of`: constrain block sizes to be multiples of a given value
 - `deep_gemm.transform_sf_into_required_layout`: transform scaling factors into the required layout

--- a/csrc/apis/layout.hpp
+++ b/csrc/apis/layout.hpp
@@ -138,6 +138,16 @@ static void register_apis(pybind11::module_& m) {
     m.def("get_theoretical_mk_alignment_for_contiguous_layout", [&](const std::optional<int>& expected_m) {
         return heuristics_runtime->get_theoretical_mk_alignment_for_contiguous_layout(expected_m);
     }, py::arg("expected_m") = std::nullopt);
+    m.def("get_recommended_mk_alignment_for_contiguous_layout", [&](const bool& use_psum_layout,
+                                                                    const std::optional<int>& expected_m,
+                                                                    const std::optional<int>& expected_k,
+                                                                    const std::optional<int>& expected_num_groups) {
+        return heuristics_runtime->get_recommended_mk_alignment_for_contiguous_layout(
+            use_psum_layout, expected_m, expected_k, expected_num_groups);
+    }, py::arg("use_psum_layout") = false,
+       py::arg("expected_m") = std::nullopt,
+       py::arg("expected_k") = std::nullopt,
+       py::arg("expected_num_groups") = std::nullopt);
 }
 
 } // namespace deep_gemm::layout

--- a/csrc/jit_kernels/heuristics/runtime.hpp
+++ b/csrc/jit_kernels/heuristics/runtime.hpp
@@ -55,6 +55,18 @@ public:
         }
         return block_m;
     }
+
+    static int get_recommended_mk_alignment_for_contiguous_layout(const bool& use_psum_layout,
+                                                                  const std::optional<int>& expected_m,
+                                                                  const std::optional<int>& expected_k,
+                                                                  const std::optional<int>& expected_num_groups) {
+        if (device_runtime->get_arch_major() == 9 and not use_psum_layout and
+            expected_m.has_value() and expected_m.value() == 128 and
+            expected_k.has_value() and expected_k.value() <= 256 and
+            expected_num_groups.has_value() and expected_num_groups.value() == 4)
+            return 64;
+        return get_theoretical_mk_alignment_for_contiguous_layout(expected_m);
+    }
 };
 
 static auto heuristics_runtime = LazyInit<HeuristicsRuntime>([](){ return std::make_shared<HeuristicsRuntime>(); });

--- a/deep_gemm/utils/layout.py
+++ b/deep_gemm/utils/layout.py
@@ -14,6 +14,7 @@ from .._C import (
     set_mk_alignment_for_contiguous_layout,
     get_mk_alignment_for_contiguous_layout,
     get_theoretical_mk_alignment_for_contiguous_layout,
+    get_recommended_mk_alignment_for_contiguous_layout,
 )
 
 # Some alias

--- a/tests/test_sm90_small_m_alignment.py
+++ b/tests/test_sm90_small_m_alignment.py
@@ -1,0 +1,80 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "tests"))
+import deep_gemm
+from deep_gemm.testing import calc_diff, get_arch_major
+
+from generators import (  # noqa: E402
+    MajorTypeAB,
+    QuantConfig,
+    align,
+    generate_m_grouped_contiguous,
+    get_mk_alignment_for_contiguous_layout,
+)
+
+
+def test_sm90_m_grouped_gemm_contiguous_small_m_recommended_alignment() -> None:
+    if get_arch_major() != 9:
+        return
+
+    print("Testing SM90 m-grouped contiguous GEMM small-M recommended alignment:")
+    quant_config = QuantConfig()
+    recipe, recipe_a, recipe_b = quant_config.get_recipes()
+    num_groups = 4
+    expected_m_per_group = 128
+    theoretical_alignment = deep_gemm.get_theoretical_mk_alignment_for_contiguous_layout(expected_m_per_group)
+    assert deep_gemm.get_recommended_mk_alignment_for_contiguous_layout(False, 128, 128, 4) == 64
+    assert deep_gemm.get_recommended_mk_alignment_for_contiguous_layout(False, 128, 256, 4) == 64
+    assert deep_gemm.get_recommended_mk_alignment_for_contiguous_layout(True, 128, 128, 4) == theoretical_alignment
+    assert deep_gemm.get_recommended_mk_alignment_for_contiguous_layout(False, 64, 128, 4) == theoretical_alignment
+    assert deep_gemm.get_recommended_mk_alignment_for_contiguous_layout(False, 128, 512, 4) == theoretical_alignment
+    assert deep_gemm.get_recommended_mk_alignment_for_contiguous_layout(False, 128, 128, 8) == theoretical_alignment
+
+    for use_psum_layout, n in ((False, 4096), (True, 7168)):
+        for k in (128, 256):
+            deep_gemm.set_mk_alignment_for_contiguous_layout(
+                deep_gemm.get_recommended_mk_alignment_for_contiguous_layout(
+                    use_psum_layout, expected_m_per_group, k, num_groups
+                )
+            )
+            m, a, b, grouped_layout, d, ref_d = generate_m_grouped_contiguous(
+                num_groups=num_groups,
+                expected_m_per_group=expected_m_per_group,
+                n=n,
+                k=k,
+                major_a=MajorTypeAB.KMajor,
+                major_b=MajorTypeAB.KMajor,
+                use_ue8m0=False,
+                use_psum_layout=use_psum_layout,
+                quant_config=quant_config,
+            )
+
+            deep_gemm.m_grouped_fp8_fp4_gemm_nt_contiguous(
+                a,
+                b,
+                d,
+                grouped_layout,
+                disable_ue8m0_cast=True,
+                use_psum_layout=use_psum_layout,
+                recipe=recipe,
+                recipe_a=recipe_a,
+                recipe_b=recipe_b,
+            )
+
+            if use_psum_layout:
+                for j in range(num_groups):
+                    start = 0 if j == 0 else align(grouped_layout[j - 1], get_mk_alignment_for_contiguous_layout())
+                    end = grouped_layout[j]
+                    diff = calc_diff(d[start:end], ref_d[start:end])
+                    assert diff < quant_config.max_diff(), (
+                        f"{m=}, {n=}, {k=}, psum={use_psum_layout}, {j=}, {diff:.5f}"
+                    )
+            else:
+                diff = calc_diff(d, ref_d)
+                assert diff < quant_config.max_diff(), f"{m=}, {n=}, {k=}, psum={use_psum_layout}, {diff:.5f}"
+
+
+if __name__ == "__main__":
+    test_sm90_m_grouped_gemm_contiguous_small_m_recommended_alignment()

--- a/tools/bench_sm90_small_m_m_grouped.py
+++ b/tools/bench_sm90_small_m_m_grouped.py
@@ -1,0 +1,184 @@
+import argparse
+import random
+import sys
+from pathlib import Path
+
+import statistics
+import torch
+
+
+ROOT = Path.cwd().resolve()
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(ROOT / "tests"))
+
+import deep_gemm  # noqa: E402
+from deep_gemm.testing import bench_kineto, calc_diff  # noqa: E402
+from generators import MajorTypeAB, QuantConfig, generate_m_grouped_contiguous  # noqa: E402
+
+
+def parse_int_list(value: str) -> list[int]:
+    return [int(x) for x in value.split(",") if x]
+
+
+def parse_bool_list(value: str) -> list[bool]:
+    values = []
+    for item in value.split(","):
+        item = item.strip().lower()
+        if item in ("1", "true", "t", "yes", "y"):
+            values.append(True)
+        elif item in ("0", "false", "f", "no", "n"):
+            values.append(False)
+        elif item:
+            raise ValueError(f"Invalid boolean value: {item}")
+    return values
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--num-groups", type=int, default=4)
+    parser.add_argument("--num-groups-list", type=parse_int_list, default=None)
+    parser.add_argument("--expected-m-per-group", type=int, default=128)
+    parser.add_argument("--expected-m-list", type=parse_int_list, default=None)
+    parser.add_argument("--n-list", type=parse_int_list, default=parse_int_list("3072,4096,6144,7168"))
+    parser.add_argument("--k-list", type=parse_int_list, default=parse_int_list("128,256"))
+    parser.add_argument("--psum-list", type=parse_bool_list, default=parse_bool_list("false,true"))
+    parser.add_argument("--mk-alignment", type=int, default=128)
+    parser.add_argument("--block-n-multiple", type=int, default=1)
+    parser.add_argument("--print-configs", action="store_true")
+    parser.add_argument("--compare-recommended", action="store_true")
+    parser.add_argument("--repeat", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    if torch.cuda.get_device_capability()[0] != 9:
+        raise RuntimeError("This benchmark targets SM90 GPUs")
+
+    deep_gemm.set_block_size_multiple_of((1, args.block_n_multiple))
+    if args.print_configs:
+        import os
+        os.environ["DG_PRINT_CONFIGS"] = "1"
+
+    quant_config = QuantConfig()
+    recipe, recipe_a, recipe_b = quant_config.get_recipes()
+    num_groups_list = args.num_groups_list if args.num_groups_list is not None else [args.num_groups]
+    expected_m_list = args.expected_m_list if args.expected_m_list is not None else [args.expected_m_per_group]
+
+    def percentile(values: list[float], pct: float) -> float:
+        assert values
+        if len(values) == 1:
+            return values[0]
+        sorted_values = sorted(values)
+        rank = (len(sorted_values) - 1) * pct
+        lower = int(rank)
+        upper = min(lower + 1, len(sorted_values) - 1)
+        weight = rank - lower
+        return sorted_values[lower] * (1.0 - weight) + sorted_values[upper] * weight
+
+    def bench_case(num_groups: int, expected_m: int, psum: bool, n: int, k: int,
+                   mk_alignment: int) -> tuple[int, float, float, float, float, float, float]:
+        deep_gemm.set_mk_alignment_for_contiguous_layout(mk_alignment)
+        times = []
+        last_m = None
+        last_diff = None
+        for _ in range(args.repeat):
+            torch.manual_seed(args.seed)
+            random.seed(args.seed)
+            m, a, b, grouped_layout, d, ref_d = generate_m_grouped_contiguous(
+                num_groups,
+                expected_m,
+                n,
+                k,
+                MajorTypeAB.KMajor,
+                MajorTypeAB.KMajor,
+                use_ue8m0=False,
+                use_psum_layout=psum,
+                quant_config=quant_config,
+            )
+
+            def run():
+                deep_gemm.m_grouped_fp8_fp4_gemm_nt_contiguous(
+                    a,
+                    b,
+                    d,
+                    grouped_layout,
+                    disable_ue8m0_cast=True,
+                    use_psum_layout=psum,
+                    recipe=recipe,
+                    recipe_a=recipe_a,
+                    recipe_b=recipe_b,
+                )
+
+            run()
+            diff = calc_diff(d, ref_d)
+            if diff >= quant_config.max_diff():
+                raise AssertionError((psum, n, k, diff))
+
+            t = bench_kineto(run, "gemm_", suppress_kineto_output=True)
+            times.append(t * 1e6)
+            last_m = m
+            last_diff = diff
+        return (
+            last_m,
+            min(times),
+            statistics.median(times),
+            sum(times) / len(times),
+            percentile(times, 0.9),
+            max(times),
+            last_diff,
+        )
+
+    if args.compare_recommended:
+        print(
+            "num_groups,expected_m_per_group,psum,n,k,baseline_alignment,recommended_alignment,"
+            "baseline_m,recommended_m,baseline_median_us,recommended_median_us,speedup,"
+            "baseline_avg_us,recommended_avg_us,baseline_p90_us,recommended_p90_us,diff",
+            flush=True,
+        )
+        for num_groups in num_groups_list:
+            for expected_m in expected_m_list:
+                for psum in args.psum_list:
+                    for n in args.n_list:
+                        for k in args.k_list:
+                            baseline_alignment = deep_gemm.get_theoretical_mk_alignment_for_contiguous_layout(expected_m)
+                            recommended_alignment = deep_gemm.get_recommended_mk_alignment_for_contiguous_layout(
+                                psum, expected_m, k, num_groups
+                            )
+                            baseline = bench_case(num_groups, expected_m, psum, n, k, baseline_alignment)
+                            recommended = bench_case(num_groups, expected_m, psum, n, k, recommended_alignment)
+                            baseline_m, _, baseline_median, baseline_avg, baseline_p90, _, _ = baseline
+                            recommended_m, _, recommended_median, recommended_avg, recommended_p90, _, diff = recommended
+                            print(
+                                f"{num_groups},{expected_m},{int(psum)},{n},{k},"
+                                f"{baseline_alignment},{recommended_alignment},"
+                                f"{baseline_m},{recommended_m},"
+                                f"{baseline_median:.3f},{recommended_median:.3f},"
+                                f"{baseline_median / recommended_median:.4f},"
+                                f"{baseline_avg:.3f},{recommended_avg:.3f},"
+                                f"{baseline_p90:.3f},{recommended_p90:.3f},{diff:.6f}",
+                                flush=True,
+                            )
+        return
+
+    print(
+        "num_groups,expected_m_per_group,psum,n,k,m,mk_alignment,block_n_multiple,"
+        "repeat,min_us,median_us,avg_us,p90_us,max_us,diff",
+        flush=True,
+    )
+    for num_groups in num_groups_list:
+        for expected_m in expected_m_list:
+            for psum in args.psum_list:
+                for n in args.n_list:
+                    for k in args.k_list:
+                        m, min_us, median_us, avg_us, p90_us, max_us, diff = bench_case(
+                            num_groups, expected_m, psum, n, k, args.mk_alignment
+                        )
+                        print(
+                            f"{num_groups},{expected_m},{int(psum)},{n},{k},{m},{args.mk_alignment},"
+                            f"{args.block_n_multiple},{args.repeat},"
+                            f"{min_us:.3f},{median_us:.3f},{avg_us:.3f},{p90_us:.3f},{max_us:.3f},{diff:.6f}",
+                            flush=True,
+                        )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

  ## Summary

  This PR adds a shape-aware recommended M/K alignment helper for contiguous grouped layouts.

  The existing `get_theoretical_mk_alignment_for_contiguous_layout()` keeps SM90 on the legacy 128 alignment. For SM90 m-grouped contiguous GEMM, this can introduce extra
  padded rows for some small-M non-psum shapes.

  This PR adds an opt-in recommendation helper that returns 64 only for the empirically validated shape family:

  - SM90
  - non-psum m-grouped contiguous layout
  - `num_groups == 4`
  - `expected_m == 128`
  - `expected_k <= 256`

  All other shapes fall back to the existing theoretical alignment.

  This does not change the default alignment.

  ## Motivation

  Grouped contiguous layout requires each expert segment to be aligned by `get_mk_alignment_for_contiguous_layout()`. In the target small-M case, using 128 alignment pads
  the generated test shape from `M=640` to `M=768`.

  Reducing the recommended alignment to 64 for the validated shape reduces padded rows while preserving correctness.

  Broader scans showed regressions for other shapes such as `expected_m=64`, `expected_m=192`, `num_groups=8/16`, and `k>=512`, so this helper intentionally keeps the 64
  recommendation restricted.

  ## Changes

  - Add `get_recommended_mk_alignment_for_contiguous_layout(use_psum_layout, expected_m, expected_k, expected_num_groups)`.
  - Expose the helper through the Python layout API.
  - Document the helper in README.
  - Rename the benchmark/test wording from small-K to small-M.
  - Add SM90 correctness and guardrail coverage for:
    - target shape returns 64
    - psum layout falls back
    - `expected_m=64` falls back
    - `k=512` falls back
    - `num_groups=8` falls back

  ## Benchmark

  Hardware:

  - NVIDIA H200
  - SM90
  - CUDA 12.8
  - NVCC 12.8

  Command:

  ```bash
  python tools/bench_sm90_small_m_m_grouped.py \
    --compare-recommended \
    --num-groups-list 4,8,16 \
    --expected-m-list 128,192 \
    --n-list 3072,4096,6144,7168 \
    --k-list 128,256,512,1024 \
    --psum-list false,true \
    --repeat 20

  Target shape results:

  num_groups=4, expected_m=128, psum=false

  n,k,baseline_alignment,recommended_alignment,baseline_m,recommended_m,speedup
  3072,128,128,64,768,640,1.0361x
  3072,256,128,64,768,640,1.0020x
  4096,128,128,64,768,640,1.0944x
  4096,256,128,64,768,640,1.0492x
  6144,128,128,64,768,640,1.0975x
  6144,256,128,64,768,640,1.0610x
  7168,128,128,64,768,640,1.1163x
  7168,256,128,64,768,640,1.0603x

  Non-target shapes keep recommended_alignment=128, including:

  - psum=true
  - expected_m=192
  - k=512/1024

  This avoids the regressions observed when applying 64 alignment more broadly.

  ## Testing

  python -m py_compile \
    tools/bench_sm90_small_m_m_grouped.py \
    tests/test_sm90_small_m_alignment.py

  On H200:

  python tests/test_sm90_small_m_alignment.py
