### PR TITLE
fix: fence combine buffer reuse in mega moe

### DIFF
--- a/deep_gemm/include/deep_gemm/impls/sm100_bf16_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_bf16_mega_moe.cuh
@@ -1238,6 +1238,8 @@ sm100_bf16_mega_moe_impl(void* y,
                         for (uint32_t l = 0; l < kNumElemsPerUint4; ++ l)
                             ptx::accumulate(reduced[j * kNumElemsPerUint4 + l], bf16_values[l]);
                     }
+                    // Order generic shared-memory reads before the next TMA load reuses this stage.
+                    ptx::fence_proxy_async_shared_cta();
                     combine_phase ^= load_stage_idx;
                     load_stage_idx ^= 1;
                 }

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
@@ -1416,6 +1416,8 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                         for (uint32_t l = 0; l < kNumElemsPerUint4; ++ l)
                             ptx::accumulate(reduced[j * kNumElemsPerUint4 + l], bf16_values[l]);
                     }
+                    // Order generic shared-memory reads before the next TMA load reuses this stage.
+                    ptx::fence_proxy_async_shared_cta();
                     combine_phase ^= load_stage_idx;
                     load_stage_idx ^= 1;
                 }

--- a/deep_gemm/include/deep_gemm/ptx/utils.cuh
+++ b/deep_gemm/include/deep_gemm/ptx/utils.cuh
@@ -28,6 +28,10 @@ CUTLASS_DEVICE void sync_unaligned(const uint32_t& num_threads, const uint32_t& 
     asm volatile("barrier.sync %0, %1;" : : "r"(barrier_idx), "r"(num_threads));
 }
 
+CUTLASS_DEVICE void fence_proxy_async_shared_cta() {
+    asm volatile("fence.proxy.async.shared::cta;" ::: "memory");
+}
+
 template <typename dtype_t>
 CUTLASS_DEVICE dtype_t exchange(dtype_t ptr, const uint32_t& src_lane_idx) {
     DG_STATIC_ASSERT(sizeof(dtype_t) % sizeof(uint32_t) == 0, "");


### PR DESCRIPTION
## Summary

This PR fixes a shared-memory reuse race in the final combine stage of the SM100 Mega MoE kernels:

- `fp8_fp4_mega_moe`
- `bf16_mega_moe`

Both kernels use two shared-memory load stages. A stage is filled by TMA through the async proxy, consumed by the warp through generic shared-memory loads, and then reused by a later TMA load. The old code did not order the generic reads against the next async-proxy write to the same stage.

The fix adds `fence.proxy.async.shared::cta` after every lane has consumed the current stage and before that stage can be selected for reuse.

## Problem

The combine loop overlaps loading and reduction with a two-stage ping-pong buffer:

```mermaid
sequenceDiagram
    participant TMA as TMA async proxy
    participant S0 as Shared stage 0
    participant S1 as Shared stage 1
    participant W as Epilogue warp

    TMA->>S0: Load top-k contribution 0
    TMA->>S1: Prefetch contribution 1
    W->>S0: Wait on mbarrier and read stage 0
    Note over W,S0: Generic shared-memory reads
    TMA->>S0: Reuse stage 0 for contribution 2
    Note over TMA,S0: Async-proxy write may race with prior generic reads
```

The mbarrier wait makes the previous TMA load visible before the warp reads the stage. It does not, by itself, order those generic reads before a later TMA async-proxy write that reuses the same shared-memory addresses. Under unlucky timing, the new TMA load can overwrite data while lanes are still consuming the old contribution, corrupting the final reduction.

## Fix

```mermaid
flowchart LR
    A[TMA load into stage] --> B[mbarrier wait]
    B --> C[All lanes read and accumulate]
    C --> D[fence.proxy.async.shared::cta]
    D --> E[Rotate load stage]
    E --> F[Later TMA load may reuse stage]
```

The new fence establishes the required generic-to-async proxy ordering at CTA scope:

```cpp
// Order generic shared-memory reads before the next TMA load reuses this stage.
ptx::fence_proxy_async_shared_cta();
combine_phase ^= load_stage_idx;
load_stage_idx ^= 1;
```

The PTX instruction is exposed through a small helper in `deep_gemm/ptx/utils.cuh` and used by both affected kernels. There are no API, layout, scheduling, or numerical changes.