### PR TITLE
feat: add SiTU support to FP8/FP4 Mega MoE

### DIFF
--- a/csrc/apis/mega.hpp
+++ b/csrc/apis/mega.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cmath>
 #include <functional>
 #include <string>
 #include <pybind11/functional.h>
@@ -41,7 +42,7 @@ get_symm_buffer_size_for_mega_moe(
     const std::string& mma_type, const std::string& activation,
     const int& num_shared_experts = 0) {
     DG_HOST_ASSERT(num_experts % num_ranks == 0);
-    DG_HOST_ASSERT(activation == "swiglu");
+    DG_HOST_ASSERT(activation == "swiglu" or (mma_type == "fp8xfp4" and activation == "situ"));
     DG_HOST_ASSERT(num_shared_experts >= 0);
 
     // Ring capacity: worst-case live pool blocks over all candidate BLOCK_M; mirrors the kernel assert.
@@ -168,7 +169,9 @@ static void fp8_fp4_mega_moe(
     const std::tuple<int, int, int>& recipe,
     const std::string& activation,
     const std::optional<float>& activation_clamp_opt,
-    const bool& fast_math
+    const bool& fast_math,
+    const std::optional<float>& situ_beta_opt,
+    const std::optional<float>& situ_linear_beta_opt
 ) {
     const auto [l1_weights, l1_weights_sf] = l1_weights_tuple;
     const auto [l2_weights, l2_weights_sf] = l2_weights_tuple;
@@ -177,13 +180,22 @@ static void fp8_fp4_mega_moe(
     const auto num_tokens = static_cast<int>(y.size(0));
     const auto [rm, rn, rk] = recipe;
     DG_HOST_ASSERT(rm == 1 and rn == 1 and rk == 32);
-    DG_HOST_ASSERT(activation == "swiglu");
+    DG_HOST_ASSERT(activation == "swiglu" or activation == "situ");
     DG_HOST_ASSERT(shared_l1_weights_tuple_opt.has_value() == shared_l2_weights_tuple_opt.has_value());
 
     // Activation checks
+    const auto use_situ = activation == "situ";
     const auto activation_clamp =
         activation_clamp_opt.value_or(std::numeric_limits<float>::infinity());
     DG_HOST_ASSERT(activation_clamp >= 0);
+    const auto situ_beta = situ_beta_opt.value_or(0.0f);
+    const auto situ_linear_beta = situ_linear_beta_opt.value_or(0.0f);
+    DG_HOST_ASSERT(not use_situ or not activation_clamp_opt.has_value());
+    DG_HOST_ASSERT(not use_situ or
+                   (std::isfinite(situ_beta) and situ_beta > 0 and
+                    std::isfinite(situ_linear_beta) and situ_linear_beta > 0));
+    DG_HOST_ASSERT(use_situ or
+                   (not situ_beta_opt.has_value() and not situ_linear_beta_opt.has_value()));
 
     // Tensor checks
     DG_HOST_ASSERT(get_major_type_ab(l1_weights) == cute::UMMA::Major::K);
@@ -274,7 +286,8 @@ static void fp8_fp4_mega_moe(
                                num_shared_experts,
                                num_tokens, num_topk,
                                hidden, intermediate_hidden,
-                               activation_clamp, fast_math);
+                               activation_clamp, fast_math,
+                               use_situ, situ_beta, situ_linear_beta);
     } else {
         DG_HOST_UNREACHABLE("Unsupported architecture");
     }

--- a/csrc/jit_kernels/impls/sm100_fp8_fp4_mega_moe.hpp
+++ b/csrc/jit_kernels/impls/sm100_fp8_fp4_mega_moe.hpp
@@ -25,6 +25,8 @@ public:
         int num_ranks;
         float activation_clamp;
         bool fast_math;
+        bool use_situ;
+        float situ_beta, situ_linear_beta;
         MegaMoEConfig config;
 
         // Runtime arguments
@@ -79,6 +81,9 @@ static void __instantiate_kernel() {{
         {}, {}, {},
         {}, {},
         {},
+        {},
+        {},
+        {},
         {}
     >);
 }};
