### PR TITLE
Fix OOB in paged MQA logits metadata scheduler

### DIFF
--- a/deep_gemm/include/deep_gemm/scheduler/paged_mqa_logits.cuh
+++ b/deep_gemm/include/deep_gemm/scheduler/paged_mqa_logits.cuh
@@ -111,7 +111,7 @@ void smxx_paged_mqa_logits_metadata(const uint32_t batch_size, const uint32_t ne
                 lo = pred ? mid + 1 : lo;
                 hi = pred ? hi : mid;
             }
-            const uint32_t q_idx = lo;
+            const uint32_t q_idx = min(lo, batch_size - 1);
             const uint32_t offset_in_q = (q_idx == 0 ? seg_starts : seg_starts - prefix_sum[q_idx - 1] * num_next_n_atoms);
             const uint32_t num_segs_q = (q_idx == 0 ? prefix_sum[0] : prefix_sum[q_idx] - prefix_sum[q_idx - 1]);
             const uint32_t atom_idx = num_segs_q > 0 ? offset_in_q / num_segs_q : 0;


### PR DESCRIPTION
When all context_lens are zero (e.g. warmup decode with kv_lens=1 and indexer_compress_ratio=4 giving gen_seq_lens=0), the binary search pushes lo to batch_size. The subsequent prefix_sum[q_idx] access is OOB when q_idx == batch_size == kAlignedBatchSize, since prefix_sum only has indices [0, batch_size).

Fix: clamp q_idx to batch_size - 1. When the binary search lands past all queries (total work = 0), num_segs_q correctly evaluates to 0, and the existing guards (num_segs_q > 0 ? ...) produce the sentinel values (atom_idx=0, kv_split_idx=0).