### PR TITLE
Fix OOB shared-memory read in paged MQA logits metadata for empty batches

### DIFF
--- a/deep_gemm/include/deep_gemm/scheduler/paged_mqa_logits.cuh
+++ b/deep_gemm/include/deep_gemm/scheduler/paged_mqa_logits.cuh
@@ -110,7 +110,7 @@ void smxx_paged_mqa_logits_metadata(const uint32_t batch_size, const uint32_t ne
             }
             const uint32_t q_idx = lo;
             const uint32_t offset_in_q = (q_idx == 0 ? seg_starts : seg_starts - prefix_sum[q_idx - 1] * num_next_n_atoms);
-            const uint32_t num_segs_q = (q_idx == 0 ? prefix_sum[0] : prefix_sum[q_idx] - prefix_sum[q_idx - 1]);
+            const uint32_t num_segs_q = (q_idx == 0 ? prefix_sum[0] : (q_idx >= batch_size ? 0u : prefix_sum[q_idx] - prefix_sum[q_idx - 1]));
             const uint32_t atom_idx = num_segs_q > 0 ? offset_in_q / num_segs_q : 0;
             const uint32_t kv_split_idx = num_segs_q > 0 ? offset_in_q % num_segs_q : 0;
             const uint32_t q_atom_idx = q_idx * num_next_n_atoms + atom_idx;


### PR DESCRIPTION

In the non-varlen branch of `smxx_paged_mqa_logits_metadata`, when the total amount of work is zero (every `context_len` maps to 0 KV segments, e.g. an all-empty decode/warmup batch), `seg_starts` is 0 for every SM and the binary search saturates to `q_idx == batch_size`. The subsequent

    num_segs_q = prefix_sum[q_idx] - prefix_sum[q_idx - 1]

then reads `prefix_sum[batch_size]`, which is out of bounds of the `prefix_sum` shared-memory buffer (it only holds `kAlignedBatchSize` entries), causing CUDA_ERROR_ILLEGAL_ADDRESS.

The varlen branch already guards the equivalent empty-work case. Clamp `num_segs_q` to 0 when `q_idx >= batch_size` so empty SMs fall through to the `atom_idx == 0` / `kv_split_idx == 0` path and emit the `batch_size * num_next_n_atoms` end sentinel.

Repro: call `get_paged_mqa_logits_metadata` with an all-zero `context_lens` tensor; compute-sanitizer reports "Invalid __shared__ read" in `smxx_paged_mqa_logits_metadata`, which this patch eliminates. Surfaced by TensorRT-LLM DeepSeek-V4 sparse-MLA indexer warmup (empty KV) on Blackwell.