@@ -96,7 +101,9 @@ static void __instantiate_kernel() {{
     args.config.num_dispatch_threads, args.config.num_non_epilogue_threads, args.config.num_epilogue_threads,
     args.launch_args.grid_dim.first, args.num_ranks,
     to_string(args.activation_clamp),
-    args.fast_math ? "true" : "false");
+    args.fast_math ? "true" : "false",
+    args.use_situ ? "true" : "false",
+    to_string(args.situ_beta), to_string(args.situ_linear_beta));
     }
 
     static void launch_impl(const KernelHandle& kernel, const LaunchConfigHandle& config, Args args) {
@@ -146,7 +153,10 @@ static void sm100_fp8_fp4_mega_moe(
     const int& num_tokens, const int& num_topk,
     const int& hidden, const int& intermediate_hidden,
     const float& activation_clamp,
-    const bool& fast_math
+    const bool& fast_math,
+    const bool& use_situ,
+    const float& situ_beta,
+    const float& situ_linear_beta
 ) {
     const auto num_ranks = static_cast<int>(sym_buffer_ptrs.size());
     const auto num_experts = num_experts_per_rank * num_ranks;
@@ -283,6 +293,9 @@ static void sm100_fp8_fp4_mega_moe(
         .num_ranks = num_ranks,
         .activation_clamp = activation_clamp,
         .fast_math = fast_math,
+        .use_situ = use_situ,
+        .situ_beta = situ_beta,
+        .situ_linear_beta = situ_linear_beta,
         .config = config,
         .y = y.data_ptr(),
         .cumulative_local_expert_recv_stats = cumulative_local_expert_recv_stats_ptr,

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
@@ -35,6 +35,9 @@ template <
     uint32_t kNumSMs, uint32_t kNumRanks,
     float kActivationClamp,
     bool kFastMath,
+    bool kUseSiTU,
+    float kSiTUBeta,
+    float kSiTULinearBeta,
     bool kHasShared = (kNumSharedExperts > 0),
     uint32_t L1_SHAPE_N = kIntermediateHidden * 2,
     uint32_t L1_SHAPE_K = kHidden,
@@ -84,6 +87,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
     DG_STATIC_ASSERT(kNumNonEpilogueThreads == 128, "Invalid number of MMA non-epilogue threads");
     DG_STATIC_ASSERT(kNumEpilogueThreads % 128 == 0, "Invalid number of MMA epilogue and combine threads");
     DG_STATIC_ASSERT(kNumExperts % kNumRanks == 0, "Invalid number of experts or ranks");
+    DG_STATIC_ASSERT(not kUseSiTU or (kSiTUBeta > 0 and kSiTULinearBeta > 0), "Invalid SiTU beta");
 
     // Thread indices
     const bool is_leader_cta = cute::block_rank_in_cluster() == 0;
@@ -1042,7 +1046,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                             shared_storage.tmem_empty_barriers[accum_stage_idx].arrive(0u);
                         }
 
-                        // Apply SwiGLU: silu(gate) * up
+                        // Apply SwiGLU or SiTU gated activation
                         auto fp32_values = reinterpret_cast<float2*>(raw_values);
                         #pragma unroll
                         for (uint32_t k = 0; k < 2; ++ k) {
@@ -1056,18 +1060,32 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                                 bf16_up = __hmin2(bf16_up, {kActivationClamp, kActivationClamp});
                             }
 
-                            // SwiGLU
-                            auto gate = __bfloat1622float2(bf16_gate);
+                            // SwiGLU or SiTU
+                            const auto raw_gate = __bfloat1622float2(bf16_gate);
                             auto neg_gate_exp = make_float2(
-                                kFastMath ? __expf(-gate.x) : expf(-gate.x),
-                                kFastMath ? __expf(-gate.y) : expf(-gate.y));
+                                kFastMath ? __expf(-raw_gate.x) : expf(-raw_gate.x),
+                                kFastMath ? __expf(-raw_gate.y) : expf(-raw_gate.y));
                             const auto denom = __fadd2_rn({1.0f, 1.0f}, neg_gate_exp);
-                            if constexpr (kFastMath) {
+                            auto gate = raw_gate;
+                            auto up = __bfloat1622float2(bf16_up);
+                            if constexpr (kUseSiTU) {
+                                float2 sigmoid;
+                                if constexpr (kFastMath) {
+                                    sigmoid = {math::fast_rcp(denom.x), math::fast_rcp(denom.y)};
+                                } else {
+                                    sigmoid = {1.0f / denom.x, 1.0f / denom.y};
+                                }
+                                gate = __fmul2_rn(sigmoid, {
+                                    kSiTUBeta * tanhf(raw_gate.x / kSiTUBeta),
+                                    kSiTUBeta * tanhf(raw_gate.y / kSiTUBeta)});
+                                up = {
+                                    kSiTULinearBeta * tanhf(up.x / kSiTULinearBeta),
+                                    kSiTULinearBeta * tanhf(up.y / kSiTULinearBeta)};
+                            } else if constexpr (kFastMath) {
                                 gate = __fmul2_rn(gate, {math::fast_rcp(denom.x), math::fast_rcp(denom.y)});
                             } else {
                                 gate = {gate.x / denom.x, gate.y / denom.y};
                             }
-                            const auto up = __bfloat1622float2(bf16_up);
                             activation_values[i][k] = __fmul2_rn(__fmul2_rn(gate, up), weights);
                         }
 

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
@@ -1060,32 +1060,42 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                                 bf16_up = __hmin2(bf16_up, {kActivationClamp, kActivationClamp});
                             }
 
