### PR TITLE
fix: index CUDA sources/headers when generating .pyi stubs

### DIFF
--- a/scripts/generate_pyi.py
+++ b/scripts/generate_pyi.py
@@ -4,7 +4,11 @@ from pathlib import Path
 
 def build_cpp_function_index(root_path):
     func_index = {}
-    extensions = {'.cpp', '.cc', '.cxx', '.c', '.hpp', '.h'}
+    # Include CUDA sources/headers: bound functions in this project may be
+    # defined in `.cu` or declared in `.cuh`, and the `is_header` check below
+    # already treats `.cuh` as a header. Without them such functions are missed
+    # and fall back to a generic `(*args, **kwargs) -> Any` stub.
+    extensions = {'.cpp', '.cc', '.cxx', '.c', '.cu', '.hpp', '.h', '.cuh'}
 
     pattern = re.compile(
         r'([\w:\s*<&>,\[\]\(\)]+?)'
@@ -153,7 +157,7 @@ def extract_m_def_statements(root_path):
     Scan all c files under root_path and extract all m.def(...) statements.
     """
     results = []
-    extensions = {'.hpp', '.cpp', '.h', '.cc'}
+    extensions = {'.hpp', '.cpp', '.h', '.cc', '.cu', '.cuh'}
 
     # Regex: match m.def( ... ), supports multi-line
     pattern = re.compile(r'm\.def\s*\(')


### PR DESCRIPTION
## Problem

`scripts/generate_pyi.py` builds the type stubs (`stubs/_C.pyi`) consumed at build time by `setup.py` (`generate_pyi_file(name='_C', root='./csrc', ...)`). It locates each bound function's C++ signature by scanning source files, but the extension allowlists omit CUDA sources/headers:

```python
# build_cpp_function_index
extensions = {'.cpp', '.cc', '.cxx', '.c', '.hpp', '.h'}      # no .cu / .cuh
# extract_m_def_statements
extensions = {'.hpp', '.cpp', '.h', '.cc'}                    # no .cu / .cuh
```

So any `m.def`-bound function whose C++ definition/declaration lives in a `.cu` or `.cuh` is **not found**, and its stub falls back to a generic `def name(*args, **kwargs) -> Any: ...` (the code even logs `Warning: C++ function "<name>" not found in any .cpp file`).

This is also internally inconsistent: `build_cpp_function_index` already classifies `.cuh` as a header in its `is_header` check —

```python
is_header = file_path.suffix.lower() in {'.h', '.hpp', '.cuh'}
```

— but never *reads* `.cuh` files, so that branch is unreachable.

## Fix

Add `.cu` and `.cuh` to both allowlists.

## Validation

Ran the generator's parser over `./csrc` before and after:

- **No regression on the current tree:** all 38 resolvable bound signatures still resolve (the 12 lambdas are unaffected). The repo's only `.cu` file, `csrc/indexing/main.cu`, registers no bindings, so output is byte-identical today.
- **Defect reproduced and fixed** with a minimal case — a binding registered in a `.hpp` whose C++ function is declared in a sibling `.cuh`:
  - before: `my_kernel` not indexed → `Warning: ... not found in any .cpp file` → generic `*args` stub
  - after: resolves to `torch::Tensor my_kernel(torch::Tensor x)` (typed stub)
  - same for a `.cu`-*defined* binding → `int cu_fn(int a, int b)`

The change is forward-looking: as more kernels/bindings move into `.cu`/`.cuh`, their public stubs stay typed instead of silently degrading to `Any`.
