### PR TITLE
fix: use importlib to load scripts/generate_pyi.py instead of package…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ from packaging.version import parse
 from pathlib import Path
 from torch.utils.cpp_extension import CUDAExtension, CUDA_HOME
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
-from scripts.generate_pyi import generate_pyi_file
 
 
 DG_SKIP_CUDA_BUILD = int(os.getenv('DG_SKIP_CUDA_BUILD', '0')) == 1
@@ -126,7 +125,13 @@ class CustomBuildPy(build_py):
         build_py.run(self)
 
     def generate_pyi_file(self):
-        generate_pyi_file(name='_C', root='./csrc', output_dir='./stubs')
+        import importlib.util
+        spec = importlib.util.spec_from_file_location(
+            'generate_pyi', os.path.join(current_dir, 'scripts', 'generate_pyi.py')
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        mod.generate_pyi_file(name='_C', root='./csrc', output_dir='./stubs')
         pyi_source = os.path.join(current_dir, 'stubs', '_C.pyi')
         pyi_target = os.path.join(self.build_lib, 'deep_gemm', '_C.pyi')
 


### PR DESCRIPTION
Hi, I ran into an install issue and this PR fixes it.

## What happened

Fresh clone + `./install.sh` blows up with:

```
ModuleNotFoundError: No module named 'scripts.generate_pyi'
```

The root cause is that `setup.py` does `from scripts.generate_pyi import generate_pyi_file` at the top level, but `scripts/` doesn't have an `__init__.py` — so Python doesn't recognize it as a package.

Looks like this was introduced in #231 when `generate_pyi.py` was added to `scripts/`.

## How to reproduce

```bash
git clone --recursive https://github.com/deepseek-ai/DeepGEMM.git
cd DeepGEMM
./install.sh   # boom
```

## What I changed

Instead of adding a `__init__.py` to `scripts/` (which feels wrong since it's not really a package), I moved the import into `CustomBuildPy.generate_pyi_file()` and used `importlib` to load it by file path:

```python
import importlib.util
spec = importlib.util.spec_from_file_location(
    'generate_pyi', os.path.join(current_dir, 'scripts', 'generate_pyi.py')
)
mod = importlib.util.module_from_spec(spec)
spec.loader.exec_module(mod)
mod.generate_pyi_file(name='_C', root='./csrc', output_dir='./stubs')
```

This way `scripts/` stays as a plain utility directory and the import only happens at build time when it's actually needed.

Tested locally, `./install.sh` works fine after the change.