-                            // SwiGLU or SiTU
-                            const auto raw_gate = __bfloat1622float2(bf16_gate);
-                            auto neg_gate_exp = make_float2(
-                                kFastMath ? __expf(-raw_gate.x) : expf(-raw_gate.x),
-                                kFastMath ? __expf(-raw_gate.y) : expf(-raw_gate.y));
-                            const auto denom = __fadd2_rn({1.0f, 1.0f}, neg_gate_exp);
-                            auto gate = raw_gate;
-                            auto up = __bfloat1622float2(bf16_up);
+                            // SiTU
                             if constexpr (kUseSiTU) {
+                                const auto raw_gate = __bfloat1622float2(bf16_gate);
+                                const auto raw_up = __bfloat1622float2(bf16_up);
+                                auto neg_gate_exp = make_float2(
+                                    kFastMath ? __expf(-raw_gate.x) : expf(-raw_gate.x),
+                                    kFastMath ? __expf(-raw_gate.y) : expf(-raw_gate.y));
+                                const auto denom = __fadd2_rn({1.0f, 1.0f}, neg_gate_exp);
                                 float2 sigmoid;
                                 if constexpr (kFastMath) {
                                     sigmoid = {math::fast_rcp(denom.x), math::fast_rcp(denom.y)};
                                 } else {
                                     sigmoid = {1.0f / denom.x, 1.0f / denom.y};
                                 }
-                                gate = __fmul2_rn(sigmoid, {
+                                const auto gate = __fmul2_rn(sigmoid, {
                                     kSiTUBeta * tanhf(raw_gate.x / kSiTUBeta),
                                     kSiTUBeta * tanhf(raw_gate.y / kSiTUBeta)});
-                                up = {
-                                    kSiTULinearBeta * tanhf(up.x / kSiTULinearBeta),
-                                    kSiTULinearBeta * tanhf(up.y / kSiTULinearBeta)};
-                            } else if constexpr (kFastMath) {
+                                const auto up = make_float2(
+                                    kSiTULinearBeta * tanhf(raw_up.x / kSiTULinearBeta),
+                                    kSiTULinearBeta * tanhf(raw_up.y / kSiTULinearBeta));
+                                activation_values[i][k] = __fmul2_rn(__fmul2_rn(gate, up), weights);
+                                continue;
+                            }
+
+                            // SwiGLU
+                            auto gate = __bfloat1622float2(bf16_gate);
+                            auto neg_gate_exp = make_float2(
+                                kFastMath ? __expf(-gate.x) : expf(-gate.x),
+                                kFastMath ? __expf(-gate.y) : expf(-gate.y));
+                            const auto denom = __fadd2_rn({1.0f, 1.0f}, neg_gate_exp);
+                            if constexpr (kFastMath) {
                                 gate = __fmul2_rn(gate, {math::fast_rcp(denom.x), math::fast_rcp(denom.y)});
                             } else {
                                 gate = {gate.x / denom.x, gate.y / denom.y};
                             }
+                            const auto up = __bfloat1622float2(bf16_up);
                             activation_values[i][k] = __fmul2_rn(__fmul2_rn(gate, up), weights);
                         }
 

--- a/deep_gemm/mega/__init__.py
+++ b/deep_gemm/mega/__init__.py
@@ -135,8 +135,9 @@ def transform_weights_for_mega_moe(
     activation: str = 'swiglu'
 ) -> Tuple[Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
            Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]]:
-    assert activation == 'swiglu' or (activation == 'situ' and isinstance(l1_weights, tuple)), \
-        f'Only FP8xFP4 MegaMoE weights support `situ`, got activation={activation!r}'
+    assert activation in ('swiglu', 'situ'), f'Unsupported activation: {activation!r}'
+    assert activation != 'situ' or (isinstance(l1_weights, tuple) and isinstance(l2_weights, tuple)), \
+        '`situ` requires FP8xFP4 `(weight, sf)` tuples for both L1 and L2 weights'
     if isinstance(l1_weights, tuple):
         # FP8: interleave gate/up for weight and SF, then transpose L1 SF for UTCCP
         l1_w = _interleave_weights(l1_weights[0])

--- a/deep_gemm/mega/__init__.py
+++ b/deep_gemm/mega/__init__.py
@@ -23,7 +23,8 @@ class SymmBuffer:
                  num_shared_experts: int = 0,
                  mma_type: str = 'fp8xfp4',
                  activation: str = 'swiglu'):
-        assert activation == 'swiglu', f'Only `swiglu` activation is supported, got `{activation}`'
+        assert activation == 'swiglu' or (mma_type == 'fp8xfp4' and activation == 'situ'), \
+            f'Only FP8xFP4 MegaMoE supports `situ`, got mma_type={mma_type!r}, activation={activation!r}'
         self.group = group
         self.num_experts = num_experts
         self.num_max_tokens_per_rank = num_max_tokens_per_rank
@@ -134,7 +135,8 @@ def transform_weights_for_mega_moe(
     activation: str = 'swiglu'
 ) -> Tuple[Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
            Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]]:
-    assert activation == 'swiglu', f'Only `swiglu` activation is supported, got `{activation}`'
+    assert activation == 'swiglu' or (activation == 'situ' and isinstance(l1_weights, tuple)), \
+        f'Only FP8xFP4 MegaMoE weights support `situ`, got activation={activation!r}'
     if isinstance(l1_weights, tuple):
         # FP8: interleave gate/up for weight and SF, then transpose L1 SF for UTCCP
         l1_w = _interleave_weights(l1_weights[0])
@@ -160,7 +162,9 @@ def fp8_fp4_mega_moe(y: torch.Tensor,
                      recipe: Tuple[int, int, int] = (1, 1, 32),
                      activation: str = 'swiglu',
                      activation_clamp: Optional[float] = None,
-                     fast_math: bool = True):
+                     fast_math: bool = True,
+                     situ_beta: Optional[float] = None,
+                     situ_linear_beta: Optional[float] = None):
     _C.fp8_fp4_mega_moe(
         y,
         l1_weights, l2_weights,
@@ -172,7 +176,8 @@ def fp8_fp4_mega_moe(y: torch.Tensor,
         sym_buffer.num_experts, sym_buffer.num_topk,
         recipe,
         activation, activation_clamp,
-        fast_math
+        fast_math,
+        situ_beta, situ_linear_beta
     )
 
 def bf16_mega_moe(y: torch.Tensor,

--- a/tests/test_mega_moe.py
+++ b/tests/test_mega_moe.py
@@ -79,6 +79,7 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
 
     # Settings
     is_bf16xbf16 = args.mma_type == 'bf16xbf16'
+    assert not is_bf16xbf16 or args.activation == 'swiglu', 'SiTU is supported only for FP8xFP4 MegaMoE'
     num_max_tokens_per_rank = args.num_max_tokens_per_rank
     num_tokens = max(0, args.num_max_tokens_per_rank - random.randint(0, args.num_max_removed_tokens)) \
         if args.num_tokens == 0 else args.num_tokens
@@ -95,7 +96,8 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
         num_max_tokens_per_rank, num_topk,
         hidden, intermediate_hidden,
         num_shared_experts=num_shared_experts,
-        mma_type=args.mma_type
+        mma_type=args.mma_type,
+        activation=args.activation
     )
 
     # Cast weights into FP4
@@ -158,10 +160,11 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
                 shared_l2_weights = _cast_fp8_for_mega_moe(shared_l2_weights)[0::2]
 
         transformed_l1_weights, transformed_l2_weights = (
-            deep_gemm.transform_weights_for_mega_moe(l1_weights, l2_weights))
+            deep_gemm.transform_weights_for_mega_moe(l1_weights, l2_weights, activation=args.activation))
         if num_shared_experts > 0:
             transformed_shared_l1_weights, transformed_shared_l2_weights = (
-                deep_gemm.transform_weights_for_mega_moe(shared_l1_weights, shared_l2_weights))
+                deep_gemm.transform_weights_for_mega_moe(
+                    shared_l1_weights, shared_l2_weights, activation=args.activation))
         else:
             transformed_shared_l1_weights = transformed_shared_l2_weights = None
 
@@ -187,8 +190,13 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
             y=y, l1_weights=transformed_l1_weights, l2_weights=transformed_l2_weights,
             sym_buffer=buffer,
             cumulative_local_expert_recv_stats=cumulative_local_expert_recv_stats_fused,
-            activation_clamp=args.activation_clamp,
+            activation=args.activation,
+            activation_clamp=args.activation_clamp if args.activation == 'swiglu' else None,
             fast_math=bool(args.fast_math))
+        if not is_bf16xbf16:
+            kernel_kwargs.update(
+                situ_beta=args.situ_beta if args.activation == 'situ' else None,
+                situ_linear_beta=args.situ_linear_beta if args.activation == 'situ' else None)
         if num_shared_experts > 0:
             kernel_kwargs.update(
                 shared_l1_weights=transformed_shared_l1_weights,
@@ -205,6 +213,7 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     dist_print(f' > Shared experts: {num_shared_experts}', once_in_node=True)
     dist_print(f' > Experts: {num_topk}/{num_experts}', once_in_node=True)
     dist_print(f' > Buffer: {buffer.buffer.nbytes / 2 ** 30:.3f} GiB', once_in_node=True)
+    dist_print(f' > Activation: {args.activation}', once_in_node=True)
     dist_print(once_in_node=True)
 
     # Only do NCU profiling
@@ -223,6 +232,8 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     # Non-overlapped baseline: EP dispatch + GEMM + EP combine
     deep_ep, tilelang_ops, tilelang_bench, is_legacy_loaded = import_baseline()
     alignment = deep_gemm.get_theoretical_mk_alignment_for_contiguous_layout()
+    # The legacy TileLang baseline only implements SwiGLU.
+    is_legacy_loaded = is_legacy_loaded and args.activation == 'swiglu'
     deep_gemm.set_mk_alignment_for_contiguous_layout(alignment)
     num_correctness_tests = 1 if args.num_correctness_tests is None else args.num_correctness_tests
     ep_buffer = deep_ep.ElasticBuffer(
@@ -423,6 +434,10 @@ if __name__ == '__main__':
     parser.add_argument('--masked-ratio', type=float, default=0.0, help='Mask some expert selections')
     parser.add_argument('--fast-math', type=int, default=1, help='Enable fast math (0 or 1, default: 1)')
     parser.add_argument('--mma-type', type=str, default='fp8xfp4', help='MMA type: fp8xfp4 or bf16xbf16')
+
+    parser.add_argument('--activation', choices=('swiglu', 'situ'), default='swiglu', help='Gated activation')
+    parser.add_argument('--situ-beta', type=float, default=4.0, help='SiTU gate tanh beta')
+    parser.add_argument('--situ-linear-beta', type=float, default=25.0, help='SiTU linear tanh beta')
 
     # Test settings
     parser.add_argument('--num-correctness-tests', type=int, default=None, help='Pressure test')

--- a/tests/test_mega_moe.py
+++ b/tests/test_mega_moe.py
@@ -79,7 +79,6 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
 
     # Settings
     is_bf16xbf16 = args.mma_type == 'bf16xbf16'
-    assert not is_bf16xbf16 or args.activation == 'swiglu', 'SiTU is supported only for FP8xFP4 MegaMoE'
     num_max_tokens_per_rank = args.num_max_tokens_per_rank
     num_tokens = max(0, args.num_max_tokens_per_rank - random.randint(0, args.num_max_removed_tokens)) \
         if args.num_tokens == 0 else args.num_tokens
@@ -96,8 +95,7 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
         num_max_tokens_per_rank, num_topk,
         hidden, intermediate_hidden,
         num_shared_experts=num_shared_experts,
-        mma_type=args.mma_type,
-        activation=args.activation
+        mma_type=args.mma_type
     )
 
     # Cast weights into FP4
@@ -160,11 +158,10 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
                 shared_l2_weights = _cast_fp8_for_mega_moe(shared_l2_weights)[0::2]
 
         transformed_l1_weights, transformed_l2_weights = (
-            deep_gemm.transform_weights_for_mega_moe(l1_weights, l2_weights, activation=args.activation))
+            deep_gemm.transform_weights_for_mega_moe(l1_weights, l2_weights))
         if num_shared_experts > 0:
             transformed_shared_l1_weights, transformed_shared_l2_weights = (
-                deep_gemm.transform_weights_for_mega_moe(
-                    shared_l1_weights, shared_l2_weights, activation=args.activation))
+                deep_gemm.transform_weights_for_mega_moe(shared_l1_weights, shared_l2_weights))
         else:
             transformed_shared_l1_weights = transformed_shared_l2_weights = None
 
@@ -190,13 +187,8 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
             y=y, l1_weights=transformed_l1_weights, l2_weights=transformed_l2_weights,
             sym_buffer=buffer,
             cumulative_local_expert_recv_stats=cumulative_local_expert_recv_stats_fused,
-            activation=args.activation,
-            activation_clamp=args.activation_clamp if args.activation == 'swiglu' else None,
+            activation_clamp=args.activation_clamp,
             fast_math=bool(args.fast_math))
-        if not is_bf16xbf16:
-            kernel_kwargs.update(
-                situ_beta=args.situ_beta if args.activation == 'situ' else None,
-                situ_linear_beta=args.situ_linear_beta if args.activation == 'situ' else None)
         if num_shared_experts > 0:
             kernel_kwargs.update(
                 shared_l1_weights=transformed_shared_l1_weights,
@@ -213,7 +205,6 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     dist_print(f' > Shared experts: {num_shared_experts}', once_in_node=True)
     dist_print(f' > Experts: {num_topk}/{num_experts}', once_in_node=True)
     dist_print(f' > Buffer: {buffer.buffer.nbytes / 2 ** 30:.3f} GiB', once_in_node=True)
-    dist_print(f' > Activation: {args.activation}', once_in_node=True)
     dist_print(once_in_node=True)
 
     # Only do NCU profiling
@@ -232,8 +223,6 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     # Non-overlapped baseline: EP dispatch + GEMM + EP combine
     deep_ep, tilelang_ops, tilelang_bench, is_legacy_loaded = import_baseline()
     alignment = deep_gemm.get_theoretical_mk_alignment_for_contiguous_layout()
-    # The legacy TileLang baseline only implements SwiGLU.
-    is_legacy_loaded = is_legacy_loaded and args.activation == 'swiglu'
     deep_gemm.set_mk_alignment_for_contiguous_layout(alignment)
     num_correctness_tests = 1 if args.num_correctness_tests is None else args.num_correctness_tests
     ep_buffer = deep_ep.ElasticBuffer(
@@ -434,10 +423,6 @@ if __name__ == '__main__':
     parser.add_argument('--masked-ratio', type=float, default=0.0, help='Mask some expert selections')
     parser.add_argument('--fast-math', type=int, default=1, help='Enable fast math (0 or 1, default: 1)')
     parser.add_argument('--mma-type', type=str, default='fp8xfp4', help='MMA type: fp8xfp4 or bf16xbf16')
-
-    parser.add_argument('--activation', choices=('swiglu', 'situ'), default='swiglu', help='Gated activation')
-    parser.add_argument('--situ-beta', type=float, default=4.0, help='SiTU gate tanh beta')
-    parser.add_argument('--situ-linear-beta', type=float, default=25.0, help='SiTU linear tanh beta')
 
     # Test settings
     parser.add_argument('--num-correctness-tests', type=int, default=None, help='Pressure test')

--- a/tests/test_mega_moe_situ.py
+++ b/tests/test_mega_moe_situ.py
@@ -1,0 +1,221 @@
+"""Deterministic single-GPU metamorphic regression for FP8xFP4 MegaMoE SiTU."""
+
+import os
+import socket
+import sys
+import unittest
+from typing import Dict, NamedTuple, Optional, Tuple
+
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+
+import torch
+import torch.distributed as dist
+
+import deep_gemm
+from deep_gemm.utils import per_token_cast_to_fp4, per_token_cast_to_fp8
+from deep_gemm.utils.dist import init_dist
+
+
+NUM_RANKS = 1
+NUM_EXPERTS = 4
+NUM_TOPK = 1
+NUM_TOKENS = 64
+HIDDEN = 1024
+INTERMEDIATE = 512
+
+
+class Case(NamedTuple):
+    activation: str
+    situ_beta: Optional[float]
+    situ_linear_beta: Optional[float]
+
+
+CASES = {
+    'swiglu': Case('swiglu', None, None),
+    'situ_hi': Case('situ', 4096.0, 4096.0),
+    'situ_gate_low': Case('situ', 0.25, 4096.0),
+    'situ_linear_low': Case('situ', 4096.0, 0.5),
+    'situ_tiny': Case('situ', 1e-40, 1e-40),
+}
+
+
+def _cast_weights_to_fp4(
+        bf16_weights: torch.Tensor
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    num_groups, n, k = bf16_weights.shape
+    w = torch.empty(
+        (num_groups, n, k // 2), device='cuda', dtype=torch.int8)
+    w_sf = torch.empty(
+        (num_groups, n, k // 32), device='cuda', dtype=torch.float)
+    for group_idx in range(num_groups):
+        w[group_idx], w_sf[group_idx] = per_token_cast_to_fp4(
+            bf16_weights[group_idx], use_ue8m0=True, gran_k=32)
+    w_sf = deep_gemm.transform_sf_into_required_layout(
+        w_sf, n, k, (1, 32), num_groups)
+    return w, w_sf
+
+
+def _relative_l2(actual: torch.Tensor, reference: torch.Tensor) -> float:
+    actual_f = actual.float()
+    reference_f = reference.float()
+    denominator = max(
+        torch.linalg.vector_norm(reference_f).item(), 1e-12)
+    return (
+        torch.linalg.vector_norm(actual_f - reference_f).item()
+        / denominator)
+
+
+def _validate_suite(
+        results: Dict[str, torch.Tensor], fast_math: bool
+) -> None:
+    mode = f'fast_math={fast_math}'
+    for case_name, y in results.items():
+        if not bool(torch.isfinite(y.float()).all().item()):
+            raise AssertionError(f'{mode}/{case_name} contains NaN or Inf')
+
+    swiglu = results['swiglu']
+    if torch.linalg.vector_norm(swiglu.float()).item() <= 1e-6:
+        raise AssertionError(f'{mode}/swiglu is identically zero or degenerate')
+    hi = _relative_l2(results['situ_hi'], swiglu)
+    gate_low = _relative_l2(results['situ_gate_low'], swiglu)
+    linear_low = _relative_l2(results['situ_linear_low'], swiglu)
+    low_vs_low = _relative_l2(
+        results['situ_gate_low'], results['situ_linear_low'])
+
+    low_floor = max(0.05, 4.0 * hi)
+    low_pair_floor = max(0.025, 2.0 * hi)
+    if hi >= 0.05:
+        raise AssertionError(
+            f'{mode}: SiTU(4096,4096) is not close to SwiGLU '
+            f'(relative L2={hi:.6f})')
+    if gate_low <= low_floor:
+        raise AssertionError(
+            f'{mode}: SiTU(.25,4096) is not significantly different '
+            f'from SwiGLU ({gate_low:.6f} <= {low_floor:.6f})')
+    if linear_low <= low_floor:
+        raise AssertionError(
+            f'{mode}: SiTU(4096,.5) is not significantly different '
+            f'from SwiGLU ({linear_low:.6f} <= {low_floor:.6f})')
+    if low_vs_low <= low_pair_floor:
+        raise AssertionError(
+            f'{mode}: the two low-beta controls are not distinct '
+            f'({low_vs_low:.6f} <= {low_pair_floor:.6f})')
+
+
+def _worker(local_rank: int, master_port: int) -> None:
+    os.environ['MASTER_ADDR'] = '127.0.0.1'
+    os.environ['MASTER_PORT'] = str(master_port)
+    os.environ['WORLD_SIZE'] = '1'
+    os.environ['RANK'] = '0'
+
+    buffer = None
+    try:
+        _, _, group = init_dist(local_rank, NUM_RANKS)
+        generator = torch.Generator(device='cuda')
+        generator.manual_seed(20260730)
+
+        def fixed_randn(
+                shape: Tuple[int, ...], scale: float
+        ) -> torch.Tensor:
+            value = torch.randn(
+                shape,
+                dtype=torch.bfloat16,
+                device='cuda',
+                generator=generator)
+            return value.mul_(scale)
+
+        x_bf16 = fixed_randn((NUM_TOKENS, HIDDEN), 0.5)
+        l1_bf16 = fixed_randn(
+            (NUM_EXPERTS, INTERMEDIATE * 2, HIDDEN), 0.05)
+        l1_bf16[0].zero_()
+        l2_bf16 = fixed_randn(
+            (NUM_EXPERTS, HIDDEN, INTERMEDIATE), 0.05)
+        topk_idx = (
+            torch.arange(NUM_TOKENS, device='cuda', dtype=torch.long)
+            % NUM_EXPERTS
+        ).view(NUM_TOKENS, NUM_TOPK)
+        topk_weights = torch.ones(
+            (NUM_TOKENS, NUM_TOPK), device='cuda', dtype=torch.float)
+
+        x_fp8, x_sf = per_token_cast_to_fp8(
+            x_bf16,
+            use_ue8m0=True,
+            gran_k=32,
+            use_packed_ue8m0=True)
+        transformed_l1, transformed_l2 = (
+            deep_gemm.transform_weights_for_mega_moe(
+                _cast_weights_to_fp4(l1_bf16),
+                _cast_weights_to_fp4(l2_bf16),
+                activation='situ'))
+        buffer = deep_gemm.get_symm_buffer_for_mega_moe(
+            group,
+            NUM_EXPERTS,
+            NUM_TOKENS,
+            NUM_TOPK,
+            HIDDEN,
+            INTERMEDIATE,
+            mma_type='fp8xfp4',
+            activation='situ')
+
+        def run_case(case: Case, fast_math: bool) -> torch.Tensor:
+            buffer.buffer.zero_()
+            buffer.x[:NUM_TOKENS].copy_(x_fp8)
+            buffer.x_sf[:NUM_TOKENS].copy_(x_sf)
+            buffer.topk_idx[:NUM_TOKENS].copy_(topk_idx)
+            buffer.topk_weights[:NUM_TOKENS].copy_(topk_weights)
+
+            y = torch.full(
+                (NUM_TOKENS, HIDDEN),
+                float('nan'),
+                dtype=torch.bfloat16,
+                device='cuda')
+            kernel_kwargs = {
+                'y': y,
+                'l1_weights': transformed_l1,
+                'l2_weights': transformed_l2,
+                'sym_buffer': buffer,
+                'activation': case.activation,
+                'fast_math': fast_math,
+            }
+            if case.activation == 'situ':
+                kernel_kwargs.update(
+                    situ_beta=case.situ_beta,
+                    situ_linear_beta=case.situ_linear_beta)
+            deep_gemm.fp8_fp4_mega_moe(**kernel_kwargs)
+            torch.cuda.synchronize()
+            return y
+
+        for fast_math in (True, False):
+            results = {
+                case_name: run_case(case, fast_math)
+                for case_name, case in CASES.items()
+            }
+            _validate_suite(results, fast_math)
+    finally:
+        if buffer is not None:
+            buffer.destroy()
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(('127.0.0.1', 0))
+        return int(sock.getsockname()[1])
+
+
+def test_situ_metamorphic() -> None:
+    if torch.cuda.device_count() < NUM_RANKS:
+        raise unittest.SkipTest('requires one CUDA device')
+    if torch.cuda.get_device_capability(0)[0] != 10:
+        raise unittest.SkipTest('requires an SM100 CUDA device')
+    torch.multiprocessing.spawn(
+        _worker,
+        args=(_find_free_port(),),
+        nprocs=NUM_RANKS,
+        join=True)
+
+
+if __name__ == '__main__':
+    test_situ_metamorphic()


### PR DESCRIPTION
## Summary

- Add SiTU gated activation support to SM100 FP8/FP4 Mega MoE while preserving the default SwiGLU path.
- Thread `activation`, `situ_beta`, and `situ_linear_beta` through symmetric-buffer validation, Python/C++ APIs, JIT specialization, and the routed/shared L1 epilogue.
- Restrict SiTU to FP8xFP4, reject activation clamp and non-positive or non-finite beta values, and keep BF16 Mega MoE SwiGLU-only.

This is a semantic port of [longlee0622/DeepGEMM@cc832217](https://github.com/longlee0622/DeepGEMM/commit/cc832217b65bbe693a9eaa64f1077f65daaee67c) onto the latest `nv_dev`. It uses the author refactor-ready follow-up [39d7cac](https://github.com/longlee0622/DeepGEMM/commit/39d7cac2170b12768a324d5013eeb2a4c81c82fa) and preserves the original authorship and sign-off.

## Validation

- Built the exact PR commit with `./develop.sh`.
- Passed the focused deterministic routed SiTU regression for both `fast_math` modes.
- Verified high-beta SiTU converges to SwiGLU, each beta control changes the result independently, the two controls remain distinct, and every output is finite with a non-degenerate baseline.
- Verified `situ_beta=+inf` is rejected by the API validation.
- PTXAS comparison reported the same 56-byte stack frame and zero spill stores/loads for SiTU and SwiGLU.
- `git diff --check` and Python `py_compile` passed.