### PR TITLE
Add SM100 NVFP4 MegaMoE with fused BF16 shared experts

### DIFF
--- a/csrc/apis/mega.hpp
+++ b/csrc/apis/mega.hpp
@@ -95,8 +95,12 @@ get_symm_buffer_size_for_mega_moe(
 
     // Check SF buffer requirements
     if (with_sf) {
-        // NVFP4 needs `hidden % 256 == 0` to keep per-token SF rows TMA-aligned (16 bytes)
-        DG_HOST_ASSERT(hidden % (sf_gran_k * 16) == 0 and intermediate_hidden % (sf_gran_k * 16) == 0);
+        // For NVFP4, the SF TMA box outer dimension is
+        // block_k / (sf_gran_k * 4) = 4, so hidden / (sf_gran_k * 4)
+        // must also be divisible by 4: hidden must be 256-element aligned.
+        // Keep the existing MXFP8FP4 contract at 128 elements.
+        const int sf_alignment = mma_kind == MmaKind::NVFP4 ? 256 : 128;
+        DG_HOST_ASSERT(hidden % sf_alignment == 0 and intermediate_hidden % sf_alignment == 0);
         DG_HOST_ASSERT(shared_intermediate_hidden % 128 == 0);
         DG_HOST_ASSERT(num_sf_ring_tokens % 4 == 0);
     }

--- a/csrc/apis/mega.hpp
+++ b/csrc/apis/mega.hpp
@@ -68,7 +68,7 @@ get_symm_buffer_size_for_mega_moe(
 
     // Parse MMA type
     const auto mma_kind = parse_mma_kind(mma_type);
-    const auto num_mma_elem_bits = get_element_bits(mma_kind);
+    const auto num_mma_elem_bits = get_num_mma_elem_bits(mma_kind);
     const auto with_sf = is_mma_with_sf(mma_kind);
     const auto sf_gran_k = get_mma_sf_gran_k(mma_kind);
 

--- a/csrc/apis/mega.hpp
+++ b/csrc/apis/mega.hpp
@@ -95,11 +95,10 @@ get_symm_buffer_size_for_mega_moe(
 
     // Check SF buffer requirements
     if (with_sf) {
-        // For NVFP4, the SF TMA box outer dimension is
-        // block_k / (sf_gran_k * 4) = 4, so hidden / (sf_gran_k * 4)
-        // must also be divisible by 4: hidden must be 256-element aligned.
+        // The smallest-token NVFP4 heuristic uses a 512-element K tile; enforce
+        // the strongest candidate constraint here instead of failing in NVRTC.
         // Keep the existing MXFP8FP4 contract at 128 elements.
-        const int sf_alignment = mma_kind == MmaKind::NVFP4 ? 256 : 128;
+        const int sf_alignment = mma_kind == MmaKind::NVFP4 ? 512 : 128;
         DG_HOST_ASSERT(hidden % sf_alignment == 0 and intermediate_hidden % sf_alignment == 0);
         DG_HOST_ASSERT(shared_intermediate_hidden % 128 == 0);
         DG_HOST_ASSERT(num_sf_ring_tokens % 4 == 0);

--- a/csrc/apis/mega.hpp
+++ b/csrc/apis/mega.hpp
@@ -351,6 +351,8 @@ static void fp4_fp4_mega_moe(
     DG_HOST_ASSERT(rm == 1 and rn == 1 and rk == 16);
     DG_HOST_ASSERT(activation == "swiglu");
     DG_HOST_ASSERT(std::isfinite(routed_scaling_factor));
+    DG_HOST_ASSERT(shared_l1_weights_opt.has_value() == shared_l2_weights_opt.has_value());
+    DG_HOST_ASSERT(shared_l1_weights_opt.has_value() == x_bf16_opt.has_value());
 
     // Activation checks
     const auto activation_clamp =
@@ -371,6 +373,16 @@ static void fp4_fp4_mega_moe(
     DG_HOST_ASSERT(hidden == hidden_);
     DG_HOST_ASSERT(intermediate_hidden_2 == 2 * intermediate_hidden);
     DG_HOST_ASSERT(l1_weights.is_contiguous() and l2_weights.is_contiguous());
+    DG_HOST_ASSERT(y.is_cuda() and y.scalar_type() == torch::kBFloat16 and y.is_contiguous());
+    DG_HOST_ASSERT(y.dim() == 2 and y.size(1) == hidden);
+
+    const auto output_device = y.device();
+    const auto is_local_cuda_tensor = [&output_device](const torch::Tensor& tensor) {
+        return tensor.is_cuda() and tensor.device() == output_device;
+    };
+    DG_HOST_ASSERT(is_local_cuda_tensor(l1_weights) and is_local_cuda_tensor(l2_weights));
+    DG_HOST_ASSERT(is_local_cuda_tensor(l1_weights_sf) and is_local_cuda_tensor(l2_weights_sf));
+    DG_HOST_ASSERT(is_local_cuda_tensor(sym_buffer));
 
     // Check weight SF layout for E4M3 packing, MN-major, and TMA alignment
     constexpr int kGranMN = 1, kGranK = 16;
@@ -384,6 +396,7 @@ static void fp4_fp4_mega_moe(
         DG_HOST_ASSERT(cumulative_local_expert_recv_stats->scalar_type() == torch::kInt);
         DG_HOST_ASSERT(cumulative_local_expert_recv_stats->numel() == num_experts_per_rank);
         DG_HOST_ASSERT(cumulative_local_expert_recv_stats->is_contiguous());
+        DG_HOST_ASSERT(is_local_cuda_tensor(cumulative_local_expert_recv_stats.value()));
     }
 
     // Check the optional BF16 shared expert tensors
@@ -397,11 +410,11 @@ static void fp4_fp4_mega_moe(
         shared_l2_weights = shared_l2_weights_opt.value();
         x_bf16 = x_bf16_opt.value();
 
+        DG_HOST_ASSERT(shared_l1_weights.dim() == 2 and shared_l2_weights.dim() == 2);
         const auto shared_intermediate_hidden = static_cast<int>(shared_l2_weights.size(1));
         DG_HOST_ASSERT(shared_intermediate_hidden % intermediate_hidden == 0);
         num_shared_experts = shared_intermediate_hidden / intermediate_hidden;
         DG_HOST_ASSERT(num_shared_experts > 0);
-        DG_HOST_ASSERT(shared_l1_weights.dim() == 2 and shared_l2_weights.dim() == 2);
         DG_HOST_ASSERT(shared_l1_weights.size(0) == shared_intermediate_hidden * 2);
         DG_HOST_ASSERT(shared_l1_weights.size(1) == hidden);
         DG_HOST_ASSERT(shared_l2_weights.size(0) == hidden);
@@ -412,6 +425,8 @@ static void fp4_fp4_mega_moe(
         DG_HOST_ASSERT(get_major_type_ab(shared_l2_weights) == cute::UMMA::Major::K);
         DG_HOST_ASSERT(x_bf16.scalar_type() == torch::kBFloat16 and x_bf16.is_contiguous());
         DG_HOST_ASSERT(x_bf16.dim() == 2 and x_bf16.size(0) >= num_tokens and x_bf16.size(1) == hidden);
+        DG_HOST_ASSERT(is_local_cuda_tensor(shared_l1_weights) and is_local_cuda_tensor(shared_l2_weights));
+        DG_HOST_ASSERT(is_local_cuda_tensor(x_bf16));
     }
 
     // Check buffer bytes
@@ -433,12 +448,14 @@ static void fp4_fp4_mega_moe(
         const auto& l1_alphas = l1_alphas_opt.value();
         DG_HOST_ASSERT(l1_alphas.scalar_type() == torch::kFloat and l1_alphas.is_contiguous());
         DG_HOST_ASSERT(l1_alphas.dim() == 2 and l1_alphas.size(0) == num_experts_per_rank and l1_alphas.size(1) == 2);
+        DG_HOST_ASSERT(is_local_cuda_tensor(l1_alphas));
         l1_alphas_ptr = l1_alphas.data_ptr();
     }
     if (l2_alphas_opt.has_value()) {
         const auto& l2_alphas = l2_alphas_opt.value();
         DG_HOST_ASSERT(l2_alphas.scalar_type() == torch::kFloat and l2_alphas.is_contiguous());
         DG_HOST_ASSERT(l2_alphas.dim() == 1 and l2_alphas.size(0) == num_experts_per_rank);
+        DG_HOST_ASSERT(is_local_cuda_tensor(l2_alphas));
         l2_alphas_ptr = l2_alphas.data_ptr();
     }
 
@@ -449,6 +466,7 @@ static void fp4_fp4_mega_moe(
         const auto& a2_scales = a2_scales_opt.value();
         DG_HOST_ASSERT(a2_scales.scalar_type() == torch::kFloat and a2_scales.is_contiguous());
         DG_HOST_ASSERT(a2_scales.dim() == 1 and a2_scales.size(0) == num_experts_per_rank);
+        DG_HOST_ASSERT(is_local_cuda_tensor(a2_scales));
         a2_scales_ptr = a2_scales.data_ptr();
     }
 

--- a/csrc/apis/mega.hpp
+++ b/csrc/apis/mega.hpp
@@ -336,7 +336,8 @@ static void fp4_fp4_mega_moe(
     const bool& fast_math,
     const std::optional<torch::Tensor>& l1_alphas_opt,
     const std::optional<torch::Tensor>& l2_alphas_opt,
-    const std::optional<torch::Tensor>& a2_scales_opt
+    const std::optional<torch::Tensor>& a2_scales_opt,
+    const float& routed_scaling_factor
 ) {
     const auto [l1_weights, l1_weights_sf] = l1_weights_tuple;
     const auto [l2_weights, l2_weights_sf] = l2_weights_tuple;
@@ -346,6 +347,7 @@ static void fp4_fp4_mega_moe(
     const auto [rm, rn, rk] = recipe;
     DG_HOST_ASSERT(rm == 1 and rn == 1 and rk == 16);
     DG_HOST_ASSERT(activation == "swiglu");
+    DG_HOST_ASSERT(std::isfinite(routed_scaling_factor));
 
     // Activation checks
     const auto activation_clamp =
@@ -471,7 +473,8 @@ static void fp4_fp4_mega_moe(
                                num_tokens, num_topk,
                                hidden, intermediate_hidden,
                                activation_clamp, fast_math,
-                               l1_alphas_ptr, l2_alphas_ptr, a2_scales_ptr);
+                               l1_alphas_ptr, l2_alphas_ptr, a2_scales_ptr,
+                               routed_scaling_factor);
     } else {
         DG_HOST_UNREACHABLE("Unsupported architecture");
     }

--- a/csrc/apis/mega.hpp
+++ b/csrc/apis/mega.hpp
@@ -14,6 +14,7 @@
 #include "../jit/device_runtime.hpp"
 #include "../jit_kernels/impls/sm100_bf16_mega_moe.hpp"
 #include "../jit_kernels/impls/sm100_fp8_fp4_mega_moe.hpp"
+#include "../jit_kernels/impls/sm100_fp4_fp4_mega_moe.hpp"
 
 namespace deep_gemm::mega {
 
@@ -67,7 +68,9 @@ get_symm_buffer_size_for_mega_moe(
 
     // Parse MMA type
     const auto mma_kind = parse_mma_kind(mma_type);
+    const auto num_mma_elem_bits = get_element_bits(mma_kind);
     const auto with_sf = is_mma_with_sf(mma_kind);
+    const auto sf_gran_k = get_mma_sf_gran_k(mma_kind);
 
     // Compute num_sf_ring_tokens (max across all candidate block sizes)
     int num_sf_ring_tokens = 0;
@@ -80,30 +83,42 @@ get_symm_buffer_size_for_mega_moe(
     }
 
     // All buffers
+    // NOTES: NVFP4 shared experts run in BF16 (16-bit, SF-free)
+    const auto shared_num_mma_elem_bits = mma_kind == MmaKind::NVFP4 ? 16 : 0;
     const auto mega_buffer = layout::MegaMoEBuffer(
         nullptr, hidden, intermediate_hidden,
         num_ranks, num_experts, num_max_tokens_per_rank,
         num_topk, num_ring_tokens, num_sf_ring_tokens, with_sf,
-        num_shared_experts
+        num_shared_experts, num_mma_elem_bits, sf_gran_k,
+        shared_num_mma_elem_bits
     );
 
     // Check SF buffer requirements
     if (with_sf) {
-        DG_HOST_ASSERT(hidden % 128 == 0 and intermediate_hidden % 128 == 0);
+        // NVFP4 needs `hidden % 256 == 0` to keep per-token SF rows TMA-aligned (16 bytes)
+        DG_HOST_ASSERT(hidden % (sf_gran_k * 16) == 0 and intermediate_hidden % (sf_gran_k * 16) == 0);
         DG_HOST_ASSERT(shared_intermediate_hidden % 128 == 0);
         DG_HOST_ASSERT(num_sf_ring_tokens % 4 == 0);
     }
 
     // Slice function: creates tensor views from the raw buffer.
     // NOTES: `x_sf` is K-major, while `l1_acts_sf` and `l2_acts_sf` are M-major
+    // NOTES: for NVFP4, token views are packed E2M1 bytes (2 elements each) and SF
+    // views pack 4 E4M3 bytes per `int`
+    const auto is_fp4 = mma_kind == MmaKind::NVFP4;
+    const auto token_dtype = is_fp4 ? torch::kUInt8 : (with_sf ? torch::kFloat8_e4m3fn : torch::kBFloat16);
+    const auto hidden_cols = is_fp4 ? hidden / 2 : hidden;
+    const auto intermediate_cols = is_fp4 ? intermediate_hidden / 2 : intermediate_hidden;
+    const auto hidden_sf_cols = hidden / (sf_gran_k * 4);
+    const auto intermediate_sf_cols = intermediate_hidden / (sf_gran_k * 4);
     auto slice_input_buffers = [=](const torch::Tensor& buffer) {
         auto x = torch::from_blob(
             math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.input_token_buffer.base)),
-            {num_max_tokens_per_rank, hidden},
-            torch::TensorOptions().dtype(with_sf ? torch::kFloat8_e4m3fn : torch::kBFloat16).device(buffer.device()));
+            {num_max_tokens_per_rank, hidden_cols},
+            torch::TensorOptions().dtype(token_dtype).device(buffer.device()));
         auto x_sf = with_sf ? torch::from_blob(
             math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.input_sf_buffer.base)),
-            {num_max_tokens_per_rank, hidden / 128},
+            {num_max_tokens_per_rank, hidden_sf_cols},
             torch::TensorOptions().dtype(torch::kInt).device(buffer.device())) : torch::Tensor();
         auto topk_idx = torch::from_blob(
             math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.input_topk_idx_buffer.base)),
@@ -114,8 +129,11 @@ get_symm_buffer_size_for_mega_moe(
             {num_max_tokens_per_rank, num_topk},
             torch::TensorOptions().dtype(torch::kFloat32).device(buffer.device()));
 
-        auto shared_l1_acts = x;
-        auto shared_l1_acts_sf = (with_sf and num_shared_experts > 0) ? torch::from_blob(
+        // NOTES: NVFP4 shared experts are BF16 and SF-free; their L1 activations come from
+        // a caller-provided BF16 tensor, so `shared_l1_acts`/SF views stay undefined
+        const bool shared_with_sf = with_sf and not is_fp4;
+        auto shared_l1_acts = is_fp4 ? torch::Tensor() : x;
+        auto shared_l1_acts_sf = (shared_with_sf and num_shared_experts > 0) ? torch::from_blob(
             math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.shared_l1_sf_buffer.base)),
             {layout::get_num_max_shared_sf_tokens(num_max_tokens_per_rank), hidden / 128},
             {1, layout::get_num_max_shared_sf_tokens(num_max_tokens_per_rank)},
@@ -123,8 +141,8 @@ get_symm_buffer_size_for_mega_moe(
         auto shared_l2_acts = num_shared_experts > 0 ? torch::from_blob(
             math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.shared_l2_token_buffer.base)),
             {num_max_tokens_per_rank, shared_intermediate_hidden},
-            torch::TensorOptions().dtype(with_sf ? torch::kFloat8_e4m3fn : torch::kBFloat16).device(buffer.device())) : torch::Tensor();
-        auto shared_l2_acts_sf = (with_sf and num_shared_experts > 0) ? torch::from_blob(
+            torch::TensorOptions().dtype(shared_with_sf ? torch::kFloat8_e4m3fn : torch::kBFloat16).device(buffer.device())) : torch::Tensor();
+        auto shared_l2_acts_sf = (shared_with_sf and num_shared_experts > 0) ? torch::from_blob(
             math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.shared_l2_sf_buffer.base)),
             {layout::get_num_max_shared_sf_tokens(num_max_tokens_per_rank), shared_intermediate_hidden / 128},
             {1, layout::get_num_max_shared_sf_tokens(num_max_tokens_per_rank)},
@@ -132,20 +150,20 @@ get_symm_buffer_size_for_mega_moe(
 
         auto l1_acts = torch::from_blob(
             math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.l1_token_buffer.base)),
-            {num_ring_tokens, hidden},
-            torch::TensorOptions().dtype(with_sf ? torch::kFloat8_e4m3fn : torch::kBFloat16).device(buffer.device()));
+            {num_ring_tokens, hidden_cols},
+            torch::TensorOptions().dtype(token_dtype).device(buffer.device()));
         auto l1_acts_sf = with_sf ? torch::from_blob(
             math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.l1_sf_buffer.base)),
-            {num_sf_ring_tokens, hidden / 128},
+            {num_sf_ring_tokens, hidden_sf_cols},
             {1, num_sf_ring_tokens},
             torch::TensorOptions().dtype(torch::kInt).device(buffer.device())) : torch::Tensor();
         auto l2_acts = torch::from_blob(
             math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.l2_token_buffer.base)),
-            {num_ring_tokens, intermediate_hidden},
-            torch::TensorOptions().dtype(with_sf ? torch::kFloat8_e4m3fn : torch::kBFloat16).device(buffer.device()));
+            {num_ring_tokens, intermediate_cols},
+            torch::TensorOptions().dtype(token_dtype).device(buffer.device()));
         auto l2_acts_sf = with_sf ? torch::from_blob(
             math::advance_ptr(buffer.data_ptr(), reinterpret_cast<int64_t>(mega_buffer.l2_sf_buffer.base)),
-            {num_sf_ring_tokens, intermediate_hidden / 128},
+            {num_sf_ring_tokens, intermediate_sf_cols},
             {1, num_sf_ring_tokens},
             torch::TensorOptions().dtype(torch::kInt).device(buffer.device())) : torch::Tensor();
         return std::make_tuple(x, x_sf, topk_idx, topk_weights,
@@ -298,6 +316,172 @@ static void fp8_fp4_mega_moe(
         sym_buffer.zero_();
 }
 
+static void fp4_fp4_mega_moe(
+    const torch::Tensor& y,
+    const std::tuple<torch::Tensor, torch::Tensor>& l1_weights_tuple,
+    const std::tuple<torch::Tensor, torch::Tensor>& l2_weights_tuple,
+    // BF16 shared expert (optional): plain BF16 weights (no SF) and the BF16 input
+    // activations of the local tokens (the routed `x` in the buffer is packed FP4)
+    const std::optional<torch::Tensor>& shared_l1_weights_opt,
+    const std::optional<torch::Tensor>& shared_l2_weights_opt,
+    const std::optional<torch::Tensor>& x_bf16_opt,
+    const std::optional<torch::Tensor>& cumulative_local_expert_recv_stats,
+    const torch::Tensor& sym_buffer,
+    const std::vector<int64_t>& sym_buffer_ptrs, const int& rank_idx,
+    const int& num_max_tokens_per_rank,
+    const int& num_experts, const int& num_topk,
+    const std::tuple<int, int, int>& recipe,
+    const std::string& activation,
+    const std::optional<float>& activation_clamp_opt,
+    const bool& fast_math,
+    const std::optional<torch::Tensor>& l1_alphas_opt,
+    const std::optional<torch::Tensor>& l2_alphas_opt,
+    const std::optional<torch::Tensor>& a2_scales_opt
+) {
+    const auto [l1_weights, l1_weights_sf] = l1_weights_tuple;
+    const auto [l2_weights, l2_weights_sf] = l2_weights_tuple;
+
+    // Config checks
+    const auto num_tokens = static_cast<int>(y.size(0));
+    const auto [rm, rn, rk] = recipe;
+    DG_HOST_ASSERT(rm == 1 and rn == 1 and rk == 16);
+    DG_HOST_ASSERT(activation == "swiglu");
+
+    // Activation checks
+    const auto activation_clamp =
+        activation_clamp_opt.value_or(std::numeric_limits<float>::infinity());
+    DG_HOST_ASSERT(activation_clamp >= 0);
+
+    // Tensor checks
+    DG_HOST_ASSERT(get_major_type_ab(l1_weights) == cute::UMMA::Major::K);
+    DG_HOST_ASSERT(get_major_type_ab(l2_weights) == cute::UMMA::Major::K);
+    const auto arch_major = device_runtime->get_arch_major();
+    DG_HOST_ASSERT(l1_weights.scalar_type() == kPackedFP4 and l2_weights.scalar_type() == kPackedFP4);
+    const auto [num_experts_per_rank, intermediate_hidden_2, hidden] =
+        check_grouped_ab_fp8_fp4(l1_weights, cute::UMMA::Major::K, arch_major);
+    const auto [num_experts_per_rank_, hidden_, intermediate_hidden] =
+        check_grouped_ab_fp8_fp4(l2_weights, cute::UMMA::Major::K, arch_major);
+    DG_HOST_ASSERT(num_tokens <= num_max_tokens_per_rank);
+    DG_HOST_ASSERT(num_experts_per_rank == num_experts_per_rank_);
+    DG_HOST_ASSERT(hidden == hidden_);
+    DG_HOST_ASSERT(intermediate_hidden_2 == 2 * intermediate_hidden);
+    DG_HOST_ASSERT(l1_weights.is_contiguous() and l2_weights.is_contiguous());
+
+    // Check weight SF layout for E4M3 packing, MN-major, and TMA alignment
+    constexpr int kGranMN = 1, kGranK = 16;
+    check_sf_layout(l1_weights_sf, intermediate_hidden * 2, hidden, kGranMN, kGranK,
+                    num_experts_per_rank, true, false, torch::kInt);
+    check_sf_layout(l2_weights_sf, hidden, intermediate_hidden, kGranMN, kGranK,
+                    num_experts_per_rank, true, false, torch::kInt);
+
+    // Check stats counter
+    if (cumulative_local_expert_recv_stats.has_value()) {
+        DG_HOST_ASSERT(cumulative_local_expert_recv_stats->scalar_type() == torch::kInt);
+        DG_HOST_ASSERT(cumulative_local_expert_recv_stats->numel() == num_experts_per_rank);
+        DG_HOST_ASSERT(cumulative_local_expert_recv_stats->is_contiguous());
+    }
+
+    // Check the optional BF16 shared expert tensors
+    // NOTES: multiple shared experts are folded into the weights (L1 concatenated on N,
+    // L2 concatenated on K), so `num_shared_experts = shared_intermediate_hidden / intermediate_hidden`
+    int num_shared_experts = 0;
+    torch::Tensor shared_l1_weights, shared_l2_weights, x_bf16;
+    if (shared_l1_weights_opt.has_value()) {
+        DG_HOST_ASSERT(shared_l2_weights_opt.has_value() and x_bf16_opt.has_value());
+        shared_l1_weights = shared_l1_weights_opt.value();
+        shared_l2_weights = shared_l2_weights_opt.value();
+        x_bf16 = x_bf16_opt.value();
+
+        const auto shared_intermediate_hidden = static_cast<int>(shared_l2_weights.size(1));
+        DG_HOST_ASSERT(shared_intermediate_hidden % intermediate_hidden == 0);
+        num_shared_experts = shared_intermediate_hidden / intermediate_hidden;
+        DG_HOST_ASSERT(num_shared_experts > 0);
+        DG_HOST_ASSERT(shared_l1_weights.dim() == 2 and shared_l2_weights.dim() == 2);
+        DG_HOST_ASSERT(shared_l1_weights.size(0) == shared_intermediate_hidden * 2);
+        DG_HOST_ASSERT(shared_l1_weights.size(1) == hidden);
+        DG_HOST_ASSERT(shared_l2_weights.size(0) == hidden);
+        DG_HOST_ASSERT(shared_l1_weights.scalar_type() == torch::kBFloat16);
+        DG_HOST_ASSERT(shared_l2_weights.scalar_type() == torch::kBFloat16);
+        DG_HOST_ASSERT(shared_l1_weights.is_contiguous() and shared_l2_weights.is_contiguous());
+        DG_HOST_ASSERT(get_major_type_ab(shared_l1_weights) == cute::UMMA::Major::K);
+        DG_HOST_ASSERT(get_major_type_ab(shared_l2_weights) == cute::UMMA::Major::K);
+        DG_HOST_ASSERT(x_bf16.scalar_type() == torch::kBFloat16 and x_bf16.is_contiguous());
+        DG_HOST_ASSERT(x_bf16.dim() == 2 and x_bf16.size(0) >= num_tokens and x_bf16.size(1) == hidden);
+    }
+
+    // Check buffer bytes
+    const auto num_ranks = static_cast<int>(sym_buffer_ptrs.size());
+    const auto num_experts_ = num_experts_per_rank * num_ranks;
+    const auto [num_required_bytes, slice] = get_symm_buffer_size_for_mega_moe(
+        num_ranks, num_experts,
+        num_max_tokens_per_rank, num_topk,
+        hidden, intermediate_hidden,
+        "fp4xfp4", activation, num_shared_experts);
+    DG_HOST_ASSERT(sym_buffer.nbytes() >= static_cast<size_t>(num_required_bytes));
+    DG_HOST_ASSERT(num_experts == num_experts_);
+
+    // Check the optional per-local-expert scales (e.g. modelopt's `weight_scale_2`)
+    // NOTES: L1 has separate gate/up factors, so its scales come as `(E, 2)` pairs
+    const void* l1_alphas_ptr = nullptr;
+    const void* l2_alphas_ptr = nullptr;
+    if (l1_alphas_opt.has_value()) {
+        const auto& l1_alphas = l1_alphas_opt.value();
+        DG_HOST_ASSERT(l1_alphas.scalar_type() == torch::kFloat and l1_alphas.is_contiguous());
+        DG_HOST_ASSERT(l1_alphas.dim() == 2 and l1_alphas.size(0) == num_experts_per_rank and l1_alphas.size(1) == 2);
+        l1_alphas_ptr = l1_alphas.data_ptr();
+    }
+    if (l2_alphas_opt.has_value()) {
+        const auto& l2_alphas = l2_alphas_opt.value();
+        DG_HOST_ASSERT(l2_alphas.scalar_type() == torch::kFloat and l2_alphas.is_contiguous());
+        DG_HOST_ASSERT(l2_alphas.dim() == 1 and l2_alphas.size(0) == num_experts_per_rank);
+        l2_alphas_ptr = l2_alphas.data_ptr();
+    }
+
+    // Per-local-expert down-proj input scale (modelopt's `input_scale`): normalizes the
+    // in-kernel intermediate NVFP4 requant and is folded into the L2 alpha
+    const void* a2_scales_ptr = nullptr;
+    if (a2_scales_opt.has_value()) {
+        const auto& a2_scales = a2_scales_opt.value();
+        DG_HOST_ASSERT(a2_scales.scalar_type() == torch::kFloat and a2_scales.is_contiguous());
+        DG_HOST_ASSERT(a2_scales.dim() == 1 and a2_scales.size(0) == num_experts_per_rank);
+        a2_scales_ptr = a2_scales.data_ptr();
+    }
+
+    // Already registered tensors
+    const auto [x, x_sf, topk_idx, topk_weights,
+                shared_l1_acts, shared_l1_acts_sf, shared_l2_acts, shared_l2_acts_sf,
+                l1_acts, l1_acts_sf, l2_acts, l2_acts_sf] = slice(sym_buffer);
+
+    // Dispatch into different architectures
+    if (arch_major == 10) {
+        sm100_fp4_fp4_mega_moe(y,
+                               l1_acts, l1_acts_sf,
+                               l2_acts, l2_acts_sf,
+                               num_shared_experts > 0 ? x_bf16 : l1_acts,
+                               num_shared_experts > 0 ? shared_l2_acts : l2_acts,
+                               num_shared_experts > 0 ? shared_l1_weights : l1_weights,
+                               num_shared_experts > 0 ? shared_l2_weights : l2_weights,
+                               l1_weights, l2_weights,
+                               l1_weights_sf, l2_weights_sf,
+                               cumulative_local_expert_recv_stats,
+                               sym_buffer_ptrs,
+                               rank_idx, num_max_tokens_per_rank,
+                               num_experts_per_rank,
+                               num_shared_experts,
+                               num_tokens, num_topk,
+                               hidden, intermediate_hidden,
+                               activation_clamp, fast_math,
+                               l1_alphas_ptr, l2_alphas_ptr, a2_scales_ptr);
+    } else {
+        DG_HOST_UNREACHABLE("Unsupported architecture");
+    }
+
+    // Zero the entire symmetric buffer for debug mode
+    // NOTES: caller must re-copy inputs into the buffer before each kernel call
+    if (get_env<int>("DG_COMM_KERNEL_DEBUG"))
+        sym_buffer.zero_();
+}
+
 static void bf16_mega_moe(
     const torch::Tensor& y,
     const torch::Tensor& l1_weights,
@@ -412,6 +596,7 @@ static void register_apis(pybind11::module_& m) {
     m.def("get_block_m_for_mega_moe", &get_block_m_for_mega_moe);
     m.def("get_symm_buffer_size_for_mega_moe", &get_symm_buffer_size_for_mega_moe);
     m.def("fp8_fp4_mega_moe", &fp8_fp4_mega_moe);
+    m.def("fp4_fp4_mega_moe", &fp4_fp4_mega_moe);
     m.def("bf16_mega_moe", &bf16_mega_moe);
 #endif
 }

--- a/csrc/apis/mega.hpp
+++ b/csrc/apis/mega.hpp
@@ -348,8 +348,10 @@ static void fp4_fp4_mega_moe(
     // Config checks
     const auto num_tokens = static_cast<int>(y.size(0));
     const auto [rm, rn, rk] = recipe;
-    DG_HOST_ASSERT(rm == 1 and rn == 1 and rk == 16);
-    DG_HOST_ASSERT(activation == "swiglu");
+    DG_HOST_ASSERT((rm == 1 and rn == 1 and rk == 16) and
+                   "NVFP4 MegaMoE currently supports only recipe (1, 1, 16)");
+    DG_HOST_ASSERT(activation == "swiglu" and
+                   "NVFP4 MegaMoE currently supports only SwiGLU");
     DG_HOST_ASSERT(std::isfinite(routed_scaling_factor));
     DG_HOST_ASSERT(shared_l1_weights_opt.has_value() == shared_l2_weights_opt.has_value());
     DG_HOST_ASSERT(shared_l1_weights_opt.has_value() == x_bf16_opt.has_value());
@@ -424,6 +426,9 @@ static void fp4_fp4_mega_moe(
         DG_HOST_ASSERT(get_major_type_ab(shared_l1_weights) == cute::UMMA::Major::K);
         DG_HOST_ASSERT(get_major_type_ab(shared_l2_weights) == cute::UMMA::Major::K);
         DG_HOST_ASSERT(x_bf16.scalar_type() == torch::kBFloat16 and x_bf16.is_contiguous());
+        // The leading dimension may be over-allocated for CUDA Graphs, but
+        // replay must preserve both this allocation and the captured token count
+        // because they are encoded in the shared-input TMA descriptor.
         DG_HOST_ASSERT(x_bf16.dim() == 2 and x_bf16.size(0) >= num_tokens and x_bf16.size(1) == hidden);
         DG_HOST_ASSERT(is_local_cuda_tensor(shared_l1_weights) and is_local_cuda_tensor(shared_l2_weights));
         DG_HOST_ASSERT(is_local_cuda_tensor(x_bf16));
@@ -477,6 +482,9 @@ static void fp4_fp4_mega_moe(
 
     // Dispatch into different architectures
     if (arch_major == 10) {
+        // With no shared expert, these descriptor placeholders alias routed
+        // tensors. Their dtype/layout is intentionally irrelevant because the
+        // kHasShared=false kernel specialization never dereferences them.
         sm100_fp4_fp4_mega_moe(y,
                                l1_acts, l1_acts_sf,
                                l2_acts, l2_acts_sf,

--- a/csrc/jit_kernels/heuristics/common.hpp
+++ b/csrc/jit_kernels/heuristics/common.hpp
@@ -12,6 +12,7 @@ namespace deep_gemm {
 
 inline int get_byte_addressable_element_size(const MmaKind& mma_kind) {
     const int element_size = get_element_size(mma_kind);
+    DG_HOST_ASSERT(element_size != -1 and "Unknown MMA kind");
     DG_HOST_ASSERT(element_size > 0);
     return element_size;
 }

--- a/csrc/jit_kernels/heuristics/common.hpp
+++ b/csrc/jit_kernels/heuristics/common.hpp
@@ -10,6 +10,12 @@
 
 namespace deep_gemm {
 
+inline int get_byte_addressable_element_size(const MmaKind& mma_kind) {
+    const int element_size = get_element_size(mma_kind);
+    DG_HOST_ASSERT(element_size > 0);
+    return element_size;
+}
+
 template <typename ArchSpec>
 static GemmConfig get_best_config(const GemmDesc& desc) {
     desc.check_validity();

--- a/csrc/jit_kernels/heuristics/mega_moe.hpp
+++ b/csrc/jit_kernels/heuristics/mega_moe.hpp
@@ -67,9 +67,10 @@ static MmaKind parse_mma_kind(const std::string& mma_type_str) {
     return MmaKind::MXFP8FP4;
 }
 
-static int get_num_mma_elem_bytes(const MmaKind& mma_kind) {
-    DG_HOST_ASSERT(mma_kind != MmaKind::NVFP4 and "NVFP4 elements are sub-byte, use `get_element_bits`");
-    return mma_kind == MmaKind::BF16 ? 2 : 1;
+static int get_num_mma_elem_bits(const MmaKind& mma_kind) {
+    if (mma_kind == MmaKind::NVFP4)
+        return 4;
+    return get_element_size(mma_kind) * 8;
 }
 
 static bool is_mma_with_sf(const MmaKind& mma_kind) {
@@ -109,7 +110,7 @@ static std::tuple<int, int, int, int, int> get_block_config_for_mega_moe(
         }
     }();
     // `block_k` above is in bytes: convert to elements
-    block_k = block_k * 8 / get_element_bits(mma_kind);
+    block_k = block_k * 8 / get_num_mma_elem_bits(mma_kind);
 
     // Check whether our `block_m` lies in `kCandidateBlockM`
     DG_HOST_ASSERT(std::any_of(
@@ -132,7 +133,7 @@ static std::pair<int, int> get_pipeline_config_for_mega_moe(
     constexpr int kSmemAlignment = 1024;
     constexpr int kNumEpilogueStages = 2;
     constexpr int kNumTMAStoreStages = 2;
-    const int num_mma_elem_bits = get_element_bits(mma_kind);
+    const int num_mma_elem_bits = get_num_mma_elem_bits(mma_kind);
 
     // Always multicast on A
     const int load_block_m = block_m / 2;
@@ -219,7 +220,7 @@ static MegaMoEConfig get_mega_moe_config(
 
     // Pull: divide token bytes by 2 until <= kPullThreshold
     constexpr int kPullThreshold = 4096;
-    int num_bytes_per_pull = hidden * get_element_bits(mma_kind) / 8;
+    int num_bytes_per_pull = hidden * get_num_mma_elem_bits(mma_kind) / 8;
     while (num_bytes_per_pull > kPullThreshold) {
         DG_HOST_ASSERT(num_bytes_per_pull % 2 == 0);
         num_bytes_per_pull /= 2;

--- a/csrc/jit_kernels/heuristics/mega_moe.hpp
+++ b/csrc/jit_kernels/heuristics/mega_moe.hpp
@@ -61,16 +61,24 @@ struct MegaMoEConfig {
 static MmaKind parse_mma_kind(const std::string& mma_type_str) {
     if (mma_type_str == "bf16xbf16")
         return MmaKind::BF16;
+    if (mma_type_str == "fp4xfp4")
+        return MmaKind::NVFP4;
     DG_HOST_ASSERT(mma_type_str == "fp8xfp4");
     return MmaKind::MXFP8FP4;
 }
 
 static int get_num_mma_elem_bytes(const MmaKind& mma_kind) {
+    DG_HOST_ASSERT(mma_kind != MmaKind::NVFP4 and "NVFP4 elements are sub-byte, use `get_element_bits`");
     return mma_kind == MmaKind::BF16 ? 2 : 1;
 }
 
 static bool is_mma_with_sf(const MmaKind& mma_kind) {
-    return mma_kind == MmaKind::MXFP8FP4;
+    return mma_kind == MmaKind::MXFP8FP4 or mma_kind == MmaKind::NVFP4;
+}
+
+// SF group size along K: MX recipes use 32, NVFP4 uses 16
+static int get_mma_sf_gran_k(const MmaKind& mma_kind) {
+    return mma_kind == MmaKind::NVFP4 ? 16 : 32;
 }
 
 static std::tuple<int, int, int, int, int> get_block_config_for_mega_moe(
@@ -100,7 +108,8 @@ static std::tuple<int, int, int, int, int> get_block_config_for_mega_moe(
             return {2, 192, 32, 128, 2};
         }
     }();
-    block_k /= get_num_mma_elem_bytes(mma_kind);
+    // `block_k` above is in bytes: convert to elements
+    block_k = block_k * 8 / get_element_bits(mma_kind);
 
     // Check whether our `block_m` lies in `kCandidateBlockM`
     DG_HOST_ASSERT(std::any_of(
@@ -123,7 +132,7 @@ static std::pair<int, int> get_pipeline_config_for_mega_moe(
     constexpr int kSmemAlignment = 1024;
     constexpr int kNumEpilogueStages = 2;
     constexpr int kNumTMAStoreStages = 2;
-    const int num_mma_elem_bytes = get_num_mma_elem_bytes(mma_kind);
+    const int num_mma_elem_bits = get_element_bits(mma_kind);
 
     // Always multicast on A
     const int load_block_m = block_m / 2;
@@ -138,7 +147,7 @@ static std::pair<int, int> get_pipeline_config_for_mega_moe(
 
     // C/D output region: max of L1 output staging and L2 BF16 staging.
     const auto num_epilogue_warpgroups = num_epilogue_warps / 4;
-    const int smem_cd_l1 = num_epilogue_warpgroups * store_block_m * (block_n / 2) * kNumTMAStoreStages * get_num_mma_elem_bytes(mma_kind);
+    const int smem_cd_l1 = num_epilogue_warpgroups * store_block_m * ((block_n / 2) * num_mma_elem_bits / 8) * kNumTMAStoreStages;
     const int smem_cd_l2 = num_epilogue_warpgroups * store_block_m * block_n * static_cast<int>(sizeof(nv_bfloat16));
     const int smem_cd = align(std::max(smem_cd_l1, smem_cd_l2), kSmemAlignment);
 
@@ -151,7 +160,8 @@ static std::pair<int, int> get_pipeline_config_for_mega_moe(
     const int smem_barriers = (num_dispatch_warps + kNumEpilogueStages * 2 + num_epilogue_warps * 2 + kNumScheduleStages * 2) * 8;
 
     // Amax warp-pair reduction buffer for SwiGLU's cross-warp amax exchange.
-    const int smem_amax_reduction = is_mma_with_sf(mma_kind) ?
+    // NOTES: NVFP4 does not need it, as one warp covers exactly one 16-element SF group
+    const int smem_amax_reduction = mma_kind == MmaKind::MXFP8FP4 ?
         store_block_m * num_epilogue_warps * static_cast<int>(sizeof(float)) : 0;
 
     // Tensor memory pointer
@@ -162,8 +172,9 @@ static std::pair<int, int> get_pipeline_config_for_mega_moe(
     const int smem_sfb_per_stage = is_mma_with_sf(mma_kind) ? sf_block_n * (block_k / gran_k) : 0;
 
     // Per-stage: A tile + B tile + optional SF tiles + full/empty barriers.
-    const int smem_a_size_per_stage = load_block_m * block_k * num_mma_elem_bytes;
-    const int smem_b_size_per_stage = block_n * block_k * num_mma_elem_bytes;
+    // Use bits rather than bytes so packed NVFP4 occupies half a byte.
+    const int smem_a_size_per_stage = load_block_m * block_k * num_mma_elem_bits / 8;
+    const int smem_b_size_per_stage = block_n * block_k * num_mma_elem_bits / 8;
     DG_HOST_ASSERT(smem_a_size_per_stage % kSmemAlignment == 0);
     DG_HOST_ASSERT(smem_b_size_per_stage % kSmemAlignment == 0);
     const int smem_stage_barriers = 2 * 8;
@@ -195,11 +206,12 @@ static MegaMoEConfig get_mega_moe_config(
     const int load_block_m = block_m / 2;
     const int load_block_n = block_n;
     const auto [sf_block_m, sf_block_n] = is_mma_with_sf(mma_kind) ?
-        SM100ArchSpec::get_sf_uttcp_aligned_block_sizes(block_m, block_n, MmaKind::MXFP8FP4) : std::pair(0, 0);
-    // NOTES: FP8 activations and FP4 weights (unpacked to 8-bit in smem) both use 128B swizzle
+        SM100ArchSpec::get_sf_uttcp_aligned_block_sizes(block_m, block_n, mma_kind) : std::pair(0, 0);
+    // NOTES: FP8 activations and FP4 weights (unpacked to 8-bit in smem, or packed for NVFP4)
+    // all use 128B swizzle
     const int swizzle_acts_mode = 128;
     const int swizzle_weights_mode = 128;
-    const int gran_k = 32;
+    const int gran_k = get_mma_sf_gran_k(mma_kind);
 
     // Thread layout
     const int num_dispatch_threads = 128;
@@ -207,7 +219,7 @@ static MegaMoEConfig get_mega_moe_config(
 
     // Pull: divide token bytes by 2 until <= kPullThreshold
     constexpr int kPullThreshold = 4096;
-    int num_bytes_per_pull = hidden * get_num_mma_elem_bytes(mma_kind);
+    int num_bytes_per_pull = hidden * get_element_bits(mma_kind) / 8;
     while (num_bytes_per_pull > kPullThreshold) {
         DG_HOST_ASSERT(num_bytes_per_pull % 2 == 0);
         num_bytes_per_pull /= 2;

--- a/csrc/jit_kernels/heuristics/mega_moe.hpp
+++ b/csrc/jit_kernels/heuristics/mega_moe.hpp
@@ -109,7 +109,9 @@ static std::tuple<int, int, int, int, int> get_block_config_for_mega_moe(
             return {2, 192, 32, 128, 2};
         }
     }();
-    // `block_k` above is in bytes: convert to elements
+    // `block_k` above is in bytes: convert to elements. The same threshold
+    // table was revalidated by the NVFP4 EP8 token sweep; NVFP4 therefore
+    // keeps the byte footprint while doubling K elements relative to FP8.
     block_k = block_k * 8 / get_num_mma_elem_bits(mma_kind);
 
     // Check whether our `block_m` lies in `kCandidateBlockM`

--- a/csrc/jit_kernels/heuristics/mega_moe.hpp
+++ b/csrc/jit_kernels/heuristics/mega_moe.hpp
@@ -109,9 +109,9 @@ static std::tuple<int, int, int, int, int> get_block_config_for_mega_moe(
             return {2, 192, 32, 128, 2};
         }
     }();
-    // `block_k` above is in bytes: convert to elements. The same threshold
-    // table was revalidated by the NVFP4 EP8 token sweep; NVFP4 therefore
-    // keeps the byte footprint while doubling K elements relative to FP8.
+    // `block_k` above is in bytes: convert to elements. NVFP4 currently reuses
+    // the FP8 x FP4 token thresholds without NVFP4-specific threshold tuning;
+    // it keeps the byte footprint while doubling K elements relative to FP8.
     block_k = block_k * 8 / get_num_mma_elem_bits(mma_kind);
 
     // Check whether our `block_m` lies in `kCandidateBlockM`

--- a/csrc/jit_kernels/heuristics/sm100.hpp
+++ b/csrc/jit_kernels/heuristics/sm100.hpp
@@ -27,7 +27,7 @@ struct SM100ArchSpec {
 
     static std::vector<Layout> get_layout_candidates(const GemmDesc& desc) {
         // Block K is always in a fixed manner
-        const int block_k = 128 / get_element_size(desc.get_mma_kind());
+        const int block_k = 128 / get_byte_addressable_element_size(desc.get_mma_kind());
 
         // Always enable swap A/B (and multicasting if possible) for m-grouped GEMMs
         if (desc.gemm_type == GemmType::MGroupedContiguous or

--- a/csrc/jit_kernels/heuristics/sm100.hpp
+++ b/csrc/jit_kernels/heuristics/sm100.hpp
@@ -19,7 +19,8 @@ struct SM100ArchSpec {
         constexpr int num_utccp_aligned_elems = 128;
         switch (mma_kind) {
             case MmaKind::BF16: return {0, 0};
-            case MmaKind::MXFP8FP4: return {align(block_m, num_utccp_aligned_elems), align(block_n, num_utccp_aligned_elems)};
+            case MmaKind::MXFP8FP4:
+            case MmaKind::NVFP4: return {align(block_m, num_utccp_aligned_elems), align(block_n, num_utccp_aligned_elems)};
             default: DG_HOST_UNREACHABLE("Unknown dtype");
         }
     }

--- a/csrc/jit_kernels/heuristics/sm120.hpp
+++ b/csrc/jit_kernels/heuristics/sm120.hpp
@@ -16,7 +16,7 @@ struct SM120ArchSpec {
     static constexpr int kMinBlockM = 64;   // kMWarps(4) * MMA_M(16), both FP8 and BF16 with kNWarps=2
 
     static std::vector<Layout> get_layout_candidates(const GemmDesc& desc) {
-        const int elem_size = get_element_size(desc.get_mma_kind());
+        const int elem_size = get_byte_addressable_element_size(desc.get_mma_kind());
         const int runtime_align = heuristics_runtime->get_mk_alignment_for_contiguous_layout();
         const int expected_m = desc.get_expected_m();
 
@@ -63,7 +63,7 @@ struct SM120ArchSpec {
         } else {
             int step = std::lcm(8, heuristics_runtime->get_block_n_multiple_of());
             for (int i = step; i <= 256; i += step) {
-                if ((i * get_element_size(desc.get_mma_kind())) % 64 != 0)
+                if ((i * elem_size) % 64 != 0)
                     continue;
                 block_n_candidates.push_back(i);
             }
@@ -242,7 +242,7 @@ struct SM120ArchSpec {
         const int64_t expected_k = desc.get_expected_k();
         const int k_blocks = ceil_div(static_cast<int>(expected_k), layout.block_k);
 
-        const int elem_size = get_element_size(desc.get_mma_kind());
+        const int elem_size = get_byte_addressable_element_size(desc.get_mma_kind());
         const int sf_bytes_a = (desc.kernel_type == KernelType::Kernel1D1D)
             ? align(layout.block_m * 4, 128) : 0;
         const int sf_bytes_b = (desc.kernel_type == KernelType::Kernel1D1D)

--- a/csrc/jit_kernels/heuristics/sm90.hpp
+++ b/csrc/jit_kernels/heuristics/sm90.hpp
@@ -57,7 +57,7 @@ struct SM90ArchSpec {
             block_n_candidates.push_back(i);
 
         // Block K is always in a fixed manner
-        const int block_k = 128 / get_element_size(desc.get_mma_kind());
+        const int block_k = 128 / get_byte_addressable_element_size(desc.get_mma_kind());
 
         // Disable multicast for performance
         const bool disable_multicast =

--- a/csrc/jit_kernels/impls/runtime_utils.hpp
+++ b/csrc/jit_kernels/impls/runtime_utils.hpp
@@ -84,6 +84,8 @@ static CUtensorMapDataType aten_dtype_to_tensor_map_dtype(const at::ScalarType& 
         case torch::kBFloat16:      return CU_TENSOR_MAP_DATA_TYPE_BFLOAT16;
         case torch::kFloat8_e4m3fn: return CU_TENSOR_MAP_DATA_TYPE_UINT8;
         case torch::kFloat16:       return CU_TENSOR_MAP_DATA_TYPE_FLOAT16;
+        // Raw bytes (e.g. packed-FP4 tensors moved without smem unpacking)
+        case torch::kUInt8:         return CU_TENSOR_MAP_DATA_TYPE_UINT8;
 #if CUDA_VERSION >= 12080
         case kPackedFP4:            return fp4_unpacked_smem ? CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B
                                                              : CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B;

--- a/csrc/jit_kernels/impls/sm100_fp4_fp4_mega_moe.hpp
+++ b/csrc/jit_kernels/impls/sm100_fp4_fp4_mega_moe.hpp
@@ -1,0 +1,297 @@
+#pragma once
+
+#include <torch/python.h>
+
+#include "../../jit/compiler.hpp"
+#include "../../jit/kernel_runtime.hpp"
+#include "../../utils/exception.hpp"
+#include "../../utils/format.hpp"
+#include "runtime_utils.hpp"
+
+#include <deep_gemm/layout/mega_moe.cuh>
+#include <deep_gemm/layout/sym_buffer.cuh>
+
+#include "../heuristics/mega_moe.hpp"
+
+namespace deep_gemm {
+
+class SM100FP4FP4MegaMoERuntime final : public LaunchRuntime<SM100FP4FP4MegaMoERuntime> {
+public:
+    struct Args {
+        // Templated arguments
+        int num_max_tokens_per_rank;
+        int hidden, intermediate_hidden;
+        int num_experts, num_shared_experts, num_topk;
+        int num_ranks;
+        float activation_clamp;
+        bool fast_math;
+        MegaMoEConfig config;
+
+        // Runtime arguments
+        void* y;
+        int* cumulative_local_expert_recv_stats;
+        int num_tokens;
+        const void* l1_alphas;
+        const void* l2_alphas;
+        const void* a2_scales;
+        layout::SymBuffer<> sym_buffer_ptrs;
+
+        // Tensormap
+        CUtensorMap tensor_map_l1_acts;
+        CUtensorMap tensor_map_l1_acts_sf;
+        CUtensorMap tensor_map_l1_weights;
+        CUtensorMap tensor_map_l1_weights_sf;
+        CUtensorMap tensor_map_l1_output;
+        CUtensorMap tensor_map_l2_acts;
+        CUtensorMap tensor_map_l2_acts_sf;
+        CUtensorMap tensor_map_l2_weights;
+        CUtensorMap tensor_map_l2_weights_sf;
+        CUtensorMap tensor_map_shared_l1_acts;
+        CUtensorMap tensor_map_shared_l1_weights;
+        CUtensorMap tensor_map_shared_l1_output;
+        CUtensorMap tensor_map_shared_l2_acts;
+        CUtensorMap tensor_map_shared_l2_weights;
+
+        // Launch configs
+        LaunchArgs launch_args;
+    };
+
+    static std::string generate_impl(const Args& args) {
+        return fmt::format(R"(
+#include <deep_gemm/impls/sm100_fp4_fp4_mega_moe.cuh>
+
+using namespace deep_gemm;
+
+static void __instantiate_kernel() {{
+    auto ptr = reinterpret_cast<void*>(&sm100_fp4_fp4_mega_moe_impl<
+        {},
+        {}, {},
+        {}, {},
+        {},
+        {}, {}, {},
+        {},
+        {}, {},
+        {},
+        {},
+        {},
+        {},
+        {}, {}, {},
+        {}, {},
+        {},
+        {}
+    >);
+}};
+)", args.num_max_tokens_per_rank,
+    args.hidden, args.intermediate_hidden,
+    args.num_experts, args.num_shared_experts,
+    args.num_topk,
+    args.config.block_m, args.config.block_n, args.config.block_k,
+    args.config.store_block_m,
+    args.config.sf_block_m, args.config.sf_block_n,
+    args.config.num_ring_tokens,
+    args.config.num_sf_ring_tokens,
+    args.config.num_stages,
+    args.config.num_bytes_per_pull,
+    args.config.num_dispatch_threads, args.config.num_non_epilogue_threads, args.config.num_epilogue_threads,
+    args.launch_args.grid_dim.first, args.num_ranks,
+    to_string(args.activation_clamp),
+    args.fast_math ? "true" : "false");
+    }
+
+    static void launch_impl(const KernelHandle& kernel, const LaunchConfigHandle& config, Args args) {
+        // TODO: optimize `args` copy
+        DG_CUDA_UNIFIED_CHECK(launch_kernel(kernel, config,
+            args.y,
+            args.cumulative_local_expert_recv_stats,
+            args.num_tokens,
+            args.l1_alphas, args.l2_alphas, args.a2_scales,
+            args.sym_buffer_ptrs,
+            args.tensor_map_l1_acts,
+            args.tensor_map_l1_acts_sf,
+            args.tensor_map_l1_weights,
+            args.tensor_map_l1_weights_sf,
+            args.tensor_map_l1_output,
+            args.tensor_map_l2_acts,
+            args.tensor_map_l2_acts_sf,
+            args.tensor_map_l2_weights,
+            args.tensor_map_l2_weights_sf,
+            args.tensor_map_shared_l1_acts,
+            args.tensor_map_shared_l1_weights,
+            args.tensor_map_shared_l1_output,
+            args.tensor_map_shared_l2_acts,
+            args.tensor_map_shared_l2_weights
+        ));
+    }
+};
+
+static void sm100_fp4_fp4_mega_moe(
+    const torch::Tensor& y,
+    const torch::Tensor& l1_acts, const torch::Tensor& l1_acts_sf,
+    const torch::Tensor& l2_acts, const torch::Tensor& l2_acts_sf,
+    // BF16 shared expert tensors: `shared_l1_acts` is the caller-provided BF16 `x`,
+    // `shared_l2_acts` is the BF16 intermediate view sliced from the symmetric buffer
+    const torch::Tensor& shared_l1_acts, const torch::Tensor& shared_l2_acts,
+    const torch::Tensor& shared_l1_weights, const torch::Tensor& shared_l2_weights,
+    const torch::Tensor& l1_weights, const torch::Tensor& l2_weights,
+    const torch::Tensor& l1_weights_sf, const torch::Tensor& l2_weights_sf,
+    const std::optional<torch::Tensor> cumulative_local_expert_recv_stats,
+    const std::vector<int64_t>& sym_buffer_ptrs,
+    const int& rank_idx, const int& num_max_tokens_per_rank,
+    const int& num_experts_per_rank,
+    const int& num_shared_experts,
+    const int& num_tokens, const int& num_topk,
+    const int& hidden, const int& intermediate_hidden,
+    const float& activation_clamp,
+    const bool& fast_math,
+    const void* l1_alphas, const void* l2_alphas, const void* a2_scales
+) {
+    const auto num_ranks = static_cast<int>(sym_buffer_ptrs.size());
+    const auto num_experts = num_experts_per_rank * num_ranks;
+    const auto num_ring_tokens = static_cast<int>(l1_acts.size(0));
+    const auto num_sf_ring_tokens = static_cast<int>(l1_acts_sf.size(0));
+    const auto shared_intermediate_hidden = intermediate_hidden * num_shared_experts;
+
+    // Heuristics
+    const auto config = get_mega_moe_config(
+        num_ranks, num_experts, num_experts_per_rank,
+        num_max_tokens_per_rank, num_tokens, num_topk, hidden, intermediate_hidden,
+        num_ring_tokens, num_sf_ring_tokens,
+        MmaKind::NVFP4);
+
+    // View all packed-FP4 tensors as raw bytes: TMA moves plain byte rows, so the
+    // K dimensions below are all `elements / 2`
+    constexpr int kGranK = 16;
+    const auto l1_weights_bytes = l1_weights.view(torch::kUInt8);
+    const auto l2_weights_bytes = l2_weights.view(torch::kUInt8);
+    const int block_k_bytes = config.block_k / 2;
+    const int sf_smem_outer_dim = config.block_k / (kGranK * 4);
+
+    // Make tensormap
+    const auto tensor_map_l1_acts = make_tma_2d_desc(l1_acts,
+                                                     hidden / 2, config.num_ring_tokens,
+                                                     block_k_bytes, config.load_block_m,
+                                                     static_cast<int>(l1_acts.stride(-2)),
+                                                     config.swizzle_acts_mode);
+    const auto tensor_map_l1_acts_sf = make_tma_sf_desc(cute::UMMA::Major::MN, l1_acts_sf,
+                                                        config.num_sf_ring_tokens, hidden,
+                                                        config.sf_block_m, kGranK,
+                                                        1, 0, 0, false,
+                                                        sf_smem_outer_dim);
+    const auto tensor_map_l1_weights = make_tma_2d_desc(l1_weights_bytes,
+                                                        hidden / 2, num_experts_per_rank * intermediate_hidden * 2,
+                                                        block_k_bytes, config.load_block_n,
+                                                        static_cast<int>(l1_weights_bytes.stride(-2)),
+                                                        config.swizzle_weights_mode);
+    const auto tensor_map_l1_weights_sf = make_tma_sf_desc(cute::UMMA::Major::MN, l1_weights_sf,
+                                                           intermediate_hidden * 2, hidden,
+                                                           config.block_n, kGranK,
+                                                           num_experts_per_rank, 0, 0, false,
+                                                           sf_smem_outer_dim);
+    // NOTES: L1 output and L2 activations are essentially the same tensor.
+    // Post-SwiGLU output has half the N width (`BLOCK_N / 2` elements = `BLOCK_N / 4`
+    // bytes per input tile); the store box is small, so no swizzling is applied
+    const auto tensor_map_l1_output = make_tma_2d_desc(l2_acts,
+                                                       intermediate_hidden / 2, config.num_ring_tokens,
+                                                       config.block_n / 4, config.store_block_m,
+                                                       static_cast<int>(l2_acts.stride(-2)),
+                                                       0);
+    const auto tensor_map_l2_acts = make_tma_2d_desc(l2_acts,
+                                                     intermediate_hidden / 2, config.num_ring_tokens,
+                                                     block_k_bytes, config.load_block_m,
+                                                     static_cast<int>(l2_acts.stride(-2)),
+                                                     config.swizzle_acts_mode);
+    const auto tensor_map_l2_acts_sf = make_tma_sf_desc(cute::UMMA::Major::MN, l2_acts_sf,
+                                                        config.num_sf_ring_tokens, intermediate_hidden,
+                                                        config.sf_block_m, kGranK,
+                                                        1, 0, 0, false,
+                                                        sf_smem_outer_dim);
+    const auto tensor_map_l2_weights = make_tma_2d_desc(l2_weights_bytes,
+                                                        intermediate_hidden / 2, num_experts_per_rank * hidden,
+                                                        block_k_bytes, config.load_block_n,
+                                                        static_cast<int>(l2_weights_bytes.stride(-2)),
+                                                        config.swizzle_weights_mode);
+    const auto tensor_map_l2_weights_sf = make_tma_sf_desc(cute::UMMA::Major::MN, l2_weights_sf,
+                                                           hidden, intermediate_hidden,
+                                                           config.block_n, kGranK,
+                                                           num_experts_per_rank, 0, 0, false,
+                                                           sf_smem_outer_dim);
+
+    // BF16 shared expert descriptors: same 128B tiles hold `block_k / 4` BF16 elements.
+    // With no shared experts they fall back to routed maps so the kernel params stay valid
+    const int shared_block_k = config.block_k / 4;
+    const auto tensor_map_shared_l1_acts = num_shared_experts > 0 ? make_tma_2d_desc(
+        shared_l1_acts,
+        hidden, num_max_tokens_per_rank,
+        shared_block_k, config.load_block_m,
+        static_cast<int>(shared_l1_acts.stride(-2)),
+        config.swizzle_acts_mode) : tensor_map_l1_acts;
+    const auto tensor_map_shared_l1_weights = num_shared_experts > 0 ? make_tma_2d_desc(
+        shared_l1_weights,
+        hidden, shared_intermediate_hidden * 2,
+        shared_block_k, config.load_block_n,
+        static_cast<int>(shared_l1_weights.stride(-2)),
+        config.swizzle_weights_mode) : tensor_map_l1_weights;
+    const auto tensor_map_shared_l1_output = num_shared_experts > 0 ? make_tma_2d_desc(
+        shared_l2_acts,
+        shared_intermediate_hidden, num_max_tokens_per_rank,
+        config.block_n / 2, config.store_block_m,
+        static_cast<int>(shared_l2_acts.stride(-2)),
+        config.swizzle_acts_mode) : tensor_map_l1_output;
+    const auto tensor_map_shared_l2_acts = num_shared_experts > 0 ? make_tma_2d_desc(
+        shared_l2_acts,
+        shared_intermediate_hidden, num_max_tokens_per_rank,
+        shared_block_k, config.load_block_m,
+        static_cast<int>(shared_l2_acts.stride(-2)),
+        config.swizzle_acts_mode) : tensor_map_l2_acts;
+    const auto tensor_map_shared_l2_weights = num_shared_experts > 0 ? make_tma_2d_desc(
+        shared_l2_weights,
+        shared_intermediate_hidden, hidden,
+        shared_block_k, config.load_block_n,
+        static_cast<int>(shared_l2_weights.stride(-2)),
+        config.swizzle_weights_mode) : tensor_map_l2_weights;
+
+    // Stats can be optional
+    int* cumulative_local_expert_recv_stats_ptr = nullptr;
+    if (cumulative_local_expert_recv_stats.has_value())
+        cumulative_local_expert_recv_stats_ptr = cumulative_local_expert_recv_stats->data_ptr<int>();
+
+    // Launch
+    const auto num_sms = device_runtime->get_num_sms();
+    const SM100FP4FP4MegaMoERuntime::Args args = {
+        .num_max_tokens_per_rank = num_max_tokens_per_rank,
+        .hidden = hidden, .intermediate_hidden = intermediate_hidden,
+        .num_experts = num_experts, .num_shared_experts = num_shared_experts, .num_topk = num_topk,
+        .num_ranks = num_ranks,
+        .activation_clamp = activation_clamp,
+        .fast_math = fast_math,
+        .config = config,
+        .y = y.data_ptr(),
+        .cumulative_local_expert_recv_stats = cumulative_local_expert_recv_stats_ptr,
+        .num_tokens = num_tokens,
+        .l1_alphas = l1_alphas, .l2_alphas = l2_alphas, .a2_scales = a2_scales,
+        .sym_buffer_ptrs = layout::SymBuffer<>(sym_buffer_ptrs, rank_idx),
+        .tensor_map_l1_acts = tensor_map_l1_acts,
+        .tensor_map_l1_acts_sf = tensor_map_l1_acts_sf,
+        .tensor_map_l1_weights = tensor_map_l1_weights,
+        .tensor_map_l1_weights_sf = tensor_map_l1_weights_sf,
+        .tensor_map_l1_output = tensor_map_l1_output,
+        .tensor_map_l2_acts = tensor_map_l2_acts,
+        .tensor_map_l2_acts_sf = tensor_map_l2_acts_sf,
+        .tensor_map_l2_weights = tensor_map_l2_weights,
+        .tensor_map_l2_weights_sf = tensor_map_l2_weights_sf,
+        .tensor_map_shared_l1_acts = tensor_map_shared_l1_acts,
+        .tensor_map_shared_l1_weights = tensor_map_shared_l1_weights,
+        .tensor_map_shared_l1_output = tensor_map_shared_l1_output,
+        .tensor_map_shared_l2_acts = tensor_map_shared_l2_acts,
+        .tensor_map_shared_l2_weights = tensor_map_shared_l2_weights,
+        .launch_args = LaunchArgs(num_sms,
+                                  config.num_dispatch_threads + config.num_non_epilogue_threads + config.num_epilogue_threads,
+                                  config.smem_size, 2)
+    };
+
+    const auto code = SM100FP4FP4MegaMoERuntime::generate(args);
+    const auto runtime = compiler->build("sm100_fp4_fp4_mega_moe", code);
+    SM100FP4FP4MegaMoERuntime::launch(runtime, args);
+}
+
+} // namespace deep_gemm

--- a/csrc/jit_kernels/impls/sm100_fp4_fp4_mega_moe.hpp
+++ b/csrc/jit_kernels/impls/sm100_fp4_fp4_mega_moe.hpp
@@ -227,7 +227,7 @@ static void sm100_fp4_fp4_mega_moe(
         // `shared_l1_acts` is the caller's current-token tensor, not a
         // capacity-sized symmetric buffer.  Describe its real row extent so
         // TMA zero-fills the partial M tile instead of reading past storage.
-        hidden, num_tokens,
+        hidden, std::max(num_tokens, 1),
         shared_block_k, config.load_block_m,
         static_cast<int>(shared_l1_acts.stride(-2)),
         config.swizzle_acts_mode) : tensor_map_l1_acts;

--- a/csrc/jit_kernels/impls/sm100_fp4_fp4_mega_moe.hpp
+++ b/csrc/jit_kernels/impls/sm100_fp4_fp4_mega_moe.hpp
@@ -31,6 +31,7 @@ public:
         void* y;
         int* cumulative_local_expert_recv_stats;
         int num_tokens;
+        float routed_scaling_factor;
         const void* l1_alphas;
         const void* l2_alphas;
         const void* a2_scales;
@@ -104,6 +105,7 @@ static void __instantiate_kernel() {{
             args.y,
             args.cumulative_local_expert_recv_stats,
             args.num_tokens,
+            args.routed_scaling_factor,
             args.l1_alphas, args.l2_alphas, args.a2_scales,
             args.sym_buffer_ptrs,
             args.tensor_map_l1_acts,
@@ -143,7 +145,8 @@ static void sm100_fp4_fp4_mega_moe(
     const int& hidden, const int& intermediate_hidden,
     const float& activation_clamp,
     const bool& fast_math,
-    const void* l1_alphas, const void* l2_alphas, const void* a2_scales
+    const void* l1_alphas, const void* l2_alphas, const void* a2_scales,
+    const float& routed_scaling_factor
 ) {
     const auto num_ranks = static_cast<int>(sym_buffer_ptrs.size());
     const auto num_experts = num_experts_per_rank * num_ranks;
@@ -221,7 +224,10 @@ static void sm100_fp4_fp4_mega_moe(
     const int shared_block_k = config.block_k / 4;
     const auto tensor_map_shared_l1_acts = num_shared_experts > 0 ? make_tma_2d_desc(
         shared_l1_acts,
-        hidden, num_max_tokens_per_rank,
+        // `shared_l1_acts` is the caller's current-token tensor, not a
+        // capacity-sized symmetric buffer.  Describe its real row extent so
+        // TMA zero-fills the partial M tile instead of reading past storage.
+        hidden, num_tokens,
         shared_block_k, config.load_block_m,
         static_cast<int>(shared_l1_acts.stride(-2)),
         config.swizzle_acts_mode) : tensor_map_l1_acts;
@@ -268,6 +274,7 @@ static void sm100_fp4_fp4_mega_moe(
         .y = y.data_ptr(),
         .cumulative_local_expert_recv_stats = cumulative_local_expert_recv_stats_ptr,
         .num_tokens = num_tokens,
+        .routed_scaling_factor = routed_scaling_factor,
         .l1_alphas = l1_alphas, .l2_alphas = l2_alphas, .a2_scales = a2_scales,
         .sym_buffer_ptrs = layout::SymBuffer<>(sym_buffer_ptrs, rank_idx),
         .tensor_map_l1_acts = tensor_map_l1_acts,

--- a/csrc/jit_kernels/impls/sm100_fp4_fp4_mega_moe.hpp
+++ b/csrc/jit_kernels/impls/sm100_fp4_fp4_mega_moe.hpp
@@ -220,36 +220,38 @@ static void sm100_fp4_fp4_mega_moe(
                                                            sf_smem_outer_dim);
 
     // BF16 shared expert descriptors: same 128B tiles hold `block_k / 4` BF16 elements.
-    // With no shared experts they fall back to routed maps so the kernel params stay valid
+    // With no shared work they fall back to routed maps so an empty local-token tensor
+    // never passes a null base pointer to cuTensorMapEncodeTiled.
     const int shared_block_k = config.block_k / 4;
-    const auto tensor_map_shared_l1_acts = num_shared_experts > 0 ? make_tma_2d_desc(
+    const bool has_shared_work = num_shared_experts > 0 and num_tokens > 0;
+    const auto tensor_map_shared_l1_acts = has_shared_work ? make_tma_2d_desc(
         shared_l1_acts,
         // `shared_l1_acts` is the caller's current-token tensor, not a
         // capacity-sized symmetric buffer.  Describe its real row extent so
         // TMA zero-fills the partial M tile instead of reading past storage.
-        hidden, std::max(num_tokens, 1),
+        hidden, num_tokens,
         shared_block_k, config.load_block_m,
         static_cast<int>(shared_l1_acts.stride(-2)),
         config.swizzle_acts_mode) : tensor_map_l1_acts;
-    const auto tensor_map_shared_l1_weights = num_shared_experts > 0 ? make_tma_2d_desc(
+    const auto tensor_map_shared_l1_weights = has_shared_work ? make_tma_2d_desc(
         shared_l1_weights,
         hidden, shared_intermediate_hidden * 2,
         shared_block_k, config.load_block_n,
         static_cast<int>(shared_l1_weights.stride(-2)),
         config.swizzle_weights_mode) : tensor_map_l1_weights;
-    const auto tensor_map_shared_l1_output = num_shared_experts > 0 ? make_tma_2d_desc(
+    const auto tensor_map_shared_l1_output = has_shared_work ? make_tma_2d_desc(
         shared_l2_acts,
         shared_intermediate_hidden, num_max_tokens_per_rank,
         config.block_n / 2, config.store_block_m,
         static_cast<int>(shared_l2_acts.stride(-2)),
         config.swizzle_acts_mode) : tensor_map_l1_output;
-    const auto tensor_map_shared_l2_acts = num_shared_experts > 0 ? make_tma_2d_desc(
+    const auto tensor_map_shared_l2_acts = has_shared_work ? make_tma_2d_desc(
         shared_l2_acts,
         shared_intermediate_hidden, num_max_tokens_per_rank,
         shared_block_k, config.load_block_m,
         static_cast<int>(shared_l2_acts.stride(-2)),
         config.swizzle_acts_mode) : tensor_map_l2_acts;
-    const auto tensor_map_shared_l2_weights = num_shared_experts > 0 ? make_tma_2d_desc(
+    const auto tensor_map_shared_l2_weights = has_shared_work ? make_tma_2d_desc(
         shared_l2_weights,
         shared_intermediate_hidden, hidden,
         shared_block_k, config.load_block_n,

--- a/deep_gemm/__init__.py
+++ b/deep_gemm/__init__.py
@@ -88,6 +88,7 @@ from .mega import (
     get_symm_buffer_for_mega_moe,
     transform_weights_for_mega_moe,
     fp8_fp4_mega_moe,
+    fp4_fp4_mega_moe,
     bf16_mega_moe,
 )
 

--- a/deep_gemm/include/deep_gemm/common/types.cuh
+++ b/deep_gemm/include/deep_gemm/common/types.cuh
@@ -15,9 +15,9 @@ constexpr CUTLASS_HOST_DEVICE int get_element_size(const MmaKind& mma_kind) {
     switch (mma_kind) {
         case MmaKind::BF16:     return 2;
         case MmaKind::MXFP8FP4: return 1;
-        // NVFP4 values are addressed through packed-byte storage. MegaMoE uses
-        // `get_num_mma_elem_bits()` when it needs the logical 4-bit width.
-        case MmaKind::NVFP4:    return 1;
+        // NVFP4 is sub-byte and has no integer byte size. Bit-aware MegaMoE
+        // helpers handle it explicitly; generic descriptor paths must not.
+        case MmaKind::NVFP4:    return 0;
         default: return 0;
     }
 }

--- a/deep_gemm/include/deep_gemm/common/types.cuh
+++ b/deep_gemm/include/deep_gemm/common/types.cuh
@@ -15,6 +15,9 @@ constexpr CUTLASS_HOST_DEVICE int get_element_size(const MmaKind& mma_kind) {
     switch (mma_kind) {
         case MmaKind::BF16:     return 2;
         case MmaKind::MXFP8FP4: return 1;
+        // NVFP4 values are addressed through packed-byte storage. MegaMoE uses
+        // `get_num_mma_elem_bits()` when it needs the logical 4-bit width.
+        case MmaKind::NVFP4:    return 1;
         default: return 0;
     }
 }

--- a/deep_gemm/include/deep_gemm/common/types.cuh
+++ b/deep_gemm/include/deep_gemm/common/types.cuh
@@ -7,12 +7,24 @@ namespace deep_gemm {
 enum class MmaKind {
     BF16        = 0,
     MXFP8FP4    = 1,
+    // NVFP4: both operands are packed E2M1 with per-16-element E4M3 scale factors
+    NVFP4       = 2,
 };
 
 constexpr CUTLASS_HOST_DEVICE int get_element_size(const MmaKind& mma_kind) {
     switch (mma_kind) {
         case MmaKind::BF16:     return 2;
         case MmaKind::MXFP8FP4: return 1;
+        default: return 0;
+    }
+}
+
+// Element sizes in bits (NVFP4 elements are sub-byte)
+constexpr CUTLASS_HOST_DEVICE int get_element_bits(const MmaKind& mma_kind) {
+    switch (mma_kind) {
+        case MmaKind::BF16:     return 16;
+        case MmaKind::MXFP8FP4: return 8;
+        case MmaKind::NVFP4:    return 4;
         default: return 0;
     }
 }

--- a/deep_gemm/include/deep_gemm/common/types.cuh
+++ b/deep_gemm/include/deep_gemm/common/types.cuh
@@ -19,16 +19,6 @@ constexpr CUTLASS_HOST_DEVICE int get_element_size(const MmaKind& mma_kind) {
     }
 }
 
-// Element sizes in bits (NVFP4 elements are sub-byte)
-constexpr CUTLASS_HOST_DEVICE int get_element_bits(const MmaKind& mma_kind) {
-    switch (mma_kind) {
-        case MmaKind::BF16:     return 16;
-        case MmaKind::MXFP8FP4: return 8;
-        case MmaKind::NVFP4:    return 4;
-        default: return 0;
-    }
-}
-
 enum class GemmType {
     Normal                              = 0,
     MGroupedContiguous                  = 1,

--- a/deep_gemm/include/deep_gemm/common/types.cuh
+++ b/deep_gemm/include/deep_gemm/common/types.cuh
@@ -18,7 +18,8 @@ constexpr CUTLASS_HOST_DEVICE int get_element_size(const MmaKind& mma_kind) {
         // NVFP4 is sub-byte and has no integer byte size. Bit-aware MegaMoE
         // helpers handle it explicitly; generic descriptor paths must not.
         case MmaKind::NVFP4:    return 0;
-        default: return 0;
+        // Keep unknown kinds distinguishable from the valid sub-byte NVFP4 kind.
+        default: return -1;
     }
 }
 

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp4_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp4_fp4_mega_moe.cuh
@@ -132,7 +132,6 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
     // the next slot makes it the highest set bit and therefore the last value
     // consumed by the combine loop's __ffs traversal.
     constexpr uint32_t kSharedCombineSlot = kNumTopk;
-    DG_STATIC_ASSERT(kSharedCombineSlot == kNumTopk, "Shared output must follow every routed combine slot");
     using Allocator = cute::TMEM::Allocator2Sm;
 
     // Template checks

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp4_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp4_fp4_mega_moe.cuh
@@ -1,0 +1,1720 @@
+#pragma once
+
+#include <cstdint>
+#include <cutlass/arch/barrier.h>
+#include <cutlass/arch/reg_reconfig.h>
+
+#include <deep_gemm/common/math.cuh>
+#include <deep_gemm/common/tma_copy.cuh>
+#include <deep_gemm/common/utils.cuh>
+#include <deep_gemm/comm/barrier.cuh>
+#include <deep_gemm/layout/sym_buffer.cuh>
+#include <deep_gemm/layout/mega_moe.cuh>
+#include <deep_gemm/mma/sm100.cuh>
+#include <deep_gemm/scheduler/mega_moe.cuh>
+#include <deep_gemm/ptx/tcgen05.cuh>
+#include <deep_gemm/ptx/tma.cuh>
+#include <deep_gemm/ptx/utils.cuh>
+
+namespace deep_gemm {
+
+#if (defined(__CUDA_ARCH__) and (__CUDA_ARCH__ >= 1000)) or defined(__CLION_IDE__)
+
+// Pack 2 FP32 values into one byte of 2 E2M1 values ({`hi`, `lo`} nibbles)
+CUTLASS_DEVICE uint32_t cvt_into_e2m1x2(const float& hi, const float& lo) {
+    uint32_t packed;
+    asm volatile(
+        "{\n"
+        ".reg .b8 byte0, byte1, byte2, byte3;\n"
+        "cvt.rn.satfinite.e2m1x2.f32 byte0, %1, %2;\n"
+        "mov.b32 %0, {byte0, byte1, byte2, byte3};\n"
+        "}" : "=r"(packed) : "f"(hi), "f"(lo));
+    return packed & 0xffu;
+}
+
+// NVFP4 SF: cast per-16-element amax into E4M3 block scales, for 2 tokens.
+//
+// The stored block SF is normalized by a per-tensor global scale so that it lands in
+// E4M3's well-represented range: `sf = e4m3(amax / 6 * inv_global)`, where
+// `inv_global = 1 / a2_scale` and `a2_scale` (the calibrated down-proj `input_scale`,
+// modelopt convention) is later folded back into the L2 GEMM alpha. With `inv_global == 1`
+// this degrades to the plain `sf = e4m3(amax / 6)` recipe.
+//
+// This matters because for small activations `amax / 6` falls into E4M3 subnormals (below
+// 2^-6) or clamps at `kMinSF`, losing scale precision; `inv_global` (large for small
+// tensors) lifts it back into the normal range, so the block scale is near-lossless.
+// NOTES: the input is clamped so that the SF never rounds to zero (keeping `sf_inv` finite)
+template <bool kFastMath>
+CUTLASS_DEVICE void get_nvfp4_e4m3_sf_and_sf_inv(const float2& amax, const float& inv_global,
+                                                 float2& sf_inv, uint32_t& sf_bytes) {
+    // 2^-9 is the smallest E4M3 subnormal
+    constexpr float kMinSF = 0.001953125f;
+    constexpr float kE2M1MaxInv = 1.0f / 6.0f;
+    const auto sf_fp8x2 = __nv_fp8x2_e4m3(make_float2(
+        fmaxf(amax.x * kE2M1MaxInv * inv_global, kMinSF),
+        fmaxf(amax.y * kE2M1MaxInv * inv_global, kMinSF)));
+    sf_bytes = *reinterpret_cast<const uint16_t*>(&sf_fp8x2);
+    const auto sf = static_cast<float2>(sf_fp8x2);
+    // Element quant factor = 1 / (sf * a2_scale) = inv_global / sf
+    if constexpr (kFastMath) {
+        sf_inv = {inv_global * math::fast_rcp(sf.x), inv_global * math::fast_rcp(sf.y)};
+    } else {
+        sf_inv = {inv_global / sf.x, inv_global / sf.y};
+    }
+}
+
+#endif
+
+template <
+    uint32_t kNumMaxTokensPerRank,
+    uint32_t kHidden, uint32_t kIntermediateHidden,
+    uint32_t kNumExperts, uint32_t kNumSharedExperts,
+    uint32_t kNumTopk,
+    uint32_t BLOCK_M, uint32_t BLOCK_N, uint32_t BLOCK_K,
+    uint32_t STORE_BLOCK_M,
+    uint32_t SF_BLOCK_M, uint32_t SF_BLOCK_N,
+    uint32_t kNumRingTokens,
+    uint32_t kNumSFRingTokens,
+    uint32_t kNumStages,
+    uint32_t kNumBytesPerPull,
+    uint32_t kNumDispatchThreads, uint32_t kNumNonEpilogueThreads,
+    uint32_t kNumEpilogueThreads,
+    uint32_t kNumSMs, uint32_t kNumRanks,
+    float kActivationClamp,
+    bool kFastMath,
+    bool kHasShared = (kNumSharedExperts > 0),
+    uint32_t L1_SHAPE_N = kIntermediateHidden * 2,
+    uint32_t L1_SHAPE_K = kHidden,
+    uint32_t L2_SHAPE_N = kHidden,
+    uint32_t L2_SHAPE_K = kIntermediateHidden,
+    uint32_t SHARED_L2_SHAPE_K = L2_SHAPE_K * kNumSharedExperts,
+    uint32_t kNumDispatchWarps = kNumDispatchThreads / 32,
+    uint32_t kNumMMANonEpilogueWarps = kNumNonEpilogueThreads / 32,
+    uint32_t kNumEpilogueWarps = kNumEpilogueThreads / 32,
+    uint32_t kNumEpilogueWarpgroups = kNumEpilogueWarps / 4,
+    uint32_t kNumThreads = kNumDispatchThreads + kNumNonEpilogueThreads + kNumEpilogueThreads,
+    uint32_t kNumTokensPerWarp = 32 / kNumTopk,
+    uint32_t kNumExpertsPerRank = kNumExperts / kNumRanks,
+    uint32_t kNumRingBlocks = kNumRingTokens / BLOCK_M,
+    typename task_info_t = sched::TaskInfo<kHasShared>
+>
+CUTLASS_GLOBAL __launch_bounds__(kNumThreads, 1) void
+sm100_fp4_fp4_mega_moe_impl(void* y,
+                            int* cumulative_local_expert_recv_stats,
+                            const uint32_t num_tokens,
+                            // Optional per-local-expert scales: L1 has separate gate/up factors
+                            // (e.g. modelopt's per-projection `weight_scale_2`)
+                            const float2* l1_alphas, const float* l2_alphas,
+                            // Optional per-local-expert down-proj input scale (modelopt's
+                            // `input_scale`): normalizes the in-kernel intermediate NVFP4
+                            // requant and is folded into the L2 alpha (`nullptr` => 1.0)
+                            const float* a2_scales,
+                            const __grid_constant__ layout::SymBuffer<kNumRanks> sym_buffer,
+                            const __grid_constant__ cute::TmaDescriptor tensor_map_l1_acts,
+                            const __grid_constant__ cute::TmaDescriptor tensor_map_l1_acts_sf,
+                            const __grid_constant__ cute::TmaDescriptor tensor_map_l1_weights,
+                            const __grid_constant__ cute::TmaDescriptor tensor_map_l1_weights_sf,
+                            const __grid_constant__ cute::TmaDescriptor tensor_map_l1_output,
+                            const __grid_constant__ cute::TmaDescriptor tensor_map_l2_acts,
+                            const __grid_constant__ cute::TmaDescriptor tensor_map_l2_acts_sf,
+                            const __grid_constant__ cute::TmaDescriptor tensor_map_l2_weights,
+                            const __grid_constant__ cute::TmaDescriptor tensor_map_l2_weights_sf,
+                            // BF16 shared expert descriptors (SF-free; fall back to routed maps when unused)
+                            const __grid_constant__ cute::TmaDescriptor tensor_map_shared_l1_acts,
+                            const __grid_constant__ cute::TmaDescriptor tensor_map_shared_l1_weights,
+                            const __grid_constant__ cute::TmaDescriptor tensor_map_shared_l1_output,
+                            const __grid_constant__ cute::TmaDescriptor tensor_map_shared_l2_acts,
+                            const __grid_constant__ cute::TmaDescriptor tensor_map_shared_l2_weights) {
+#if (defined(__CUDA_ARCH__) and (__CUDA_ARCH__ >= 1000)) or defined(__CLION_IDE__)
+    using Barrier = cutlass::arch::ClusterTransactionBarrier;
+    using Allocator = cute::TMEM::Allocator2Sm;
+
+    // Template checks
+    DG_STATIC_ASSERT(kNumDispatchThreads % 128 == 0, "Invalid number of dispatch threads");
+    DG_STATIC_ASSERT(kNumNonEpilogueThreads == 128, "Invalid number of MMA non-epilogue threads");
+    DG_STATIC_ASSERT(kNumEpilogueThreads % 128 == 0, "Invalid number of MMA epilogue and combine threads");
+    DG_STATIC_ASSERT(kNumExperts % kNumRanks == 0, "Invalid number of experts or ranks");
+
+    // NVFP4 layout checks: SF rows (per 16 elements) must stay TMA-aligned (16B)
+    DG_STATIC_ASSERT(kHidden % 256 == 0 and kIntermediateHidden % 256 == 0, "Invalid hidden sizes for NVFP4");
+
+    // Thread indices
+    const bool is_leader_cta = cute::block_rank_in_cluster() == 0;
+    const uint32_t sm_idx = blockIdx.x;
+    const uint32_t thread_idx = threadIdx.x;
+    const uint32_t warp_idx = cutlass::canonical_warp_idx_sync();
+    const uint32_t lane_idx = ptx::get_lane_idx();
+
+    // Prefetch TMA descriptors at the very beginning
+    if (warp_idx == 0) {
+        cute::prefetch_tma_descriptor(&tensor_map_l1_acts);
+        cute::prefetch_tma_descriptor(&tensor_map_l1_acts_sf);
+        cute::prefetch_tma_descriptor(&tensor_map_l1_weights);
+        cute::prefetch_tma_descriptor(&tensor_map_l1_weights_sf);
+        cute::prefetch_tma_descriptor(&tensor_map_l1_output);
+        cute::prefetch_tma_descriptor(&tensor_map_l2_acts);
+        cute::prefetch_tma_descriptor(&tensor_map_l2_acts_sf);
+        cute::prefetch_tma_descriptor(&tensor_map_l2_weights);
+        cute::prefetch_tma_descriptor(&tensor_map_l2_weights_sf);
+        cute::prefetch_tma_descriptor(&tensor_map_shared_l1_acts);
+        cute::prefetch_tma_descriptor(&tensor_map_shared_l1_weights);
+        cute::prefetch_tma_descriptor(&tensor_map_shared_l1_output);
+        cute::prefetch_tma_descriptor(&tensor_map_shared_l2_acts);
+        cute::prefetch_tma_descriptor(&tensor_map_shared_l2_weights);
+    }
+
+    // Workspaces and Buffer
+    // NOTES: tokens are packed E2M1 (2 elements per byte, 4 bits each), SFs are E4M3
+    // (1 byte per 16 elements, `sf_gran_k = 16`)
+    const auto buffer = layout::MegaMoEBuffer(
+        sym_buffer.get_base_ptr(),
+        kHidden, kIntermediateHidden,
+        kNumRanks, kNumExperts,
+        kNumMaxTokensPerRank, kNumTopk,
+        kNumRingTokens, kNumSFRingTokens,
+        /*with_sf=*/ true,
+        kNumSharedExperts,
+        /*num_mma_elem_bits=*/ 4,
+        /*sf_gran_k=*/ 16,
+        /*shared_num_mma_elem_bits=*/ 16  // BF16 shared experts, SF-free
+    );
+    const auto workspace = buffer.workspace;
+
+    // SF and its buffer configs
+    constexpr uint32_t kGranK = 16;
+    constexpr uint32_t kNumUTCCPAlignedElems = 128;
+    DG_STATIC_ASSERT(SF_BLOCK_M == math::constexpr_align(BLOCK_M, kNumUTCCPAlignedElems), "Invalid SF_BLOCK_M");
+    DG_STATIC_ASSERT(SF_BLOCK_N == BLOCK_N, "No padding is needed for SFB");
+
+    // UTCCP 4x32 transpose index mapping within each 128-element group
+    const auto transform_sf_token_idx = [](const uint32_t& token_idx_in_expert) {
+        const uint32_t idx = token_idx_in_expert % BLOCK_M;
+        return token_idx_in_expert / BLOCK_M * SF_BLOCK_M +
+               (idx & ~127u) + (idx & 31u) * 4 + ((idx >> 5) & 3u);
+    };
+
+    // MMA configs
+    // NOTES: always swap A/B, 2-CTA MMA, and matrices are K-major.
+    // Both operands are packed E2M1: smem tiles are treated as raw bytes,
+    // `kind::mxf4nvf4` MMA consumes 64 elements (32 bytes) per instruction with
+    // 4 E4M3 SF bytes per row (one full TMEM SF word, `scale_vec::4X`)
+    constexpr uint32_t LAYOUT_AD_M = 128;
+    constexpr uint32_t UMMA_M = LAYOUT_AD_M * 2;
+    constexpr uint32_t UMMA_N = BLOCK_M;  // Swap AB
+    constexpr uint32_t UMMA_K = 64;
+    constexpr uint32_t BLOCK_K_BYTES = BLOCK_K / 2;
+    constexpr uint32_t UMMA_BLOCK_K_BYTES = 128;  // One 128B swizzle atom on K
+    constexpr uint32_t kNumMMAsPerKAtom = UMMA_BLOCK_K_BYTES * 2 / UMMA_K;
+
+    // BF16 shared-expert MMA configs (`kind::f16`, non-block-scaled, no SF/UTCCP).
+    // BF16 tiles pack fewer elements into the same 128B swizzle atom, so the per-stage
+    // byte footprint is identical to the packed-FP4 tiles and `smem_a/b` are reused
+    using shared_dtype_t = cutlass::bfloat16_t;
+    constexpr uint32_t SHARED_UMMA_K = 16;
+    constexpr uint32_t SHARED_BLOCK_K = BLOCK_K_BYTES / sizeof(shared_dtype_t);
+    constexpr uint32_t SHARED_UMMA_BLOCK_K = UMMA_BLOCK_K_BYTES / sizeof(shared_dtype_t);
+    DG_STATIC_ASSERT(SHARED_BLOCK_K * sizeof(shared_dtype_t) == BLOCK_K_BYTES, "Invalid shared block K");
+    constexpr uint32_t LOAD_BLOCK_M = BLOCK_M / 2;  // Multicast on A
+    constexpr uint32_t LOAD_BLOCK_N = BLOCK_N;
+    DG_STATIC_ASSERT(BLOCK_M % 16 == 0, "Invalid block M");
+    DG_STATIC_ASSERT(BLOCK_N == LAYOUT_AD_M, "Invalid block N");
+    DG_STATIC_ASSERT(BLOCK_K_BYTES % UMMA_BLOCK_K_BYTES == 0, "Invalid block K");
+
+    // Swizzle configs (in bytes)
+    constexpr uint32_t kSwizzleAMode = 128;
+    constexpr uint32_t kSwizzleBMode = 128;
+    constexpr uint32_t kSwizzleCDMode = 128;
+    DG_STATIC_ASSERT(BLOCK_N % kSwizzleCDMode == 0, "Invalid block N");
+    DG_STATIC_ASSERT(kSwizzleAMode == UMMA_BLOCK_K_BYTES and kSwizzleBMode == UMMA_BLOCK_K_BYTES,
+                     "Swizzle atoms must match the UMMA K block");
+
+    // Epilogue configs
+    constexpr uint32_t kNumEpilogueStages = 2;
+    constexpr uint32_t kNumTMAStoreStages = 2;
+
+    // Shared memory
+    constexpr uint32_t kSharedMemoryAlignment = 1024;
+    extern __shared__ __align__(kSharedMemoryAlignment) uint8_t smem_buffer[];
+
+    // Shared memory sizes
+    // NOTES: packed FP4 CD output for L1 (2 TMA stages, `BLOCK_N / 2` post-SwiGLU elements
+    // = `BLOCK_N / 4` bytes), BF16 output for L2 (no TMA, a single stage)
+    constexpr uint32_t L1_OUT_BLOCK_N = BLOCK_N / 2;
+    constexpr uint32_t L1_OUT_BLOCK_N_BYTES = L1_OUT_BLOCK_N / 2;
+
+    // Scheduler configs
+    constexpr uint32_t kNumScheduleStages = 2;
+    constexpr uint32_t kNumScheduleConsumerThreads = 2 * kNumEpilogueThreads;
+
+    struct SharedStorage {
+        alignas(kSharedMemoryAlignment) uint32_t expert_token_count[kNumExperts];
+        alignas(kSharedMemoryAlignment) uint8_t dispatch_send_buffer[kNumDispatchWarps][kNumBytesPerPull];
+        union {
+            alignas(kSharedMemoryAlignment) uint8_t l1[kNumEpilogueWarpgroups][kNumTMAStoreStages][STORE_BLOCK_M * L1_OUT_BLOCK_N_BYTES];
+            alignas(kSharedMemoryAlignment) nv_bfloat16 l2[kNumEpilogueWarpgroups][STORE_BLOCK_M * BLOCK_N];
+            // BF16 shared-expert L1 staging (`BLOCK_N / 2` post-SwiGLU columns);
+            // same byte size as the `l2` member, so the union does not grow
+            alignas(kSharedMemoryAlignment) nv_bfloat16 shared_l1[kNumEpilogueWarpgroups][kNumTMAStoreStages][STORE_BLOCK_M * (BLOCK_N / 2)];
+        } smem_d;
+        alignas(kSharedMemoryAlignment) uint8_t smem_a[kNumStages][LOAD_BLOCK_M * BLOCK_K_BYTES];
+        alignas(kSharedMemoryAlignment) uint8_t smem_b[kNumStages][LOAD_BLOCK_N * BLOCK_K_BYTES];
+        uint32_t smem_sfa[kNumStages][SF_BLOCK_M * (BLOCK_K / (kGranK * 4))];
+        uint32_t smem_sfb[kNumStages][SF_BLOCK_N * (BLOCK_K / (kGranK * 4))];
+        task_info_t task_infos[kNumScheduleStages];
+        Barrier dispatch_barriers[kNumDispatchWarps];
+        Barrier full_barriers[kNumStages];
+        Barrier empty_barriers[kNumStages];
+        Barrier tmem_full_barriers[kNumEpilogueStages];
+        Barrier tmem_empty_barriers[kNumEpilogueStages];
+        Barrier combine_barriers[kNumEpilogueWarps * 2];
+        Barrier task_info_full_barriers[kNumScheduleStages];
+        Barrier task_info_empty_barriers[kNumScheduleStages];
+        uint32_t tmem_ptr_in_smem;
+    };
+    constexpr uint32_t kNumReusableSmemBytes = offsetof(SharedStorage, dispatch_barriers);
+    SharedStorage &shared_storage = *reinterpret_cast<SharedStorage*>(smem_buffer);
+
+    // Send buffers
+    constexpr auto pull_layout = layout::Data(kNumBytesPerPull);
+    const auto smem_send_buffers = layout::Buffer(
+        pull_layout, kNumDispatchWarps, 1,
+        static_cast<void*>(shared_storage.dispatch_send_buffer));
+
+    // Tensor memory size
+    constexpr uint32_t kNumAccumTmemCols = UMMA_N * kNumEpilogueStages;
+    constexpr uint32_t kNumSFATmemCols = SF_BLOCK_M / 32;
+    constexpr uint32_t kNumSFBTmemCols = SF_BLOCK_N / 32;
+    constexpr uint32_t kNumTmemCols = utils::get_num_aligned_tmem_cols<kNumAccumTmemCols + kNumSFATmemCols + kNumSFBTmemCols>();
+    constexpr uint32_t kTmemStartColOfSFA = kNumAccumTmemCols;
+    constexpr uint32_t kTmemStartColOfSFB = kNumAccumTmemCols + kNumSFATmemCols;
+    DG_STATIC_ASSERT(32 <= kNumTmemCols and kNumTmemCols <= 512, "Invalid tensor memory columns");
+
+    // A cluster sync is essential for 2CTA tensor memory allocation
+    comm::cluster_sync_with_relaxed_arrive();
+
+    // Initialization
+    if (warp_idx == 0) {
+        // Clean shared memory
+        if (cute::elect_one_sync()) {
+            // The bytes must be 8 bytes aligned
+            ptx::st_shared_bulk(
+                shared_storage.expert_token_count,
+                math::constexpr_align<uint32_t>(kNumExperts * sizeof(uint32_t), kSharedMemoryAlignment)
+            );
+        }
+    } else if (warp_idx == 1) {
+        // Init m-barriers for dispatch
+        #pragma unroll
+        for (uint32_t i = lane_idx; i < kNumDispatchWarps; i += 32)
+            shared_storage.dispatch_barriers[i].init(1);
+        cutlass::arch::fence_barrier_init();
+    } else if (warp_idx == 2) {
+        // Init GEMM barriers
+        if (cute::elect_one_sync()) {
+            #pragma unroll
+            for (uint32_t i = 0; i < kNumStages; ++ i) {
+                // Arrive at 2 CTAs, A + B
+                shared_storage.full_barriers[i].init(2 * 2);
+                shared_storage.empty_barriers[i].init(1);
+            }
+            #pragma unroll
+            for (uint32_t i = 0; i < kNumEpilogueStages; ++ i) {
+                // Arrive at all CTAs
+                shared_storage.tmem_full_barriers[i].init(1);
+                // Arrive only at the leader CTA
+                shared_storage.tmem_empty_barriers[i].init(2 * kNumEpilogueThreads);
+            }
+            #pragma unroll
+            for (uint32_t i = 0; i < kNumEpilogueWarps * 2; ++ i)
+                shared_storage.combine_barriers[i].init(1);
+            #pragma unroll
+            for (uint32_t i = 0; i < kNumScheduleStages; ++ i) {
+                shared_storage.task_info_full_barriers[i].init(1);
+                shared_storage.task_info_empty_barriers[i].init(kNumScheduleConsumerThreads);
+            }
+        }
+        cutlass::arch::fence_barrier_init();
+    } else if (warp_idx == 3) {
+        // Allocate tensor memory
+        Allocator().allocate(kNumTmemCols, &shared_storage.tmem_ptr_in_smem);
+    }
+    // NOTES: Using `.relaxed` is allowed here since `fence_barrier_init` is `.release.cluster`,
+    // and `barrier.cluster.wait.aligned` is by default `.acquire`
+    comm::cluster_sync_with_relaxed_arrive();
+
+    // Task scheduler
+    auto scheduler = sched::MegaMoEScheduler<
+        BLOCK_M, BLOCK_N, BLOCK_K,
+        L1_SHAPE_N, L1_SHAPE_K,
+        L2_SHAPE_N, L2_SHAPE_K,
+        kNumExpertsPerRank,
+        kNumSMs, kNumRanks,
+        kNumRingBlocks,
+        kNumSharedExperts>(
+            workspace,
+            shared_storage.task_info_full_barriers,
+            shared_storage.task_info_empty_barriers,
+            shared_storage.task_infos
+    );
+
+    // MMA pipeline and TMA phases
+    uint32_t stage_idx = 0, phase = 0;
+    auto advance_pipeline = [&](uint32_t& k_block_idx) {
+        ++ k_block_idx;
+
+        // Flip phases only if reach the next first stage
+        stage_idx = stage_idx == kNumStages - 1 ? 0 : stage_idx + 1;
+        phase ^= stage_idx == 0;
+    };
+
+    // Intra-SM Barrier indices
+    constexpr uint32_t kDispatchBarrierIdx = 0;
+    constexpr uint32_t kDispatchWithEpilogueBarrierIdx = 1;
+    constexpr uint32_t kEpilogueFullBarrierIdx = 2;
+    constexpr uint32_t kEpilogueWGBarrierStartIdx = 3;
+
+    // NVLink barrier tags
+    constexpr uint32_t kBeforeDispatchPullBarrierTag = 1;
+    constexpr uint32_t kBeforeCombineReduceBarrierTag = 2;
+    constexpr uint32_t kAfterWorkspaceCleanBarrierTag = 3;
+
+    // Adjust registers
+    // NOTES: more experts per rank will cost more schedulers' registers
+    constexpr bool kUseMoreEpilogueRegisters = kNumExpertsPerRank <= 64;
+    constexpr uint32_t kNumDispatchRegisters = kUseMoreEpilogueRegisters ? 48 : 96;
+    constexpr uint32_t kNumNonEpilogueRegisters = kUseMoreEpilogueRegisters ? 40 : 88;
+    constexpr uint32_t kNumEpilogueRegisters = kUseMoreEpilogueRegisters ? 208 : 160;
+    DG_STATIC_ASSERT(kNumDispatchRegisters * kNumDispatchThreads +
+                     kNumNonEpilogueRegisters * kNumNonEpilogueThreads +
+                     kNumEpilogueRegisters * kNumEpilogueThreads <= 64512,
+                     "Too many registers");
+
+    // Grid sync index assignments (dispatch and epilogue use separate counters to avoid conflicts)
+    constexpr uint32_t kDispatchGridSyncIndex = 0;
+    constexpr uint32_t kEpilogueGridSyncIndex = 1;
+
+    // Different warp roles
+    if (warp_idx < kNumDispatchWarps) {
+        // Adjust registers
+        cutlass::arch::warpgroup_reg_dealloc<kNumDispatchRegisters>();
+
+        // Dispatch warps
+        DG_STATIC_ASSERT(kNumTopk <= 32, "Invalid number of topk");
+        constexpr uint32_t kNumActivateLanes = kNumTokensPerWarp * kNumTopk;
+        const auto read_topk_idx = [&](const auto& process) {
+            // TODO: figure out better unrolling
+            // Now, `unroll` is better than `unroll 8`
+            #pragma unroll
+            for (uint32_t i = (sm_idx * kNumDispatchWarps + warp_idx) * kNumTokensPerWarp;
+                 i < num_tokens;
+                 i += kNumSMs * kNumDispatchWarps * kNumTokensPerWarp) {
+                // Allocate slots for each token-topk
+                int expert_idx = -1;
+                if (i + (lane_idx / kNumTopk) < num_tokens and lane_idx < kNumActivateLanes) {
+                    expert_idx = static_cast<int>(
+                        __ldg(buffer.input_topk_idx_buffer.get_base_ptr<int64_t>() + i * kNumTopk + lane_idx));
+                    if (expert_idx >= 0)
+                        process(i * kNumTopk + lane_idx, expert_idx);
+                }
+                __syncwarp();
+            }
+        };
+
+        // Count experts' tokens
+        read_topk_idx([&](const uint32_t& token_topk_idx, const int& expert_idx) {
+           atomicAdd_block(shared_storage.expert_token_count + expert_idx, 1);
+        });
+        ptx::sync_aligned(kNumDispatchThreads, kDispatchBarrierIdx);
+
+        // Get SM offset (~6.5 us)
+        #pragma unroll
+        for (uint32_t i = thread_idx; i < kNumExperts; i += kNumDispatchThreads) {
+            const uint64_t send_value = (1ull << 32) | static_cast<uint64_t>(shared_storage.expert_token_count[i]);
+            shared_storage.expert_token_count[i] = static_cast<uint32_t>(
+                ptx::atomic_add(workspace.get_expert_send_count_ptr(i), send_value));
+        }
+        ptx::sync_aligned(kNumDispatchThreads, kDispatchBarrierIdx);
+
+        // Write source indices (~2 us with 512 tokens)
+        read_topk_idx([&](const uint32_t& token_topk_idx, const int& expert_idx) {
+            const auto dst_rank_idx = expert_idx / kNumExpertsPerRank;
+            const auto dst_slot_idx = atomicAdd_block(shared_storage.expert_token_count + expert_idx, 1);
+            const auto dst_ptr = workspace.get_src_token_topk_idx_ptr(
+                expert_idx % kNumExpertsPerRank, sym_buffer.rank_idx, dst_slot_idx);
+            *sym_buffer.map(dst_ptr, dst_rank_idx) = token_topk_idx;
+        });
+
+        // Grid sync
+        comm::grid_sync<kNumSMs, kDispatchGridSyncIndex>(
+            workspace, sm_idx, thread_idx,
+            [=]() { ptx::sync_aligned(kNumDispatchThreads, kDispatchBarrierIdx); }
+        );
+
+        // Write expert count
+        if (sm_idx == 0) {
+            #pragma unroll
+            for (uint32_t i = thread_idx; i < kNumExperts; i += kNumDispatchThreads) {
+                const auto dst_rank_idx = i / kNumExpertsPerRank;
+                const auto dst_local_expert_idx = i % kNumExpertsPerRank;
+                const auto expert_status = *workspace.get_expert_send_count_ptr(i);
+                *sym_buffer.map(
+                    workspace.get_expert_recv_count_ptr(sym_buffer.rank_idx, dst_local_expert_idx),
+                    dst_rank_idx) = expert_status & 0xffffffff;
+                ptx::atomic_add_sys(
+                    sym_buffer.map(workspace.get_expert_recv_count_sum_ptr(dst_local_expert_idx), dst_rank_idx),
+                    expert_status);
+            }
+        }
+        ptx::sync_aligned(kNumDispatchThreads, kDispatchBarrierIdx);
+
+        // Barrier before pulling
+        comm::nvlink_barrier<kNumRanks, kNumSMs, kNumDispatchThreads,
+                             kDispatchGridSyncIndex, kBeforeDispatchPullBarrierTag>(
+            workspace, sym_buffer, sm_idx, thread_idx,
+            [=]() { ptx::sync_aligned(kNumDispatchThreads, kDispatchBarrierIdx); },
+            /* After the grid sync above, there is no more writes by other SMs (except 0) */ false,
+            /* After the NVLink barrier, there is a grid sync */ true
+        );
+
+        // Ensure the epilogue barrier cannot run with the pull barrier
+        ptx::sync_unaligned(kNumDispatchThreads + kNumEpilogueThreads, kDispatchWithEpilogueBarrierIdx);
+
+        // Pull token data and SF from remote ranks into local L1 buffer
+        uint32_t pull_mbarrier_phase = 0;
+        const auto pull_buffer = smem_send_buffers.get_rank_buffer(warp_idx).get_data_buffer(0);
+        const auto pull_mbarrier = &shared_storage.dispatch_barriers[warp_idx];
+
+        // Cache expert token counts in registers (same pattern as scheduler)
+        scheduler.fetch_expert_recv_count();
+
+        // Per-rank counts for current expert (re-loaded when expert changes)
+        constexpr uint32_t kNumRanksPerLane = math::constexpr_ceil_div(kNumRanks, 32u);
+        int current_expert_idx = -1;
+        uint32_t stored_rank_count[kNumRanksPerLane] = {};
+        uint32_t expert_start_idx = 0, expert_end_idx = 0;
+        uint32_t expert_pool_block_offset = 0;
+
+        constexpr uint32_t kNumGlobalWarps = kNumSMs * kNumDispatchWarps;
+        for (uint32_t token_idx = sm_idx * kNumDispatchWarps + warp_idx; ; token_idx += kNumGlobalWarps) {
+            // Advance expert until within the range
+            int old_expert_idx = current_expert_idx;
+            while (token_idx >= expert_end_idx) {
+                if (++ current_expert_idx >= kNumExpertsPerRank)
+                    break;
+
+                // Update pool block offset for the new expert
+                expert_pool_block_offset += math::ceil_div(expert_end_idx - expert_start_idx, BLOCK_M);
+
+                // Move start and end to the next expert
+                expert_start_idx = expert_end_idx;
+                expert_end_idx += scheduler.get_num_tokens(current_expert_idx);
+            }
+
+            // Finish all tokens
+            if (current_expert_idx >= kNumExpertsPerRank)
+                break;
+
+            // Load per-rank counts when expert changes
+            if (old_expert_idx != current_expert_idx) {
+                old_expert_idx = current_expert_idx;
+                #pragma unroll
+                for (uint32_t i = 0; i < kNumRanksPerLane; ++ i) {
+                    const uint32_t j = i * 32 + lane_idx;
+                    // TODO: this is not coalesced
+                    stored_rank_count[i] = j < kNumRanks ?
+                        static_cast<uint32_t>(*workspace.get_expert_recv_count_ptr(j, current_expert_idx)) : 0;
+                }
+            }
+
+            // Round-robin rank selection via iterative min-peeling
+            uint32_t current_rank_in_expert_idx;
+            uint32_t remaining[kNumRanksPerLane];
+            #pragma unroll
+            for (uint32_t i = 0; i < kNumRanksPerLane; ++ i)
+                remaining[i] = stored_rank_count[i];
+            uint32_t offset = 0;
+            uint32_t token_idx_in_expert = token_idx - expert_start_idx;
+            uint32_t slot_idx = token_idx_in_expert;
+            uint32_t token_idx_in_rank;
+            while (true) {
+                // Compute active count and min across all ranks
+                // NOTES: reduce within each lane first, then warp-reduce once
+                uint32_t num_actives_in_lane = 0;
+                uint32_t min_in_lane = 0xffffffff;
+                #pragma unroll
+                for (uint32_t i = 0; i < kNumRanksPerLane; ++ i) {
+                    num_actives_in_lane += remaining[i] > 0;
+                    if (remaining[i] > 0)
+                        min_in_lane = cute::min(min_in_lane, remaining[i]);
+                }
+                const uint32_t num_active_ranks = __reduce_add_sync(0xffffffff, num_actives_in_lane);
+                const uint32_t length = __reduce_min_sync(0xffffffff, min_in_lane);
+
+                // Hit in the current round
+                const uint32_t num_round_tokens = length * num_active_ranks;
+                if (slot_idx < num_round_tokens) {
+                    const uint32_t slot_idx_in_round = slot_idx % num_active_ranks;
+                    uint32_t num_seen_ranks = 0;
+                    current_rank_in_expert_idx = 0;
+                    #pragma unroll
+                    for (uint32_t i = 0; i < kNumRanksPerLane; ++ i) {
+                        const uint32_t mask = __ballot_sync(0xffffffff, remaining[i] > 0);
+                        const uint32_t num_active_lanes = __popc(mask);
+                        if (slot_idx_in_round >= num_seen_ranks and slot_idx_in_round < num_seen_ranks + num_active_lanes)
+                            current_rank_in_expert_idx = i * 32 + __fns(mask, 0, slot_idx_in_round - num_seen_ranks + 1);
+                        num_seen_ranks += num_active_lanes;
+                    }
+                    token_idx_in_rank = offset + (slot_idx / num_active_ranks);
+                    break;
+                }
+
+                // Move into the next round
+                slot_idx -= num_round_tokens;
+                offset += length;
+                #pragma unroll
+                for (uint32_t i = 0; i < kNumRanksPerLane; ++ i)
+                    remaining[i] -= cute::min(remaining[i], length);
+            }
+
+            // Read source token-topk index (written by remote dispatch via NVLink)
+            const uint32_t src_token_topk_idx = *workspace.get_src_token_topk_idx_ptr(
+                current_expert_idx, current_rank_in_expert_idx, token_idx_in_rank);
+            const uint32_t src_token_idx = src_token_topk_idx / kNumTopk;
+            const uint32_t src_topk_idx = src_token_topk_idx % kNumTopk;
+
+            // Hidden bytes are divided into chunks
+            constexpr uint32_t kNumHiddenFP4Bytes = kHidden / 2;
+            constexpr uint32_t kNumChunks = kNumHiddenFP4Bytes / kNumBytesPerPull;
+            DG_STATIC_ASSERT(kNumChunks * kNumBytesPerPull == kNumHiddenFP4Bytes, "kNumBytesPerPull must divide hidden bytes");
+
+            // TMA load token from remote rank and store into local
+            const uint32_t pool_token_idx = expert_pool_block_offset * BLOCK_M + token_idx_in_expert;
+            const uint32_t pool_block_idx = pool_token_idx / BLOCK_M;
+
+            // Wait for ring buffer slot to be available (previous consumer must have finished all N blocks)
+            constexpr uint32_t kNumL1BlockNs = L1_SHAPE_N / BLOCK_N;
+            const auto l1_empty_count_target = (pool_block_idx / kNumRingBlocks) * kNumL1BlockNs;
+            if (l1_empty_count_target > 0) {
+                const auto empty_ptr = workspace.get_l1_empty_count_ptr(pool_block_idx % kNumRingBlocks);
+                while (ptx::ld_acq(empty_ptr) < l1_empty_count_target);
+            }
+
+            const auto src_base_ptr = sym_buffer.map(
+                buffer.input_token_buffer.get_data_buffer(src_token_idx).get_base_ptr(), current_rank_in_expert_idx);
+            const auto dst_base_ptr = buffer.l1_token_buffer.get_data_buffer(pool_token_idx % kNumRingTokens).get_base_ptr();
+            const auto issue_and_wait_pull_store = [&](const uint32_t& i) {
+                ptx::mbarrier_wait_and_flip_phase(pull_mbarrier, pull_mbarrier_phase);
+                ptx::tma_store_1d(
+                    math::advance_ptr(dst_base_ptr, i * kNumBytesPerPull),
+                    pull_buffer.get_base_ptr(), kNumBytesPerPull
+                );
+                cute::tma_store_arrive();
+                ptx::tma_store_wait<0>();
+            };
+            if (cute::elect_one_sync()) {
+                #pragma unroll
+                for (uint32_t i = 0; i < kNumChunks; ++ i) {
+                    ptx::tma_load_1d(
+                        pull_buffer.get_base_ptr(),
+                        math::advance_ptr(src_base_ptr, i * kNumBytesPerPull),
+                        pull_mbarrier, kNumBytesPerPull
+                    );
+                    ptx::mbarrier_arrive_and_set_tx(pull_mbarrier, kNumBytesPerPull);
+                    i != (kNumChunks - 1) ? issue_and_wait_pull_store(i) : void();
+                }
+            }
+            __syncwarp();
+
+            // Load and store SF (overlaps with last chunk's TMA load from remote)
+            // NOTES: 1 E4M3 SF byte per 16 elements, 4 packed per `uint32_t`
+            constexpr uint32_t kNumSFUint32 = kHidden / (kGranK * 4);
+            DG_STATIC_ASSERT(kNumSFUint32 > 0 and kHidden % (kGranK * 4) == 0, "Invalid SF");
+            const auto remote_sf_ptr = sym_buffer.map(
+                buffer.input_sf_buffer.get_data_buffer(src_token_idx).get_base_ptr<uint32_t>(),
+                current_rank_in_expert_idx);
+            const auto local_sf_ptr = buffer.l1_sf_buffer.get_base_ptr<uint32_t>();
+            const uint32_t ring_block_idx = pool_block_idx % kNumRingBlocks;
+            const uint32_t token_idx_in_block = token_idx_in_expert % BLOCK_M;
+            const auto sf_ring_token_idx = ring_block_idx * SF_BLOCK_M +
+                transform_sf_token_idx(token_idx_in_block);
+            #pragma unroll
+            for (uint32_t i = 0; i < math::constexpr_ceil_div(kNumSFUint32, 32u); ++ i) {
+                const uint32_t j = i * 32 + lane_idx;
+                if (j < kNumSFUint32)
+                    local_sf_ptr[j * kNumSFRingTokens + sf_ring_token_idx] = remote_sf_ptr[j];
+            }
+            __syncwarp();
+
+            // Store weights and metadata
+            if (cute::elect_one_sync()) {
+                // Load weights
+                const auto weight = *sym_buffer.map(
+                    buffer.input_topk_weights_buffer.get_base_ptr<float>() + src_token_topk_idx,
+                    current_rank_in_expert_idx);
+                *buffer.l1_topk_weights_buffer.get_data_buffer(pool_token_idx % kNumRingTokens).template get_base_ptr<float>() = weight;
+
+                // Write source metadata for combine write-back (logical pool token)
+                *workspace.get_token_src_metadata_ptr(pool_token_idx) =
+                    {current_rank_in_expert_idx, src_token_idx, src_topk_idx};
+
+                // Complete last chunk's store
+                issue_and_wait_pull_store(kNumChunks - 1);
+                const bool is_last_token = (token_idx == expert_end_idx - 1);
+                ptx::red_add_rel(
+                    workspace.get_l1_full_count_ptr(pool_block_idx % kNumRingBlocks),
+                    is_last_token ? BLOCK_M - (token_idx_in_expert % BLOCK_M) : 1u
+                );
+            }
+            __syncwarp();
+        }
+
+        // Clean workspace for the next usage, and also do cumulative stats
+        // NOTES: it is overlapped with combine reduction epilogue
+        ptx::sync_unaligned(kNumDispatchThreads + kNumEpilogueThreads, kDispatchWithEpilogueBarrierIdx);
+
+        DG_STATIC_ASSERT(kNumSMs > 1, "Invalid SM count");
+        if (sm_idx == 0) {
+            // SM 0: clear expert send count and schedule task counters
+            #pragma unroll
+            for (uint32_t i = thread_idx; i < kNumExperts; i += kNumDispatchThreads)
+                *workspace.get_expert_send_count_ptr(i) = 0;
+            if (warp_idx == 0 and cute::elect_one_sync()) {
+                *workspace.get_l1_task_count_ptr() = 0;
+                *workspace.get_l2_task_count_ptr() = 0;
+                *workspace.get_shared_l1_task_count_ptr() = 0;
+                *workspace.get_shared_l2_task_count_ptr() = 0;
+            }
+            __syncwarp();
+            for (uint32_t i = thread_idx; i < workspace.num_shared_l2_pool_blocks; i += kNumDispatchThreads)
+                *workspace.get_shared_l2_full_count_ptr(i) = 0;
+            __syncwarp();
+        } else {
+            // Other SMs: clean blocks
+            for (uint32_t i = sm_idx - 1; i < kNumExpertsPerRank; i += kNumSMs - 1) {
+                // Read expert token count before clearing
+                const auto num_recv_tokens = static_cast<uint32_t>(
+                    *workspace.get_expert_recv_count_sum_ptr(i));
+                const auto num_recv_m_blocks = math::ceil_div(num_recv_tokens, BLOCK_M);
+
+                // Compute expert pool block offset
+                expert_pool_block_offset = scheduler.get_pool_block_offset(i);
+
+                // Wait read count ready
+                ptx::sync_aligned(kNumDispatchThreads, kDispatchBarrierIdx);
+
+                // Clean expert token count, and add cumulative results
+                DG_STATIC_ASSERT(kNumDispatchWarps >= 2, "Not enough dispatch warps");
+                if (warp_idx == 0) {
+                    *workspace.get_expert_recv_count_sum_ptr(i) = 0;
+                } else if (warp_idx == 1) {
+                    if (cute::elect_one_sync() and cumulative_local_expert_recv_stats != nullptr)
+                        ptx::red_add(cumulative_local_expert_recv_stats + i, static_cast<int>(num_recv_tokens));
+                    __syncwarp();
+                }
+
+                // Clean per-rank token count
+                for (uint32_t j = thread_idx; j < kNumRanks; j += kNumDispatchThreads)
+                    *workspace.get_expert_recv_count_ptr(j, i) = 0;
+                __syncwarp();
+
+                // Clean L1 and L2 full stuffs and ring buffer counts
+                for (uint32_t j = thread_idx; j < num_recv_m_blocks; j += kNumDispatchThreads) {
+                    *workspace.get_l1_full_count_ptr((expert_pool_block_offset + j) % kNumRingBlocks) = 0;
+                    *workspace.get_l1_empty_count_ptr((expert_pool_block_offset + j) % kNumRingBlocks) = 0;
+                    *workspace.get_l2_full_count_ptr((expert_pool_block_offset + j) % kNumRingBlocks) = 0;
+                    *workspace.get_l2_empty_count_ptr((expert_pool_block_offset + j) % kNumRingBlocks) = 0;
+                }
+                __syncwarp();
+            }
+        }
+
+        // Wait for all ranks to finish cleaning
+        comm::nvlink_barrier<kNumRanks, kNumSMs, kNumDispatchThreads,
+                             kDispatchGridSyncIndex, kAfterWorkspaceCleanBarrierTag>(
+            workspace, sym_buffer, sm_idx, thread_idx,
+            [=]() { ptx::sync_aligned(kNumDispatchThreads, kDispatchBarrierIdx); },
+            /* Before the NVLink barrier, there is a grid sync */ true,
+            /* At the end of kernel does not need to sync */ false
+        );
+    } else if (warp_idx == kNumDispatchWarps) {
+        // Adjust registers
+        cutlass::arch::warpgroup_reg_dealloc<kNumNonEpilogueRegisters>();
+
+        // GEMM TMA load warp for tokens with SFA
+        task_info_t task_info;
+        while (scheduler.get_next_task(task_info)) {
+            const auto tensor_map_a_ptr = task_info.block_phase == sched::BlockPhase::Linear1 ? &tensor_map_l1_acts :
+                                          task_info.block_phase == sched::BlockPhase::Linear2 ? &tensor_map_l2_acts :
+                                          task_info.block_phase == sched::BlockPhase::SharedLinear1 ? &tensor_map_shared_l1_acts :
+                                        /*task_info.block_phase == sched::BlockPhase::SharedLinear2*/ &tensor_map_shared_l2_acts;
+            const auto tensor_map_sfa_ptr = task_info.block_phase == sched::BlockPhase::Linear2
+                ? &tensor_map_l2_acts_sf : &tensor_map_l1_acts_sf;
+            const auto num_k_blocks = math::ceil_div(task_info.shape_k, task_info.is_shared() ? SHARED_BLOCK_K : BLOCK_K);
+
+            // Compute pool block offset for this expert
+            const uint32_t pool_block_idx = task_info.pool_block_idx;
+            const uint32_t ring_block_idx = pool_block_idx % kNumRingBlocks;
+            const uint32_t block_idx = task_info.is_shared() ? pool_block_idx : ring_block_idx;
+
+            // Wait the entire token arrival
+            // NOTES: `SharedLinear1` reads the resident local BF16 tokens, no wait needed
+            if (task_info.block_phase == sched::BlockPhase::Linear1) {
+                const auto ptr = workspace.get_l1_full_count_ptr(block_idx);
+                const auto num_expected_tokens = BLOCK_M * (pool_block_idx / kNumRingBlocks + 1);
+                while (ptx::ld_acq(ptr) != num_expected_tokens);
+            } else if (task_info.block_phase == sched::BlockPhase::Linear2) {
+                const auto ptr = workspace.get_l2_full_count_ptr(block_idx);
+                const auto num_expected_blocks = (L2_SHAPE_K / BLOCK_N) * 2 * (pool_block_idx / kNumRingBlocks + 1);
+                while (ptx::ld_acq(ptr) != num_expected_blocks);
+            } else if (task_info.block_phase == sched::BlockPhase::SharedLinear2) {
+                const auto ptr = workspace.get_shared_l2_full_count_ptr(block_idx);
+                const auto num_expected_blocks = (SHARED_L2_SHAPE_K / BLOCK_N) * 2;
+                while (ptx::ld_acq(ptr) != num_expected_blocks);
+            }
+
+            for (uint32_t k_block_idx = 0; k_block_idx < num_k_blocks; advance_pipeline(k_block_idx)) {
+                // Wait consumer release
+                shared_storage.empty_barriers[stage_idx].wait(phase ^ 1);
+
+                // Compute token offsets from block index
+                // NOTES: routed token data offsets on K are in packed FP4 bytes,
+                // shared token offsets are in BF16 elements
+                uint32_t m_idx = block_idx * BLOCK_M;
+                uint32_t k_idx = k_block_idx * (task_info.is_shared() ? SHARED_BLOCK_K : BLOCK_K_BYTES);
+                uint32_t sfa_m_idx = block_idx * SF_BLOCK_M;
+                uint32_t sfa_k_idx = k_block_idx * (BLOCK_K / (kGranK * 4));
+
+                // Add 2 CTA offsets for non-leader CTA
+                if (not is_leader_cta)
+                    m_idx += task_info.get_umma_aligned_valid_m() / 2;
+
+                // TMA copy tokens and SFA, then arrive at full barrier
+                if (cute::elect_one_sync()) {
+                    if (task_info.is_shared()) {
+                        // BF16 shared tokens: same tile bytes, no SFA
+                        tma::copy<SHARED_BLOCK_K, LOAD_BLOCK_M, kSwizzleAMode, shared_dtype_t>(
+                            tensor_map_a_ptr, &shared_storage.full_barriers[stage_idx],
+                            reinterpret_cast<shared_dtype_t*>(shared_storage.smem_a[stage_idx]), k_idx, m_idx, 2);
+                        if (is_leader_cta) {
+                            shared_storage.full_barriers[stage_idx].arrive_and_expect_tx(sizeof(SharedStorage::smem_a[0]) * 2);
+                        } else {
+                            shared_storage.full_barriers[stage_idx].arrive(0u);
+                        }
+                    } else {
+                        tma::copy<BLOCK_K_BYTES, LOAD_BLOCK_M, kSwizzleAMode, uint8_t>(
+                            tensor_map_a_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_a[stage_idx], k_idx, m_idx, 2);
+                        tma::copy<SF_BLOCK_M, 1, 0>(
+                            tensor_map_sfa_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_sfa[stage_idx], sfa_m_idx, sfa_k_idx, 2);
+                        if (is_leader_cta) {
+                            shared_storage.full_barriers[stage_idx].arrive_and_expect_tx(sizeof(SharedStorage::smem_a[0]) * 2 + sizeof(SharedStorage::smem_sfa[0]) * 2);
+                        } else {
+                            shared_storage.full_barriers[stage_idx].arrive(0u);
+                        }
+                    }
+                }
+                __syncwarp();
+            }
+        }
+    } else if (warp_idx == kNumDispatchWarps + 1) {
+        // Adjust registers
+        cutlass::arch::warpgroup_reg_dealloc<kNumNonEpilogueRegisters>();
+
+        // GEMM TMA load warp for weights with SF
+        task_info_t task_info;
+        while (scheduler.get_next_task(task_info)) {
+            const auto tensor_map_b_ptr = task_info.block_phase == sched::BlockPhase::Linear1 ? &tensor_map_l1_weights :
+                                          task_info.block_phase == sched::BlockPhase::Linear2 ? &tensor_map_l2_weights :
+                                          task_info.block_phase == sched::BlockPhase::SharedLinear1 ? &tensor_map_shared_l1_weights :
+                                        /*task_info.block_phase == sched::BlockPhase::SharedLinear2*/ &tensor_map_shared_l2_weights;
+            const auto tensor_map_sfb_ptr =
+                task_info.block_phase == sched::BlockPhase::Linear2 ? &tensor_map_l2_weights_sf : &tensor_map_l1_weights_sf;
+
+            const auto shape_k = task_info.shape_k;
+            const auto shape_n = task_info.shape_n;
+            const auto shape_sfb_k = math::ceil_div(shape_k, kGranK * 4u);
+            const auto n_block_idx = task_info.n_cluster_idx * 2 + (is_leader_cta ? 0u : 1u);
+            const auto num_k_blocks = math::ceil_div(shape_k, task_info.is_shared() ? SHARED_BLOCK_K : BLOCK_K);
+
+            for (uint32_t k_block_idx = 0; k_block_idx < num_k_blocks; advance_pipeline(k_block_idx)) {
+                // Wait consumer release
+                shared_storage.empty_barriers[stage_idx].wait(phase ^ 1);
+
+                // Compute weight offset
+                // NOTES: routed weight data offsets on K are in packed FP4 bytes,
+                // shared weight offsets are in BF16 elements (no per-expert stride)
+                uint32_t n_idx = task_info.is_shared() ? n_block_idx * BLOCK_N : task_info.local_expert_idx * shape_n + n_block_idx * BLOCK_N;
+                uint32_t k_idx = k_block_idx * (task_info.is_shared() ? SHARED_BLOCK_K : BLOCK_K_BYTES);
+                uint32_t sfb_n_idx = n_block_idx * BLOCK_N;
+                uint32_t sfb_k_idx = task_info.local_expert_idx * shape_sfb_k + k_block_idx * (BLOCK_K / (kGranK * 4));
+
+                // TMA copy weights with SF
+                if (cute::elect_one_sync()) {
+                    if (task_info.is_shared()) {
+                        // BF16 shared weights: same tile bytes, no SFB
+                        tma::copy<SHARED_BLOCK_K, LOAD_BLOCK_N, kSwizzleBMode, shared_dtype_t>(
+                            tensor_map_b_ptr, &shared_storage.full_barriers[stage_idx],
+                            reinterpret_cast<shared_dtype_t*>(shared_storage.smem_b[stage_idx]), k_idx, n_idx, 2);
+                        if (is_leader_cta) {
+                            shared_storage.full_barriers[stage_idx].arrive_and_expect_tx(sizeof(SharedStorage::smem_b[0]) * 2);
+                        } else {
+                            shared_storage.full_barriers[stage_idx].arrive(0u);
+                        }
+                    } else {
+                        tma::copy<BLOCK_K_BYTES, LOAD_BLOCK_N, kSwizzleBMode, uint8_t>(
+                            tensor_map_b_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_b[stage_idx], k_idx, n_idx, 2);
+                        tma::copy<BLOCK_N, 1, 0>(
+                            tensor_map_sfb_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_sfb[stage_idx], sfb_n_idx, sfb_k_idx, 2);
+                        if (is_leader_cta) {
+                            // NOTES: unlike the FP8 x FP4 kernel (whose unpacked-FP4 weight TMA counts
+                            // gmem bytes), packed weights are moved as plain bytes, so both CTAs' issues
+                            // count the full tile
+                            shared_storage.full_barriers[stage_idx].arrive_and_expect_tx(sizeof(SharedStorage::smem_b[0]) * 2 + sizeof(SharedStorage::smem_sfb[0]) * 2);
+                        } else {
+                            shared_storage.full_barriers[stage_idx].arrive(0u);
+                        }
+                    }
+                }
+                __syncwarp();
+            }
+        }
+    } else if (warp_idx == kNumDispatchWarps + 2) {
+        // Adjust registers
+        cutlass::arch::warpgroup_reg_dealloc<kNumNonEpilogueRegisters>();
+
+        // GEMM MMA issue warp (only the leader CTA will run)
+        if (is_leader_cta) {
+            // Make instruction descriptor with block scaling
+            // NOTES: always swap A/B; packed E2M1 operands with E4M3 SF (`kind::mxf4nvf4`)
+            auto instr_desc = cute::UMMA::make_instr_desc_block_scaled<
+                cutlass::float_e2m1_t, cutlass::float_e2m1_t, float, cutlass::float_ue4m3_t,
+                UMMA_M, UMMA_N,
+                cute::UMMA::Major::K, cute::UMMA::Major::K
+            >();
+            auto sf_desc = mma::sm100::make_sf_desc(nullptr);
+
+            DG_STATIC_ASSERT(kNumStages <= 32, "Too many stages");
+            auto a_desc = mma::sm100::make_umma_desc<cute::UMMA::Major::K, LOAD_BLOCK_M, UMMA_BLOCK_K_BYTES, kSwizzleAMode>(shared_storage.smem_a[0], 0, 0);
+            auto b_desc = mma::sm100::make_umma_desc<cute::UMMA::Major::K, LOAD_BLOCK_N, UMMA_BLOCK_K_BYTES, kSwizzleBMode>(shared_storage.smem_b[0], 0, 0);
+            uint32_t a_desc_lo = lane_idx < kNumStages ? a_desc.lo + lane_idx * sizeof(SharedStorage::smem_a[0]) / 16 : 0u;
+            uint32_t b_desc_lo = lane_idx < kNumStages ? b_desc.lo + lane_idx * sizeof(SharedStorage::smem_b[0]) / 16 : 0u;
+
+            // BF16 shared-expert descriptors (`kind::f16`, non-block-scaled), reusing the same smem tiles
+            auto shared_instr_desc = cute::UMMA::make_instr_desc<
+                shared_dtype_t, shared_dtype_t, float,
+                UMMA_M, UMMA_N,
+                cute::UMMA::Major::K, cute::UMMA::Major::K
+            >();
+            auto shared_a_desc = mma::sm100::make_umma_desc<cute::UMMA::Major::K, LOAD_BLOCK_M, SHARED_UMMA_BLOCK_K, kSwizzleAMode>(
+                reinterpret_cast<shared_dtype_t*>(shared_storage.smem_a[0]), 0, 0);
+            auto shared_b_desc = mma::sm100::make_umma_desc<cute::UMMA::Major::K, LOAD_BLOCK_N, SHARED_UMMA_BLOCK_K, kSwizzleBMode>(
+                reinterpret_cast<shared_dtype_t*>(shared_storage.smem_b[0]), 0, 0);
+            uint32_t shared_a_desc_lo = lane_idx < kNumStages ? shared_a_desc.lo + lane_idx * sizeof(SharedStorage::smem_a[0]) / 16 : 0u;
+            uint32_t shared_b_desc_lo = lane_idx < kNumStages ? shared_b_desc.lo + lane_idx * sizeof(SharedStorage::smem_b[0]) / 16 : 0u;
+
+            // Checks for MMA instructions
+            DG_STATIC_ASSERT(UMMA_M == 256 and UMMA_N % 16 == 0 and 16 <= UMMA_N and UMMA_N <= 256,
+                             "Invalid MMA instruction shape");
+
+            // Persistently schedule over blocks
+            uint32_t current_iter_idx = 0;
+            task_info_t task_info;
+            while (scheduler.get_next_task(task_info)) {
+                const auto num_k_blocks = math::ceil_div(task_info.shape_k, task_info.is_shared() ? SHARED_BLOCK_K : BLOCK_K);
+
+                // Dynamic update of UMMA N based on effective M
+                if (task_info.is_shared()) {
+                    mma::sm100::update_instr_desc_with_umma_n(shared_instr_desc, task_info.get_umma_aligned_valid_m());
+                } else {
+                    mma::sm100::update_instr_desc_with_umma_n(instr_desc, task_info.get_umma_aligned_valid_m());
+                }
+
+                // NVFP4 uses `scale_vec::4X`: each MMA consumes a full SF TMEM word, so SF IDs are always 0
+                const auto runtime_instr_desc = mma::sm100::make_runtime_instr_desc_with_sf_id(instr_desc, 0, 0);
+                const auto shared_runtime_instr_desc = static_cast<uint64_t>(static_cast<uint32_t>(shared_instr_desc)) << 32;
+
+                // Wait tensor memory empty barrier arrival
+                const auto accum_stage_idx = current_iter_idx % kNumEpilogueStages;
+                const auto accum_phase = (current_iter_idx ++ / kNumEpilogueStages) & 1;
+                shared_storage.tmem_empty_barriers[accum_stage_idx].wait(accum_phase ^ 1);
+                ptx::tcgen05_after_thread_sync();
+
+                // Empty barrier arrival
+                auto empty_barrier_arrive = [&](const bool& do_tmem_full_arrive) {
+                    auto umma_arrive = [](const uint64_t* barrier) {
+                        constexpr uint16_t kCTAMask = (1 << 2) - 1;
+                        cutlass::arch::umma_arrive_multicast_2x1SM(barrier, kCTAMask);
+                    };
+                    umma_arrive(reinterpret_cast<uint64_t*>(&shared_storage.empty_barriers[stage_idx]));
+
+                    // NOTES: the tensor memory accumulator pipeline has nothing to do with multicasting
+                    if (do_tmem_full_arrive)
+                        umma_arrive(reinterpret_cast<uint64_t*>(&shared_storage.tmem_full_barriers[accum_stage_idx]));
+                    __syncwarp();
+                };
+
+                // Launch MMAs
+                #pragma unroll 2
+                for (uint32_t k_block_idx = 0; k_block_idx < num_k_blocks; advance_pipeline(k_block_idx)) {
+                    // Wait TMA load completion
+                    shared_storage.full_barriers[stage_idx].wait(phase);
+                    ptx::tcgen05_after_thread_sync();
+
+                    const auto a_desc_base_lo = ptx::exchange(task_info.is_shared() ? shared_a_desc_lo : a_desc_lo, stage_idx);
+                    const auto b_desc_base_lo = ptx::exchange(task_info.is_shared() ? shared_b_desc_lo : b_desc_lo, stage_idx);
+                    if (task_info.is_shared()) {
+                        // BF16 shared expert: plain `kind::f16` MMA, no UTCCP/SF
+                        if (cute::elect_one_sync()) {
+                            #pragma unroll
+                            for (uint32_t umma_k_block_idx = 0; umma_k_block_idx < SHARED_BLOCK_K / SHARED_UMMA_BLOCK_K; ++ umma_k_block_idx) {
+                                #pragma unroll
+                                for (uint32_t k = 0; k < SHARED_UMMA_BLOCK_K / SHARED_UMMA_K; ++ k) {
+                                    shared_a_desc.lo = mma::sm100::advance_umma_desc_lo<
+                                        cute::UMMA::Major::K, LOAD_BLOCK_M, kSwizzleAMode, shared_dtype_t>(
+                                            a_desc_base_lo, umma_k_block_idx * SHARED_UMMA_BLOCK_K * LOAD_BLOCK_M, k * SHARED_UMMA_K);
+                                    shared_b_desc.lo = mma::sm100::advance_umma_desc_lo<
+                                        cute::UMMA::Major::K, LOAD_BLOCK_N, kSwizzleBMode, shared_dtype_t>(
+                                            b_desc_base_lo, umma_k_block_idx * SHARED_UMMA_BLOCK_K * LOAD_BLOCK_N, k * SHARED_UMMA_K);
+                                    ptx::SM100_MMA_F16BF16_2x1SM_SS::fma(
+                                        shared_b_desc, shared_a_desc, accum_stage_idx * UMMA_N,
+                                        k_block_idx > 0 or umma_k_block_idx > 0 or k > 0,
+                                        shared_runtime_instr_desc);
+                                }
+                            }
+                        }
+                        __syncwarp();
+
+                        // Commit to the mbarrier object
+                        empty_barrier_arrive(k_block_idx == num_k_blocks - 1);
+                        continue;
+                    }
+                    if (cute::elect_one_sync()) {
+                        #pragma unroll
+                        for (uint32_t umma_k_block_idx = 0; umma_k_block_idx < BLOCK_K_BYTES / UMMA_BLOCK_K_BYTES; ++ umma_k_block_idx) {
+                            #pragma unroll
+                            for (uint32_t k = 0; k < kNumMMAsPerKAtom; ++ k) {
+                                // UTCCP copy SFA and SFB to TMEM (each 64-element MMA consumes
+                                // one fresh SF word per row; in-order `tcgen05` execution allows
+                                // rewriting the same TMEM columns between MMAs)
+                                const uint32_t sf_group_idx = umma_k_block_idx * kNumMMAsPerKAtom + k;
+                                using cute_utccp_t = cute::SM100_UTCCP_4x32dp128bit_2cta;
+                                #pragma unroll
+                                for (uint32_t i = 0; i < SF_BLOCK_M / kNumUTCCPAlignedElems; ++ i) {
+                                    auto smem_ptr = shared_storage.smem_sfa[stage_idx] + sf_group_idx * SF_BLOCK_M + i * kNumUTCCPAlignedElems;
+                                    mma::sm100::replace_smem_desc_addr(sf_desc, smem_ptr);
+                                    cute_utccp_t::copy(sf_desc, kTmemStartColOfSFA + i * 4);
+                                }
+                                #pragma unroll
+                                for (uint32_t i = 0; i < SF_BLOCK_N / kNumUTCCPAlignedElems; ++ i) {
+                                    auto smem_ptr = shared_storage.smem_sfb[stage_idx] + sf_group_idx * SF_BLOCK_N + i * kNumUTCCPAlignedElems;
+                                    mma::sm100::replace_smem_desc_addr(sf_desc, smem_ptr);
+                                    cute_utccp_t::copy(sf_desc, kTmemStartColOfSFB + i * 4);
+                                }
+
+                                // Issue UMMA (data offsets on K are in packed FP4 bytes)
+                                a_desc.lo = mma::sm100::advance_umma_desc_lo<
+                                    cute::UMMA::Major::K, LOAD_BLOCK_M, kSwizzleAMode, uint8_t>(a_desc_base_lo, umma_k_block_idx * UMMA_BLOCK_K_BYTES * LOAD_BLOCK_M, k * (UMMA_K / 2));
+                                b_desc.lo = mma::sm100::advance_umma_desc_lo<
+                                    cute::UMMA::Major::K, LOAD_BLOCK_N, kSwizzleBMode, uint8_t>(b_desc_base_lo, umma_k_block_idx * UMMA_BLOCK_K_BYTES * LOAD_BLOCK_N, k * (UMMA_K / 2));
+                                ptx::SM100_MMA_MXF4NVF4_2x1SM_SS::fma(
+                                    b_desc, a_desc, accum_stage_idx * UMMA_N,
+                                    k_block_idx > 0 or umma_k_block_idx > 0 or k > 0, runtime_instr_desc,
+                                    kTmemStartColOfSFB, kTmemStartColOfSFA);
+                            }
+                        }
+                    }
+                    __syncwarp();
+
+                    // Commit to the mbarrier object
+                    // No explicit `tcgen05.fence::before_thread_sync` is needed, as this is implicitly performed by `tcgen05.commit`
+                    empty_barrier_arrive(k_block_idx == num_k_blocks - 1);
+                }
+            }
+
+            // To safely deconstruct barriers, we need another round of waits
+            if (current_iter_idx > 0) {
+                const auto accum_phase_idx = ((current_iter_idx - 1) / kNumEpilogueStages) & 1;
+                shared_storage.tmem_empty_barriers[(current_iter_idx - 1) % kNumEpilogueStages].wait(accum_phase_idx);
+            }
+        }
+    } else if (warp_idx == kNumDispatchWarps + 3) {
+        // Adjust registers
+        cutlass::arch::warpgroup_reg_dealloc<kNumNonEpilogueRegisters>();
+
+        // Do mainloop by the leader CTA
+        if (is_leader_cta)
+            scheduler.mainloop(num_tokens);
+    } else if (warp_idx >= kNumDispatchWarps + kNumMMANonEpilogueWarps) {
+        // Adjust registers
+        cutlass::arch::warpgroup_reg_alloc<kNumEpilogueRegisters>();
+
+        // NOTES: tensor memory addresses are simplified, as the hardware will ignore the warp index bits,
+        // i.e., no need for `tmem_ptr |= (epilogue_warp_idx * 32) << 16`.
+        // NOTES: we also forbid two CTAs to share the same SM and its tensor memory
+        DG_TRAP_ONLY_DEVICE_ASSERT(ptx::ld_shared(&shared_storage.tmem_ptr_in_smem) == 0);
+
+        // GEMM epilogue warps
+        const auto epilogue_warp_idx = warp_idx - (kNumDispatchWarps + kNumMMANonEpilogueWarps);
+        const auto epilogue_wg_idx = epilogue_warp_idx / 4;
+        const auto epilogue_thread_idx = epilogue_warp_idx * 32 + lane_idx;
+        const auto warp_idx_in_wg = epilogue_warp_idx % 4;
+        DG_STATIC_ASSERT((kNumDispatchWarps + kNumMMANonEpilogueWarps) % 4 == 0 and
+                         kNumEpilogueWarps % 4 == 0, "Invalid epilogue warps");
+
+        // TODO: support effective block M
+        // NOTES:
+        //  - 2 warpgroups divide the whole BM into BM / 2
+        //  - 4 warps divide the whole BN into BN / 4
+        //  - BM / 2 is further divided into stored blocks, i.e. with `STORE_BLOCK_M` size
+        //  - `STORE_BLOCK_M` in further divided into `ATOM_M`
+        constexpr uint32_t WG_BLOCK_M = BLOCK_M / kNumEpilogueWarpgroups;
+        constexpr uint32_t ATOM_M = 8;
+        constexpr uint32_t kNumBankGroupBytes = 16u;
+        constexpr uint32_t kNumAtomsPerStore = STORE_BLOCK_M / ATOM_M;
+        DG_STATIC_ASSERT(BLOCK_M % kNumEpilogueWarpgroups == 0, "Invalid block M");
+        DG_STATIC_ASSERT(WG_BLOCK_M % STORE_BLOCK_M == 0, "Invalid warpgroup block M");
+        DG_STATIC_ASSERT(STORE_BLOCK_M % ATOM_M == 0, "Invalid store block M");
+        DG_STATIC_ASSERT(BLOCK_N == 128, "Invalid block N");
+
+        // Ensure the epilogue barrier cannot run with the pull barrier
+        ptx::sync_unaligned(kNumDispatchThreads + kNumEpilogueThreads, kDispatchWithEpilogueBarrierIdx);
+
+        // Persistently schedule over blocks
+        uint32_t current_iter_idx = 0;
+        task_info_t task_info;
+        while (scheduler.get_next_task(task_info)) {
+            // Wait UMMA arrival
+            const auto accum_stage_idx = current_iter_idx % kNumEpilogueStages;
+            const auto accum_phase = (current_iter_idx ++ / kNumEpilogueStages) & 1;
+            shared_storage.tmem_full_barriers[accum_stage_idx].wait(accum_phase);
+            ptx::tcgen05_after_thread_sync();
+
+            // Now we can release the task
+            scheduler.release_task_info();
+
+            // Compute offsets
+            // NOTES: use shuffle here to let NVCC know warp divergence won't happen
+            const uint32_t valid_m = ptx::exchange(task_info.valid_m, 0);
+            const uint32_t pool_block_idx = task_info.pool_block_idx;
+            const uint32_t ring_block_idx = pool_block_idx % kNumRingBlocks;
+            const uint32_t block_idx = task_info.is_shared() ? pool_block_idx : ring_block_idx;
+            const uint32_t ring_m_idx = ring_block_idx * BLOCK_M;  // Ring-buffer offset for reusable data buffers
+            const uint32_t m_idx = block_idx * BLOCK_M;
+            const uint32_t pool_m_idx = pool_block_idx * BLOCK_M;       // Full-pool offset for non-ring metadata
+            const uint32_t n_block_idx = task_info.n_cluster_idx * 2 + (is_leader_cta ? 0u : 1u);
+            uint32_t n_idx = n_block_idx * BLOCK_N;
+
+            if (task_info.block_phase == sched::BlockPhase::SharedLinear1) {
+                // BF16 shared-expert L1 epilogue: SwiGLU (no topk weight, no alphas, no requant),
+                // BF16 output staged in smem and TMA-stored into the shared L2 activations
+                constexpr uint32_t SHARED_L1_OUT_BLOCK_N = BLOCK_N / 2;
+
+                #pragma unroll
+                for (uint32_t s = 0; s < WG_BLOCK_M / STORE_BLOCK_M; ++ s) {
+                    // Early break if the entire store block is beyond the valid token range
+                    if (epilogue_wg_idx * WG_BLOCK_M + s * STORE_BLOCK_M >= valid_m) {
+                        ptx::tcgen05_before_thread_sync();
+                        shared_storage.tmem_empty_barriers[accum_stage_idx].arrive(0u);
+                        break;
+                    }
+
+                    // Iterate all atoms in the store block
+                    nv_bfloat162 bf16x2_output[kNumAtomsPerStore * 2];
+                    #pragma unroll
+                    for (uint32_t i = 0; i < kNumAtomsPerStore; ++ i) {
+                        const uint32_t j = s * kNumAtomsPerStore + i;
+
+                        // Load from TMEM
+                        uint32_t tmem_addr = accum_stage_idx * UMMA_N + epilogue_wg_idx * WG_BLOCK_M + j * ATOM_M;
+                        uint32_t values[ATOM_M];
+                        cute::SM100_TMEM_LOAD_16dp256b1x::copy(tmem_addr,
+                                                               values[0], values[1], values[2], values[3]);
+                        cute::SM100_TMEM_LOAD_16dp256b1x::copy(tmem_addr | 0x00100000,
+                                                               values[4], values[5], values[6], values[7]);
+                        cutlass::arch::fence_view_async_tmem_load();
+
+                        // Signal tensor memory consumed on the last atom
+                        if (j == WG_BLOCK_M / ATOM_M - 1) {
+                            ptx::tcgen05_before_thread_sync();
+                            shared_storage.tmem_empty_barriers[accum_stage_idx].arrive(0u);
+                        }
+
+                        // Apply SwiGLU: silu(gate) * up
+                        // Gate/up pairs: (0, 2), (1, 3), (4, 6), (5, 7)
+                        auto fp32_values = reinterpret_cast<float*>(values);
+                        #pragma unroll
+                        for (uint32_t k = 0; k < 2; ++ k) {
+                            auto bf16_gate = __float22bfloat162_rn(make_float2(fp32_values[k * 4], fp32_values[k * 4 + 1]));
+                            auto bf16_up = __float22bfloat162_rn(make_float2(fp32_values[k * 4 + 2], fp32_values[k * 4 + 3]));
+
+                            // Clamp
+                            if constexpr (kActivationClamp != cute::numeric_limits<float>::infinity()) {
+                                bf16_gate = __hmin2(bf16_gate, {kActivationClamp, kActivationClamp});
+                                bf16_up = __hmax2(bf16_up, {-kActivationClamp, -kActivationClamp});
+                                bf16_up = __hmin2(bf16_up, {kActivationClamp, kActivationClamp});
+                            }
+
+                            // SwiGLU
+                            auto gate = __bfloat1622float2(bf16_gate);
+                            auto neg_gate_exp = make_float2(
+                                kFastMath ? __expf(-gate.x) : expf(-gate.x),
+                                kFastMath ? __expf(-gate.y) : expf(-gate.y));
+                            const auto denom = __fadd2_rn({1.0f, 1.0f}, neg_gate_exp);
+                            if constexpr (kFastMath) {
+                                gate = __fmul2_rn(gate, {math::fast_rcp(denom.x), math::fast_rcp(denom.y)});
+                            } else {
+                                gate = {gate.x / denom.x, gate.y / denom.y};
+                            }
+                            const auto up = __bfloat1622float2(bf16_up);
+                            bf16x2_output[i * 2 + k] = __float22bfloat162_rn(__fmul2_rn(gate, up));
+                        }
+                    }
+
+                    // Wait shared memory release from previous TMA store
+                    const uint32_t tma_stage_idx = s % kNumTMAStoreStages;
+                    ptx::tma_store_wait<kNumTMAStoreStages - 1>();
+                    ptx::sync_aligned(128, kEpilogueWGBarrierStartIdx + epilogue_wg_idx);
+
+                    #pragma unroll
+                    for (uint32_t i = 0; i < kNumAtomsPerStore; ++ i) {
+                        // STSM
+                        uint32_t row = lane_idx % 8;
+                        uint32_t col = warp_idx_in_wg * 2 + lane_idx / 8;
+                        const auto smem_ptr = shared_storage.smem_d.shared_l1[epilogue_wg_idx][tma_stage_idx]
+                                            + (i * ATOM_M + row) * SHARED_L1_OUT_BLOCK_N
+                                            + (col ^ row) * (kNumBankGroupBytes / sizeof(nv_bfloat16));
+                        ptx::SM90_U32x2_STSM_T<__nv_bfloat162>::copy(
+                            bf16x2_output[i * 2 + 0],
+                            bf16x2_output[i * 2 + 1],
+                            smem_ptr
+                        );
+                    }
+                    ptx::sync_aligned(128, kEpilogueWGBarrierStartIdx + epilogue_wg_idx);
+
+                    // Issue TMA store after all atoms in this store block
+                    if (warp_idx_in_wg == 0 and cute::elect_one_sync()) {
+                        uint32_t out_n_idx = n_block_idx * SHARED_L1_OUT_BLOCK_N;
+                        cute::tma_store_fence();
+                        cute::SM90_TMA_STORE_2D::copy(
+                            &tensor_map_shared_l1_output,
+                            shared_storage.smem_d.shared_l1[epilogue_wg_idx][tma_stage_idx],
+                            out_n_idx,
+                            m_idx + epilogue_wg_idx * WG_BLOCK_M + s * STORE_BLOCK_M);
+                        cute::tma_store_arrive();
+                    }
+                    __syncwarp();
+                }
+
+                // Notify shared L2 arrival
+                ptx::tma_store_wait<0>();
+                ptx::sync_aligned(kNumEpilogueThreads, kEpilogueFullBarrierIdx);
+                if (epilogue_warp_idx == 0 and cute::elect_one_sync()) {
+                    ptx::red_add_rel(
+                        workspace.get_shared_l2_full_count_ptr(pool_block_idx), 1u);
+                }
+                __syncwarp();
+            } else if (task_info.block_phase == sched::BlockPhase::Linear1) {
+                // Wait L2 block empty
+                const auto l2_empty_ptr = workspace.get_l2_empty_count_ptr(ring_block_idx);
+                const auto num_expected_blocks = (L2_SHAPE_N / BLOCK_N) * (pool_block_idx / kNumRingBlocks);
+                while (ptx::ld_acq(l2_empty_ptr) != num_expected_blocks);
+
+                // Per-expert L1 scales for the gate and up halves
+                const float2 l1_alpha = l1_alphas == nullptr ?
+                    make_float2(1.0f, 1.0f) : __ldg(l1_alphas + task_info.local_expert_idx);
+
+                // Per-expert down-proj input scale for the intermediate NVFP4 requant.
+                // `inv_global = 1 / a2_scale` normalizes the block SF into E4M3 range; the
+                // matching `a2_scale` factor is folded back into the L2 alpha (see below).
+                const float l2_input_scale_inv = a2_scales == nullptr ? 1.0f :
+                    (kFastMath ? math::fast_rcp(__ldg(a2_scales + task_info.local_expert_idx))
+                               : 1.0f / __ldg(a2_scales + task_info.local_expert_idx));
+
+                // Unified L1 epilogue: SwiGLU in-place using granularity 8 interleaved weights
+                // With `SM100_TMEM_LOAD_16dp256b1x`, gate/up pairs are in the same thread.
+                // NVFP4 output: each warp covers 16 output channels, which is exactly one
+                // 16-element SF group, so amax needs no cross-warp exchange.
+                // NOTES: the top-k routing weight is NOT applied here. It is applied to the
+                // L2 output before the combine write (see `Linear2` epilogue), matching the
+                // standard MoE recipe: quantizing the *unweighted* intermediate keeps the
+                // NVFP4 block scale well-conditioned (folding the small per-token weight in
+                // before quantization would couple it into the E4M3 SF rounding).
+
+                #pragma unroll
+                for (uint32_t s = 0; s < WG_BLOCK_M / STORE_BLOCK_M; ++ s) {
+                    // Early break if the entire store block is beyond the valid token range
+                    if (epilogue_wg_idx * WG_BLOCK_M + s * STORE_BLOCK_M >= valid_m) {
+                        ptx::tcgen05_before_thread_sync();
+                        shared_storage.tmem_empty_barriers[accum_stage_idx].arrive(0u);
+                        break;
+                    }
+
+                    // Iterate all atoms in the store block
+                    float2 activation_values[kNumAtomsPerStore][2];
+                    float2 sf_inv_values[kNumAtomsPerStore];
+                    #pragma unroll
+                    for (uint32_t i = 0; i < kNumAtomsPerStore; ++ i) {
+                        const uint32_t j = s * kNumAtomsPerStore + i;
+
+                        // Load from TMEM
+                        uint2 raw_values[4];
+                        uint32_t tmem_addr = accum_stage_idx * UMMA_N + epilogue_wg_idx * WG_BLOCK_M + j * ATOM_M;
+                        cute::SM100_TMEM_LOAD_16dp256b1x::copy(tmem_addr,
+                                                               raw_values[0].x, raw_values[0].y, raw_values[1].x, raw_values[1].y);
+                        cute::SM100_TMEM_LOAD_16dp256b1x::copy(tmem_addr | 0x00100000,
+                                                               raw_values[2].x, raw_values[2].y, raw_values[3].x, raw_values[3].y);
+                        cutlass::arch::fence_view_async_tmem_load();
+
+                        // Signal tensor memory consumed on the last atom
+                        if (j == WG_BLOCK_M / ATOM_M - 1) {
+                            ptx::tcgen05_before_thread_sync();
+                            shared_storage.tmem_empty_barriers[accum_stage_idx].arrive(0u);
+                        }
+
+                        // Apply SwiGLU: silu(gate) * up
+                        auto fp32_values = reinterpret_cast<float2*>(raw_values);
+                        #pragma unroll
+                        for (uint32_t k = 0; k < 2; ++ k) {
+                            // Apply the per-expert L1 scales before the non-linear activation
+                            auto bf16_gate = __float22bfloat162_rn(__fmul2_rn(fp32_values[k * 2 + 0], {l1_alpha.x, l1_alpha.x}));
+                            auto bf16_up =   __float22bfloat162_rn(__fmul2_rn(fp32_values[k * 2 + 1], {l1_alpha.y, l1_alpha.y}));
+
+                            // Clamp
+                            if constexpr (kActivationClamp != cute::numeric_limits<float>::infinity()) {
+                                bf16_gate = __hmin2(bf16_gate, {kActivationClamp, kActivationClamp});
+                                bf16_up = __hmax2(bf16_up, {-kActivationClamp, -kActivationClamp});
+                                bf16_up = __hmin2(bf16_up, {kActivationClamp, kActivationClamp});
+                            }
+
+                            // SwiGLU
+                            auto gate = __bfloat1622float2(bf16_gate);
+                            auto neg_gate_exp = make_float2(
+                                kFastMath ? __expf(-gate.x) : expf(-gate.x),
+                                kFastMath ? __expf(-gate.y) : expf(-gate.y));
+                            const auto denom = __fadd2_rn({1.0f, 1.0f}, neg_gate_exp);
+                            if constexpr (kFastMath) {
+                                gate = __fmul2_rn(gate, {math::fast_rcp(denom.x), math::fast_rcp(denom.y)});
+                            } else {
+                                gate = {gate.x / denom.x, gate.y / denom.y};
+                            }
+                            const auto up = __bfloat1622float2(bf16_up);
+                            // Unweighted intermediate; the top-k weight is applied post-L2 (combine)
+                            activation_values[i][k] = __fmul2_rn(gate, up);
+                        }
+
+                        // Amax reduction (thread-level)
+                        float2 thread_local_amax = {0.f, 0.f};
+                        #pragma unroll
+                        for (uint32_t k = 0; k < 2; ++ k) {
+                            thread_local_amax.x = cute::max(thread_local_amax.x, cute::abs(activation_values[i][k].x));
+                            thread_local_amax.y = cute::max(thread_local_amax.y, cute::abs(activation_values[i][k].y));
+                        }
+
+                        // Amax reduction (warp-level): after this, each lane holds the amax of
+                        // its own 2 tokens over the warp's 16 output channels (one SF group)
+                        float2 amax = {
+                            math::warp_reduce<4, true>(thread_local_amax.x, math::ReduceMax<float>()),
+                            math::warp_reduce<4, true>(thread_local_amax.y, math::ReduceMax<float>())
+                        };
+
+                        // Calculate the NVFP4 E4M3 SF (block SF normalized by `1 / a2_scale`)
+                        uint32_t sf_bytes;
+                        get_nvfp4_e4m3_sf_and_sf_inv<kFastMath>(amax, l2_input_scale_inv, sf_inv_values[i], sf_bytes);
+
+                        // Store SF to `buffer.l2_sf_buffer` as E4M3 (MN-major layout)
+                        // Each lane < 4 holds SF for 2 rows (tokens `2 * lane_idx` and `2 * lane_idx + 1`)
+                        // NOTES: `k_uint_idx = n_block_idx` since each BLOCK_N tile produces exactly
+                        // 64 output elements = 4 SF groups = 1 packed `uint32_t` on L2's K
+                        if (lane_idx < 4) {
+                            const uint32_t k_uint_idx = n_block_idx, byte_idx = warp_idx_in_wg;
+                            const uint32_t mn_stride = kNumSFRingTokens * sizeof(uint32_t);
+                            const auto sf_base_ptr = buffer.l2_sf_buffer.get_base_ptr<uint8_t>();
+                            // NOTES: consecutive tokens (t, t + 1) are in the same 32-group, so `sf_idx` differs by 4
+                            const uint32_t token_base_idx = epilogue_wg_idx * WG_BLOCK_M + s * STORE_BLOCK_M + i * ATOM_M;
+                            __builtin_assume(token_base_idx < BLOCK_M);
+                            const auto sf_ring_token_idx = ring_block_idx * SF_BLOCK_M
+                                + transform_sf_token_idx(token_base_idx) + (lane_idx * 2) * 4;
+                            const auto sf_addr = k_uint_idx * mn_stride + sf_ring_token_idx * static_cast<uint32_t>(sizeof(uint32_t)) + byte_idx;
+                            sf_base_ptr[sf_addr] = static_cast<uint8_t>(sf_bytes & 0xffu);
+                            sf_base_ptr[sf_addr + 4 * static_cast<uint32_t>(sizeof(uint32_t))] = static_cast<uint8_t>(sf_bytes >> 8);
+                        }
+                        __syncwarp();
+                    }
+
+                    // Wait shared memory release from previous TMA store
+                    const uint32_t tma_stage_idx = s % kNumTMAStoreStages;
+                    ptx::tma_store_wait<kNumTMAStoreStages - 1>();
+                    ptx::sync_aligned(128, kEpilogueWGBarrierStartIdx + epilogue_wg_idx);
+
+                    // Cast to packed E2M1 and store into shared memory
+                    // Thread value layout: lane `t` holds 2 tokens (`2 * (t % 4) + {0, 1}`) at output
+                    // channels `t / 4` (k = 0) and `t / 4 + 8` (k = 1) of the warp's 16-channel group.
+                    // Adjacent channels live in lanes `t` and `t ^ 4`, so exchange and let the lanes
+                    // with even `t / 4` pack both nibbles of each byte.
+                    #pragma unroll
+                    for (uint32_t i = 0; i < kNumAtomsPerStore; ++ i) {
+                        const float2 sf_inv = sf_inv_values[i];
+                        const float2 scaled_k0 = __fmul2_rn(activation_values[i][0], sf_inv);
+                        const float2 scaled_k1 = __fmul2_rn(activation_values[i][1], sf_inv);
+
+                        // Exchange with the adjacent-channel lane
+                        const float2 paired_k0 = {
+                            __shfl_xor_sync(0xffffffff, scaled_k0.x, 4),
+                            __shfl_xor_sync(0xffffffff, scaled_k0.y, 4)
+                        };
+                        const float2 paired_k1 = {
+                            __shfl_xor_sync(0xffffffff, scaled_k1.x, 4),
+                            __shfl_xor_sync(0xffffffff, scaled_k1.y, 4)
+                        };
+
+                        if ((lane_idx & 4) == 0) {
+                            // This lane holds even channels; the partner holds channel + 1
+                            const uint32_t token_0 = i * ATOM_M + (lane_idx % 4) * 2;
+                            const uint32_t byte_in_row_k0 = warp_idx_in_wg * 8 + (lane_idx >> 3);
+                            const uint32_t byte_in_row_k1 = byte_in_row_k0 + 4;
+                            const auto smem_base = shared_storage.smem_d.l1[epilogue_wg_idx][tma_stage_idx];
+
+                            // Token `token_0`
+                            smem_base[(token_0 + 0) * L1_OUT_BLOCK_N_BYTES + byte_in_row_k0] =
+                                static_cast<uint8_t>(cvt_into_e2m1x2(paired_k0.x, scaled_k0.x));
+                            smem_base[(token_0 + 0) * L1_OUT_BLOCK_N_BYTES + byte_in_row_k1] =
+                                static_cast<uint8_t>(cvt_into_e2m1x2(paired_k1.x, scaled_k1.x));
+
+                            // Token `token_0 + 1`
+                            smem_base[(token_0 + 1) * L1_OUT_BLOCK_N_BYTES + byte_in_row_k0] =
+                                static_cast<uint8_t>(cvt_into_e2m1x2(paired_k0.y, scaled_k0.y));
+                            smem_base[(token_0 + 1) * L1_OUT_BLOCK_N_BYTES + byte_in_row_k1] =
+                                static_cast<uint8_t>(cvt_into_e2m1x2(paired_k1.y, scaled_k1.y));
+                        }
+                        __syncwarp();
+                    }
+                    ptx::sync_aligned(128, kEpilogueWGBarrierStartIdx + epilogue_wg_idx);
+
+                    // Issue TMA store after all atoms in this store block
+                    if (warp_idx_in_wg == 0 and cute::elect_one_sync()) {
+                        uint32_t out_n_idx = n_block_idx * L1_OUT_BLOCK_N_BYTES;
+                        cute::tma_store_fence();
+                        cute::SM90_TMA_STORE_2D::copy(
+                            &tensor_map_l1_output,
+                            shared_storage.smem_d.l1[epilogue_wg_idx][tma_stage_idx],
+                            out_n_idx,
+                            ring_m_idx + epilogue_wg_idx * WG_BLOCK_M + s * STORE_BLOCK_M);
+                        cute::tma_store_arrive();
+                    }
+                    __syncwarp();
+                }
+
+                // Notify L2 and increment L1 empty count
+                // TODO: less epilogue sync scope
+                ptx::tma_store_wait<0>();
+                ptx::sync_aligned(kNumEpilogueThreads, kEpilogueFullBarrierIdx);
+                if (epilogue_warp_idx == 0 and cute::elect_one_sync()) {
+                    ptx::red_add_rel(
+                        workspace.get_l2_full_count_ptr(ring_block_idx), 1u);
+
+                    // Increment L1 empty count for this physical slot (one per N block)
+                    ptx::red_add(
+                        workspace.get_l1_empty_count_ptr(ring_block_idx), 1u);
+                }
+                __syncwarp();
+            } else {
+                // Increment L2 empty count for this physical slot (one per N block)
+                if (not task_info.is_shared()) {
+                    if (epilogue_warp_idx == 0 and cute::elect_one_sync()) {
+                        ptx::red_add(
+                            workspace.get_l2_empty_count_ptr(ring_block_idx), 1u);
+                    }
+                    __syncwarp();
+                }
+
+                // Per-expert L2 scale (shared experts carry no quantization scales).
+                // Fold in the down-proj input scale `a2_scale`: the intermediate NVFP4
+                // requant stored block SFs normalized by `1 / a2_scale`, so the GEMM output
+                // must be multiplied by `a2_scale` to recover the true magnitude.
+                const bool l2_no_scale = task_info.is_shared();
+                const float l2_alpha = (l2_no_scale or l2_alphas == nullptr) ?
+                    1.0f : __ldg(l2_alphas + task_info.local_expert_idx);
+                const float a2_scale = (l2_no_scale or a2_scales == nullptr) ?
+                    1.0f : __ldg(a2_scales + task_info.local_expert_idx);
+                const float l2_scale = l2_alpha * a2_scale;
+
+                DG_STATIC_ASSERT(STORE_BLOCK_M % 8 == 0, "Invalid store M");
+                constexpr uint32_t kNumRowsPerWarp = STORE_BLOCK_M / 8;
+
+                // L2 BF16 epilogue: write GEMM output to remote combine buffer via NVLink
+                #pragma unroll
+                for (uint32_t s = 0; s < WG_BLOCK_M / STORE_BLOCK_M; ++ s) {
+                    // Early break if the entire store block is beyond the valid token range
+                    // TODO: check performance
+                    if (epilogue_wg_idx * WG_BLOCK_M + s * STORE_BLOCK_M >= valid_m) {
+                        ptx::tcgen05_before_thread_sync();
+                        shared_storage.tmem_empty_barriers[accum_stage_idx].arrive(0u);
+                        break;
+                    }
+
+                    #pragma unroll
+                    for (uint32_t i = 0; i < STORE_BLOCK_M / ATOM_M; ++ i) {
+                        // Load from TMEM using .16x256b shape to satisfy STSM layout requirements
+                        // Start from lane index 0 and 16
+                        uint32_t tmem_addr = accum_stage_idx * UMMA_N + epilogue_wg_idx * WG_BLOCK_M + s * STORE_BLOCK_M + i * ATOM_M;
+                        uint32_t values[ATOM_M];
+                        cute::SM100_TMEM_LOAD_16dp256b1x::copy(tmem_addr,
+                                                               values[0], values[1], values[2], values[3]);
+                        cute::SM100_TMEM_LOAD_16dp256b1x::copy(tmem_addr | 0x00100000,
+                                                               values[4], values[5], values[6], values[7]);
+                        cutlass::arch::fence_view_async_tmem_load();
+
+                        // Wait shared memory release from previous NVLink store
+                        // NOTES: skip for the first store block since the prior full barrier already ensures completion
+                        if (i == 0 and s > 0)
+                            ptx::sync_aligned(128, kEpilogueWGBarrierStartIdx + epilogue_wg_idx);
+
+                        // Signal tensor memory consumed
+                        if (s == WG_BLOCK_M / STORE_BLOCK_M - 1 and i == STORE_BLOCK_M / ATOM_M - 1) {
+                            ptx::tcgen05_before_thread_sync();
+                            shared_storage.tmem_empty_barriers[accum_stage_idx].arrive(0u);
+                        }
+
+                        // Apply the L2 per-tensor scale (weight_scale_2 * a2_scale)
+                        #pragma unroll
+                        for (uint32_t v = 0; v < ATOM_M; ++ v) {
+                            const auto scaled = __fmul_rn(*reinterpret_cast<const float*>(&values[v]), l2_scale);
+                            values[v] = *reinterpret_cast<const uint32_t*>(&scaled);
+                        }
+
+                        // Store into shared memory
+                        // NOTES: each lane provides its own address for stmatrix; 2 warps share a BF16 swizzle atom
+                        uint32_t row = lane_idx % 8;
+                        uint32_t col = (epilogue_warp_idx % 2) * 4 + lane_idx / 8;
+                        const auto smem_ptr = reinterpret_cast<uint8_t*>(shared_storage.smem_d.l2[epilogue_wg_idx]) +
+                            (warp_idx_in_wg / 2) * STORE_BLOCK_M * kSwizzleCDMode +
+                            i * ATOM_M * kSwizzleCDMode +
+                            row * (kNumBankGroupBytes * 8) +
+                            (col ^ row) * kNumBankGroupBytes;
+                        ptx::SM90_U32x4_STSM_T<uint32_t>::copy(
+                            math::cast_into_bf16_and_pack(values[0], values[1]),
+                            math::cast_into_bf16_and_pack(values[2], values[3]),
+                            math::cast_into_bf16_and_pack(values[4], values[5]),
+                            math::cast_into_bf16_and_pack(values[6], values[7]),
+                            smem_ptr
+                        );
+                    }
+
+                    // Wait shared memory ready
+                    ptx::sync_aligned(128, kEpilogueWGBarrierStartIdx + epilogue_wg_idx);
+
+                    // Write into remote buffers
+                    // Each warp writes 2 rows (lane_idx/16 splits the warp into two halves, one per row)
+                    const uint32_t row_in_atom = (warp_idx_in_wg * 2 + lane_idx / 16) % ATOM_M;
+                    const uint32_t bank_group_idx = lane_idx % 8;
+
+                    #pragma unroll
+                    for (uint32_t j = 0; j < kNumRowsPerWarp; ++ j) {
+                        const uint32_t row_in_store = j * 8 + warp_idx_in_wg * 2 + lane_idx / 16;
+                        const uint32_t m_idx_in_block = epilogue_wg_idx * WG_BLOCK_M + s * STORE_BLOCK_M + row_in_store;
+
+                        // Skip padding rows beyond the actual token count for this expert
+                        if (m_idx_in_block >= valid_m)
+                            break;
+
+                        uint32_t dst_rank_idx, dst_token_idx, dst_topk_idx;
+                        if (task_info.is_shared()) {
+                            // Shared output stays local: the extra combine slot beyond top-k
+                            dst_rank_idx = sym_buffer.rank_idx;
+                            dst_token_idx = pool_m_idx + m_idx_in_block;
+                            dst_topk_idx = kNumTopk;
+                        } else {
+                            const auto src_metadata = *workspace.get_token_src_metadata_ptr(pool_m_idx + m_idx_in_block);
+                            dst_rank_idx = src_metadata.rank_idx;
+                            dst_token_idx = src_metadata.token_idx;
+                            dst_topk_idx = src_metadata.topk_idx;
+                        }
+
+                        // Read from shared memory
+                        const auto smem_ptr = reinterpret_cast<uint8_t*>(shared_storage.smem_d.l2[epilogue_wg_idx]) +
+                            (lane_idx % 16 / 8) * STORE_BLOCK_M * kSwizzleCDMode +
+                            row_in_store * kSwizzleCDMode +
+                            (bank_group_idx ^ row_in_atom) * kNumBankGroupBytes;
+                        auto packed = ptx::ld_shared(reinterpret_cast<float4*>(smem_ptr));
+
+                        // Apply the per-token top-k routing weight here (post-L2), not before
+                        // the intermediate quant. Shared-expert output carries no routing weight.
+                        if (not task_info.is_shared()) {
+                            const float topk_weight = *buffer.l1_topk_weights_buffer
+                                .get_data_buffer(ring_m_idx + m_idx_in_block)
+                                .template get_base_ptr<float>();
+                            const float2 w2 = {topk_weight, topk_weight};
+                            auto* bf = reinterpret_cast<nv_bfloat162*>(&packed);
+                            #pragma unroll
+                            for (uint32_t q = 0; q < sizeof(float4) / sizeof(nv_bfloat162); ++ q)
+                                bf[q] = __float22bfloat162_rn(__fmul2_rn(__bfloat1622float2(bf[q]), w2));
+                        }
+
+                        // Write into remote
+                        const auto dst_token = buffer.combine_token_buffer.get_rank_buffer(dst_topk_idx)
+                                               .get_data_buffer(dst_token_idx);
+                        const auto dst_ptr = math::advance_ptr<float4>(
+                            dst_token.get_base_ptr(),
+                            n_idx * static_cast<uint32_t>(sizeof(nv_bfloat16)) + (lane_idx % 16) * static_cast<uint32_t>(sizeof(float4)));
+                        *sym_buffer.map(dst_ptr, dst_rank_idx) = packed;
+                    }
+                }
+
+                // Ensure the next epilogue safe to use shared memory
+                ptx::sync_aligned(kNumEpilogueThreads, kEpilogueFullBarrierIdx);
+            }
+        }
+
+        // Deallocate tensor memory
+        // NOTES: must be called by the same logical warp ID on both CTAs
+        if (epilogue_warp_idx == 0)
+            Allocator().free(0, kNumTmemCols);
+
+        // NVLink barrier (grid sync + cross-rank signal + grid sync): ~4 us
+        comm::nvlink_barrier<kNumRanks, kNumSMs, kNumEpilogueThreads,
+                             kEpilogueGridSyncIndex, kBeforeCombineReduceBarrierTag>(
+            workspace, sym_buffer, sm_idx, epilogue_thread_idx,
+            [&]() { ptx::sync_aligned(kNumEpilogueThreads, kEpilogueFullBarrierIdx); }
+        );
+
+        // Barrier with dispatch warps, so that they can do clean workspace
+        ptx::sync_unaligned(kNumDispatchThreads + kNumEpilogueThreads, kDispatchWithEpilogueBarrierIdx);
+
+        // Combine: reduce top-k results and write back
+        // NOTES: reuse shared memory from start up to the barriers
+        // 1 token, 1 topk latency: ~3 us
+        constexpr uint32_t kNumHiddenBytes = kHidden * sizeof(nv_bfloat16);
+        constexpr uint32_t kNumElemsPerUint4 = sizeof(uint4) / sizeof(nv_bfloat162);
+
+        // 3 slots of chunk is needed: 2 load stages and 1 store
+        constexpr uint32_t kNumChunkSlots = 3;
+        constexpr uint32_t kNumMaxRegistersForBuffer = 128;
+
+        // NOTES: either 1 or 2 chunks for simplicity
+        // NOTES: Restrict on both smem and register
+        constexpr uint32_t kNumChunks =
+            kNumChunkSlots * kNumEpilogueWarps * kNumHiddenBytes <= kNumReusableSmemBytes and kHidden <= 32 * kNumMaxRegistersForBuffer ? 1 : 2;
+        constexpr uint32_t kNumChunkBytes = kNumHiddenBytes / kNumChunks;
+        constexpr uint32_t kNumChunkUint4 = kNumChunkBytes / sizeof(uint4);
+        constexpr uint32_t kNumUint4PerLane = kNumChunkUint4 / 32;
+        DG_STATIC_ASSERT(kHidden % kNumChunks == 0, "Hidden must be divisible by number of chunks");
+        DG_STATIC_ASSERT(kNumChunkSlots * kNumEpilogueWarps * kNumHiddenBytes / kNumChunks <= kNumReusableSmemBytes, "Hidden is too large");
+        DG_STATIC_ASSERT(kNumChunkBytes % 16 == 0, "Combine chunk must be TMA-aligned (16 bytes)");
+        DG_STATIC_ASSERT(kNumChunkBytes % sizeof(uint4) == 0, "Combine chunk must be divisible by 16 bytes");
+        DG_STATIC_ASSERT(kNumChunkUint4 % 32 == 0, "Combine chunk must be a multiple of 32 16-byte elements (one per lane)");
+        DG_STATIC_ASSERT(kNumTopk + (kNumSharedExperts > 0 ? 1u : 0u) <= 32u, "Top-k + shared must fit in a single warp");
+
+        // Verify combined shared memory budget at runtime
+        DG_DEVICE_ASSERT(kNumChunkSlots * kNumEpilogueWarps * kNumChunkBytes <= kNumReusableSmemBytes);
+
+        // Per-warp buffer: 2 stage load buffers + 1 store buffer
+        const auto combine_load_buffer = utils::PatternVisitor([&](const uint32_t& i) {
+            return math::advance_ptr<uint4>(smem_buffer, (epilogue_warp_idx + i * kNumEpilogueWarps) * kNumChunkBytes);
+        });
+        const auto combine_store_buffer  = math::advance_ptr<uint4>(smem_buffer, (epilogue_warp_idx + kNumEpilogueWarps * 2) * kNumChunkBytes);
+
+        // Per-warp barriers
+        auto combine_load_barriers = utils::PatternVisitor([&](const uint32_t& i) {
+            return &shared_storage.combine_barriers[i + epilogue_warp_idx * 2];
+        });
+
+        // Iterate over all tokens
+        uint32_t combine_phase = 0;
+        uint32_t load_stage_idx = 0;
+        for (uint32_t token_idx = sm_idx * kNumEpilogueWarps + epilogue_warp_idx;
+             token_idx < num_tokens;
+             token_idx += kNumSMs * kNumEpilogueWarps) {
+            // Read top-k slot indices: each lane reads one slot, then broadcast via exchange
+            DG_STATIC_ASSERT(kNumTopk <= 32, "Invalid number of topk");
+            const int stored_topk_slot_idx = lane_idx < kNumTopk ?
+                static_cast<int>(__ldg(buffer.input_topk_idx_buffer.get_base_ptr<int64_t>() + token_idx * kNumTopk + lane_idx)) :
+                (kNumSharedExperts > 0 and lane_idx == kNumTopk ? static_cast<int>(kNumTopk) : -1);
+            const uint32_t total_mask = __ballot_sync(0xffffffff, stored_topk_slot_idx >= 0);
+
+            // Iterate all chunks
+            for (uint32_t chunk = 0; chunk < kNumChunks; ++ chunk) {
+                const uint32_t chunk_byte_offset = chunk * kNumChunkBytes;
+
+                // Move mask and load
+                uint32_t mask = total_mask;
+                const auto move_mask_and_load = [&](const uint32_t& i) {
+                    if (mask) {
+                        // Move
+                        const uint32_t slot_idx = __ffs(mask) - 1;
+                        mask ^= 1 << slot_idx;
+
+                        // Load
+                        if (cute::elect_one_sync()) {
+                            const auto src_ptr = math::advance_ptr<uint8_t>(
+                                buffer.combine_token_buffer.get_rank_buffer(slot_idx)
+                                                    .get_data_buffer(token_idx).get_base_ptr(),
+                                chunk_byte_offset);
+                            ptx::tma_load_1d(combine_load_buffer[i], src_ptr, combine_load_barriers[i], kNumChunkBytes);
+                            ptx::mbarrier_arrive_and_set_tx(combine_load_barriers[i], kNumChunkBytes);
+                        }
+                        __syncwarp();
+                        return true;
+                    }
+                    return false;
+                };
+
+                // Load the first selection
+                bool do_reduce = move_mask_and_load(load_stage_idx);
+
+                // Accumulate all top-k contributions for this chunk in float registers
+                float2 reduced[kNumUint4PerLane * kNumElemsPerUint4] = {};
+                while (do_reduce) {
+                    // Prefetch next top-k into the buffer while current is being accumulated
+                    do_reduce = move_mask_and_load(load_stage_idx ^ 1);
+
+                    // Accumulate
+                    combine_load_barriers[load_stage_idx]->wait(combine_phase);
+                    #pragma unroll
+                    for (uint32_t j = 0; j < kNumUint4PerLane; ++ j) {
+                        const auto uint4_values = combine_load_buffer[load_stage_idx][j * 32 + lane_idx];
+                        const auto bf16_values = reinterpret_cast<const nv_bfloat162*>(&uint4_values);
+                        #pragma unroll
+                        for (uint32_t l = 0; l < kNumElemsPerUint4; ++ l)
+                            ptx::accumulate(reduced[j * kNumElemsPerUint4 + l], bf16_values[l]);
+                    }
+                    combine_phase ^= load_stage_idx;
+                    load_stage_idx ^= 1;
+                }
+
+                // Cast
+                #pragma unroll
+                for (uint32_t j = 0; j < kNumUint4PerLane; ++ j) {
+                    uint4 casted;
+                    auto casted_bf16 = reinterpret_cast<nv_bfloat162*>(&casted);
+                    #pragma unroll
+                    for (uint32_t l = 0; l < kNumElemsPerUint4; ++ l)
+                        casted_bf16[l] = __float22bfloat162_rn(reduced[j * kNumElemsPerUint4 + l]);
+
+                    // Wait share memory release and write
+                    if (j == 0) {
+                        ptx::tma_store_wait<0>();
+                        __syncwarp();
+                    }
+                    ptx::st_shared(combine_store_buffer + j * 32 + lane_idx,
+                                   casted.x, casted.y, casted.z, casted.w);
+                }
+                __syncwarp();
+
+                // TMA store the token chunk
+                if (cute::elect_one_sync()) {
+                    cute::tma_store_fence();
+                    ptx::tma_store_1d(
+                        math::advance_ptr(y, static_cast<uint64_t>(token_idx) * kNumHiddenBytes + chunk_byte_offset),
+                        combine_store_buffer, kNumChunkBytes);
+                    cute::tma_store_arrive();
+                }
+                __syncwarp();
+            }
+        }
+    }
+#else
+    if (blockIdx.x == 0 and threadIdx.x == 0)
+        DG_DEVICE_ASSERT(false and "This kernel only support sm_100f");
+#endif
+}
+
+} // namespace deep_gemm

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp4_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp4_fp4_mega_moe.cuh
@@ -655,7 +655,8 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
                     current_rank_in_expert_idx);
                 // Write source metadata for combine write-back (logical pool token)
                 *workspace.get_token_src_metadata_ptr(pool_token_idx) =
-                    {current_rank_in_expert_idx, src_token_idx, src_topk_idx, weight};
+                    {current_rank_in_expert_idx, src_token_idx, src_topk_idx};
+                *buffer.routed_topk_weights_buffer.get_data_buffer(pool_token_idx).get_base_ptr<float>() = weight;
 
                 // Complete last chunk's store
                 issue_and_wait_pull_store(kNumChunks - 1);
@@ -1529,11 +1530,13 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
                             dst_token_idx = pool_m_idx + m_idx_in_block;
                             dst_topk_idx = kNumTopk;
                         } else {
-                            const auto src_metadata = *workspace.get_token_src_metadata_ptr(pool_m_idx + m_idx_in_block);
+                            const auto pool_token_idx = pool_m_idx + m_idx_in_block;
+                            const auto src_metadata = *workspace.get_token_src_metadata_ptr(pool_token_idx);
                             dst_rank_idx = src_metadata.rank_idx;
                             dst_token_idx = src_metadata.token_idx;
                             dst_topk_idx = src_metadata.topk_idx;
-                            topk_weight = src_metadata.topk_weight;
+                            topk_weight = *buffer.routed_topk_weights_buffer
+                                .get_data_buffer(pool_token_idx).get_base_ptr<float>();
                         }
 
                         // Read from shared memory

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp4_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp4_fp4_mega_moe.cuh
@@ -351,7 +351,8 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
         kNumExpertsPerRank,
         kNumSMs, kNumRanks,
         kNumRingBlocks,
-        kNumSharedExperts>(
+        kNumSharedExperts,
+        BLOCK_K / 4>(
             workspace,
             shared_storage.task_info_full_barriers,
             shared_storage.task_info_empty_barriers,
@@ -652,11 +653,9 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
                 const auto weight = *sym_buffer.map(
                     buffer.input_topk_weights_buffer.get_base_ptr<float>() + src_token_topk_idx,
                     current_rank_in_expert_idx);
-                *buffer.l1_topk_weights_buffer.get_data_buffer(pool_token_idx % kNumRingTokens).template get_base_ptr<float>() = weight;
-
                 // Write source metadata for combine write-back (logical pool token)
                 *workspace.get_token_src_metadata_ptr(pool_token_idx) =
-                    {current_rank_in_expert_idx, src_token_idx, src_topk_idx};
+                    {current_rank_in_expert_idx, src_token_idx, src_topk_idx, weight};
 
                 // Complete last chunk's store
                 issue_and_wait_pull_store(kNumChunks - 1);
@@ -1519,6 +1518,7 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
                             break;
 
                         uint32_t dst_rank_idx, dst_token_idx, dst_topk_idx;
+                        float topk_weight = 1.0f;
                         if (task_info.is_shared()) {
                             // Shared output stays local: the extra combine slot beyond top-k
                             dst_rank_idx = sym_buffer.rank_idx;
@@ -1529,6 +1529,7 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
                             dst_rank_idx = src_metadata.rank_idx;
                             dst_token_idx = src_metadata.token_idx;
                             dst_topk_idx = src_metadata.topk_idx;
+                            topk_weight = src_metadata.topk_weight;
                         }
 
                         // Read from shared memory
@@ -1541,9 +1542,6 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
                         // Apply the per-token top-k routing weight here (post-L2), not before
                         // the intermediate quant. Shared-expert output carries no routing weight.
                         if (not task_info.is_shared()) {
-                            const float topk_weight = *buffer.l1_topk_weights_buffer
-                                .get_data_buffer(ring_m_idx + m_idx_in_block)
-                                .template get_base_ptr<float>();
                             const float2 w2 = {topk_weight, topk_weight};
                             auto* bf = reinterpret_cast<nv_bfloat162*>(&packed);
                             #pragma unroll

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp4_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp4_fp4_mega_moe.cuh
@@ -128,6 +128,11 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
                             const __grid_constant__ cute::TmaDescriptor tensor_map_shared_l2_weights) {
 #if (defined(__CUDA_ARCH__) and (__CUDA_ARCH__ >= 1000)) or defined(__CLION_IDE__)
     using Barrier = cutlass::arch::ClusterTransactionBarrier;
+    // Routed contributions occupy [0, kNumTopk); keeping the shared output in
+    // the next slot makes it the highest set bit and therefore the last value
+    // consumed by the combine loop's __ffs traversal.
+    constexpr uint32_t kSharedCombineSlot = kNumTopk;
+    DG_STATIC_ASSERT(kSharedCombineSlot == kNumTopk, "Shared output must follow every routed combine slot");
     using Allocator = cute::TMEM::Allocator2Sm;
 
     // Template checks
@@ -1528,7 +1533,7 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
                             // Shared output stays local: the extra combine slot beyond top-k
                             dst_rank_idx = sym_buffer.rank_idx;
                             dst_token_idx = pool_m_idx + m_idx_in_block;
-                            dst_topk_idx = kNumTopk;
+                            dst_topk_idx = kSharedCombineSlot;
                         } else {
                             const auto pool_token_idx = pool_m_idx + m_idx_in_block;
                             const auto src_metadata = *workspace.get_token_src_metadata_ptr(pool_token_idx);
@@ -1633,7 +1638,7 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
             // Read top-k slot indices: each lane reads one slot, then broadcast via exchange
             const int stored_topk_slot_idx = lane_idx < kNumTopk ?
                 static_cast<int>(__ldg(buffer.input_topk_idx_buffer.get_base_ptr<int64_t>() + token_idx * kNumTopk + lane_idx)) :
-                (kNumSharedExperts > 0 and lane_idx == kNumTopk ? static_cast<int>(kNumTopk) : -1);
+                (kNumSharedExperts > 0 and lane_idx == kSharedCombineSlot ? static_cast<int>(kSharedCombineSlot) : -1);
             const uint32_t total_mask = __ballot_sync(0xffffffff, stored_topk_slot_idx >= 0);
 
             // Iterate all chunks

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp4_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp4_fp4_mega_moe.cuh
@@ -102,6 +102,7 @@ CUTLASS_GLOBAL __launch_bounds__(kNumThreads, 1) void
 sm100_fp4_fp4_mega_moe_impl(void* y,
                             int* cumulative_local_expert_recv_stats,
                             const uint32_t num_tokens,
+                            const float routed_scaling_factor,
                             // Optional per-local-expert scales: L1 has separate gate/up factors
                             // (e.g. modelopt's per-projection `weight_scale_2`)
                             const float2* l1_alphas, const float* l2_alphas,
@@ -1620,6 +1621,7 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
         // Iterate over all tokens
         uint32_t combine_phase = 0;
         uint32_t load_stage_idx = 0;
+        bool load_stage_is_shared[2] = {};
         for (uint32_t token_idx = sm_idx * kNumEpilogueWarps + epilogue_warp_idx;
              token_idx < num_tokens;
              token_idx += kNumSMs * kNumEpilogueWarps) {
@@ -1641,6 +1643,8 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
                         // Move
                         const uint32_t slot_idx = __ffs(mask) - 1;
                         mask ^= 1 << slot_idx;
+                        if constexpr (kHasShared)
+                            load_stage_is_shared[i] = slot_idx == kNumTopk;
 
                         // Load
                         if (cute::elect_one_sync()) {
@@ -1674,7 +1678,29 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
                         const auto bf16_values = reinterpret_cast<const nv_bfloat162*>(&uint4_values);
                         #pragma unroll
                         for (uint32_t l = 0; l < kNumElemsPerUint4; ++ l)
-                            ptx::accumulate(reduced[j * kNumElemsPerUint4 + l], bf16_values[l]);
+                            if constexpr (kHasShared) {
+                                auto& value = reduced[j * kNumElemsPerUint4 + l];
+                                if (load_stage_is_shared[load_stage_idx]) {
+                                    // Match the unfused vLLM order exactly:
+                                    // combine routed slots -> BF16, apply the
+                                    // routed factor -> BF16, then add the BF16
+                                    // shared result -> BF16 at the final cast.
+                                    auto routed = __float22bfloat162_rn(value);
+                                    if (routed_scaling_factor != 1.0f) {
+                                        const float2 factor = {
+                                            routed_scaling_factor,
+                                            routed_scaling_factor};
+                                        routed = __float22bfloat162_rn(__fmul2_rn(
+                                            __bfloat1622float2(routed), factor));
+                                    }
+                                    value = __bfloat1622float2(routed);
+                                }
+                                ptx::accumulate(value, bf16_values[l]);
+                            } else {
+                                ptx::accumulate(
+                                    reduced[j * kNumElemsPerUint4 + l],
+                                    bf16_values[l]);
+                            }
                     }
                     combine_phase ^= load_stage_idx;
                     load_stage_idx ^= 1;
@@ -1710,6 +1736,12 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
                 __syncwarp();
             }
         }
+
+        // The last combine store has no following chunk to wait on.  Make it
+        // visible before the kernel returns so a CUDA Graph can immediately
+        // reuse `y` as the next layer's input.
+        ptx::tma_store_wait<0>();
+        __syncwarp();
     }
 #else
     if (blockIdx.x == 0 and threadIdx.x == 0)

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp4_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp4_fp4_mega_moe.cuh
@@ -845,7 +845,7 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
                 uint32_t n_idx = task_info.is_shared() ? n_block_idx * BLOCK_N : task_info.local_expert_idx * shape_n + n_block_idx * BLOCK_N;
                 uint32_t k_idx = k_block_idx * (task_info.is_shared() ? SHARED_BLOCK_K : BLOCK_K_BYTES);
                 uint32_t sfb_n_idx = n_block_idx * BLOCK_N;
-                uint32_t sfb_k_idx = task_info.is_shared() ? 0u :
+                uint32_t sfb_k_idx =
                     task_info.local_expert_idx * shape_sfb_k + k_block_idx * (BLOCK_K / (kGranK * 4));
 
                 // TMA copy weights with SF
@@ -1226,9 +1226,13 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
                 // Per-expert down-proj input scale for the intermediate NVFP4 requant.
                 // `inv_global = 1 / a2_scale` normalizes the block SF into E4M3 range; the
                 // matching `a2_scale` factor is folded back into the L2 alpha (see below).
-                const float l2_input_scale_inv = a2_scales == nullptr ? 1.0f :
-                    (kFastMath ? math::fast_rcp(__ldg(a2_scales + task_info.local_expert_idx))
-                               : 1.0f / __ldg(a2_scales + task_info.local_expert_idx));
+                const float a2_scale = a2_scales == nullptr ?
+                    1.0f : __ldg(a2_scales + task_info.local_expert_idx);
+                if (a2_scales != nullptr and epilogue_warp_idx == 0 and lane_idx == 0) {
+                    DG_DEVICE_ASSERT(isfinite(a2_scale) and a2_scale > 0.0f);
+                }
+                const float l2_input_scale_inv = kFastMath ?
+                    math::fast_rcp(a2_scale) : 1.0f / a2_scale;
 
                 // Unified L1 epilogue: SwiGLU in-place using granularity 8 interleaved weights
                 // With `SM100_TMEM_LOAD_16dp256b1x`, gate/up pairs are in the same thread.

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp4_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp4_fp4_mega_moe.cuh
@@ -25,9 +25,9 @@ CUTLASS_DEVICE uint32_t cvt_into_e2m1x2(const float& hi, const float& lo) {
     uint32_t packed;
     asm volatile(
         "{\n"
-        ".reg .b8 byte0, byte1, byte2, byte3;\n"
+        ".reg .b8 byte0;\n"
         "cvt.rn.satfinite.e2m1x2.f32 byte0, %1, %2;\n"
-        "mov.b32 %0, {byte0, byte1, byte2, byte3};\n"
+        "mov.b32 %0, {byte0, byte0, byte0, byte0};\n"
         "}" : "=r"(packed) : "f"(hi), "f"(lo));
     return packed & 0xffu;
 }
@@ -846,7 +846,8 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
                 uint32_t n_idx = task_info.is_shared() ? n_block_idx * BLOCK_N : task_info.local_expert_idx * shape_n + n_block_idx * BLOCK_N;
                 uint32_t k_idx = k_block_idx * (task_info.is_shared() ? SHARED_BLOCK_K : BLOCK_K_BYTES);
                 uint32_t sfb_n_idx = n_block_idx * BLOCK_N;
-                uint32_t sfb_k_idx = task_info.local_expert_idx * shape_sfb_k + k_block_idx * (BLOCK_K / (kGranK * 4));
+                uint32_t sfb_k_idx = task_info.is_shared() ? 0u :
+                    task_info.local_expert_idx * shape_sfb_k + k_block_idx * (BLOCK_K / (kGranK * 4));
 
                 // TMA copy weights with SF
                 if (cute::elect_one_sync()) {
@@ -1621,12 +1622,10 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
         // Iterate over all tokens
         uint32_t combine_phase = 0;
         uint32_t load_stage_idx = 0;
-        bool load_stage_is_shared[2] = {};
         for (uint32_t token_idx = sm_idx * kNumEpilogueWarps + epilogue_warp_idx;
              token_idx < num_tokens;
              token_idx += kNumSMs * kNumEpilogueWarps) {
             // Read top-k slot indices: each lane reads one slot, then broadcast via exchange
-            DG_STATIC_ASSERT(kNumTopk <= 32, "Invalid number of topk");
             const int stored_topk_slot_idx = lane_idx < kNumTopk ?
                 static_cast<int>(__ldg(buffer.input_topk_idx_buffer.get_base_ptr<int64_t>() + token_idx * kNumTopk + lane_idx)) :
                 (kNumSharedExperts > 0 and lane_idx == kNumTopk ? static_cast<int>(kNumTopk) : -1);
@@ -1643,9 +1642,6 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
                         // Move
                         const uint32_t slot_idx = __ffs(mask) - 1;
                         mask ^= 1 << slot_idx;
-                        if constexpr (kHasShared)
-                            load_stage_is_shared[i] = slot_idx == kNumTopk;
-
                         // Load
                         if (cute::elect_one_sync()) {
                             const auto src_ptr = math::advance_ptr<uint8_t>(
@@ -1672,38 +1668,59 @@ sm100_fp4_fp4_mega_moe_impl(void* y,
 
                     // Accumulate
                     combine_load_barriers[load_stage_idx]->wait(combine_phase);
+                    if constexpr (kHasShared) {
+                        // The shared slot is the highest bit and is therefore
+                        // consumed last by __ffs. Round and scale the routed sum
+                        // once, immediately before accumulating shared output.
+                        if (not do_reduce) {
+                            #pragma unroll
+                            for (uint32_t j = 0; j < kNumUint4PerLane; ++ j) {
+                                #pragma unroll
+                                for (uint32_t l = 0; l < kNumElemsPerUint4; ++ l) {
+                                    auto& value = reduced[j * kNumElemsPerUint4 + l];
+                                    auto routed = __float22bfloat162_rn(value);
+                                    if (routed_scaling_factor != 1.0f) {
+                                        const float2 factor = {routed_scaling_factor, routed_scaling_factor};
+                                        routed = __float22bfloat162_rn(__fmul2_rn(
+                                            __bfloat1622float2(routed), factor));
+                                    }
+                                    value = __bfloat1622float2(routed);
+                                }
+                            }
+                        }
+                    }
                     #pragma unroll
                     for (uint32_t j = 0; j < kNumUint4PerLane; ++ j) {
                         const auto uint4_values = combine_load_buffer[load_stage_idx][j * 32 + lane_idx];
                         const auto bf16_values = reinterpret_cast<const nv_bfloat162*>(&uint4_values);
                         #pragma unroll
                         for (uint32_t l = 0; l < kNumElemsPerUint4; ++ l)
-                            if constexpr (kHasShared) {
-                                auto& value = reduced[j * kNumElemsPerUint4 + l];
-                                if (load_stage_is_shared[load_stage_idx]) {
-                                    // Match the unfused vLLM order exactly:
-                                    // combine routed slots -> BF16, apply the
-                                    // routed factor -> BF16, then add the BF16
-                                    // shared result -> BF16 at the final cast.
-                                    auto routed = __float22bfloat162_rn(value);
-                                    if (routed_scaling_factor != 1.0f) {
-                                        const float2 factor = {
-                                            routed_scaling_factor,
-                                            routed_scaling_factor};
-                                        routed = __float22bfloat162_rn(__fmul2_rn(
-                                            __bfloat1622float2(routed), factor));
-                                    }
-                                    value = __bfloat1622float2(routed);
-                                }
-                                ptx::accumulate(value, bf16_values[l]);
-                            } else {
-                                ptx::accumulate(
-                                    reduced[j * kNumElemsPerUint4 + l],
-                                    bf16_values[l]);
-                            }
+                            ptx::accumulate(
+                                reduced[j * kNumElemsPerUint4 + l],
+                                bf16_values[l]);
                     }
                     combine_phase ^= load_stage_idx;
                     load_stage_idx ^= 1;
+                }
+
+                if constexpr (not kHasShared) {
+                    // With no shared slot there is no final iteration at which
+                    // to apply the routed factor. Preserve the public API's
+                    // BF16 -> scale -> BF16 ordering before the final cast.
+                    if (routed_scaling_factor != 1.0f) {
+                        #pragma unroll
+                        for (uint32_t j = 0; j < kNumUint4PerLane; ++ j) {
+                            #pragma unroll
+                            for (uint32_t l = 0; l < kNumElemsPerUint4; ++ l) {
+                                auto& value = reduced[j * kNumElemsPerUint4 + l];
+                                auto routed = __float22bfloat162_rn(value);
+                                const float2 factor = {routed_scaling_factor, routed_scaling_factor};
+                                routed = __float22bfloat162_rn(__fmul2_rn(
+                                    __bfloat1622float2(routed), factor));
+                                value = __bfloat1622float2(routed);
+                            }
+                        }
+                    }
                 }
 
                 // Cast

--- a/deep_gemm/include/deep_gemm/layout/mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/layout/mega_moe.cuh
@@ -386,9 +386,13 @@ struct MegaMoEBuffer {
         const auto bf16_token_layout = layout::Data(hidden * 2);
         const auto intermediate_token_layout = layout::Data(intermediate_hidden * num_mma_elem_bits / 8);
         const auto shared_intermediate_token_layout = layout::Data(shared_intermediate_hidden * shared_num_mma_elem_bits / 8);
-        const auto input_sf_layout = layout::Data(with_sf ? hidden / sf_gran_k : 0);
-        const auto intermediate_sf_layout = layout::Data(with_sf ? intermediate_hidden / sf_gran_k : 0);
-        const auto shared_intermediate_sf_layout = layout::Data(shared_with_sf ? shared_intermediate_hidden / sf_gran_k : 0);
+        // SF buffers are MN-major: an individual logical token row need not be
+        // 16-byte aligned. Their complete allocations remain aligned through
+        // the token-count constraints checked by the host API.
+        const auto input_sf_layout = layout::Data(with_sf ? hidden / sf_gran_k : 0, false);
+        const auto intermediate_sf_layout = layout::Data(with_sf ? intermediate_hidden / sf_gran_k : 0, false);
+        const auto shared_intermediate_sf_layout = layout::Data(
+            shared_with_sf ? shared_intermediate_hidden / sf_gran_k : 0, false);
         const auto input_topk_idx_layout = layout::Data(num_topk * sizeof(int64_t), false);
         const auto input_topk_weights_layout = layout::Data(num_topk * sizeof(float), false);
         const auto l1_topk_weights_layout = layout::Data(sizeof(float), false);

--- a/deep_gemm/include/deep_gemm/layout/mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/layout/mega_moe.cuh
@@ -41,8 +41,6 @@ struct TokenSrcMetadata {
     uint32_t rank_idx;
     uint32_t token_idx;
     uint32_t topk_idx;
-    // Full-pool storage keeps this alive until L2 finishes, unlike the L1 ring.
-    float topk_weight;
 };
 
 struct Workspace {
@@ -350,7 +348,8 @@ struct MegaMoEBuffer {
            l1_topk_weights_buffer,
            l2_token_buffer,
            l2_sf_buffer,
-           combine_token_buffer;
+           combine_token_buffer,
+           routed_topk_weights_buffer;
 
     CUTLASS_HOST_DEVICE
     MegaMoEBuffer(void* base,
@@ -394,15 +393,23 @@ struct MegaMoEBuffer {
             shared_with_sf ? shared_intermediate_hidden / sf_gran_k : 0);
         const auto input_topk_idx_layout = layout::Data(num_topk * sizeof(int64_t), false);
         const auto input_topk_weights_layout = layout::Data(num_topk * sizeof(float), false);
-        // NVFP4 keeps the routing weight in full-pool metadata because the ring slot may
-        // be reused before combine. The older BF16/MXFP8 kernels still use this ring buffer.
+        // NVFP4 keeps routing weights in the full-pool tail sidecar because the L1 ring
+        // may be reused before L2. The older BF16/MXFP8 kernels use this ring buffer.
         const auto l1_topk_weights_layout = layout::Data(
             num_mma_elem_bits == 4 ? 0 : sizeof(float), false);
+        // NVFP4 applies routing weights after L2, so they must outlive the L1 ring.
+        // Place this NVFP4-only sidecar directly after the compact metadata workspace:
+        // NVFP4 keeps its established input-buffer offsets, while BF16/MXFP8 pay zero bytes.
+        const auto routed_topk_weights_layout = layout::Data(
+            num_mma_elem_bits == 4 ? sizeof(float) : 0, false);
 
         // Input buffers
+        routed_topk_weights_buffer = Buffer(
+            routed_topk_weights_layout, 1, workspace.num_max_pool_tokens,
+            workspace.get_end_ptr());
         input_token_buffer = Buffer(
             input_token_layout, 1, num_max_tokens_per_rank,
-            workspace.get_end_ptr());
+            routed_topk_weights_buffer.get_end_ptr());
         input_sf_buffer = Buffer(
             input_sf_layout, 1, num_max_tokens_per_rank,
             input_token_buffer.get_end_ptr());
@@ -449,6 +456,7 @@ struct MegaMoEBuffer {
         combine_token_buffer = Buffer(
             bf16_token_layout, num_topk + (num_shared_experts > 0 ? 1u : 0u), num_max_tokens_per_rank,
             with_sf ? l2_sf_buffer.get_end_ptr() : l2_token_buffer.get_end_ptr());
+
     }
 
     CUTLASS_HOST_DEVICE

--- a/deep_gemm/include/deep_gemm/layout/mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/layout/mega_moe.cuh
@@ -394,7 +394,10 @@ struct MegaMoEBuffer {
             shared_with_sf ? shared_intermediate_hidden / sf_gran_k : 0);
         const auto input_topk_idx_layout = layout::Data(num_topk * sizeof(int64_t), false);
         const auto input_topk_weights_layout = layout::Data(num_topk * sizeof(float), false);
-        const auto l1_topk_weights_layout = layout::Data(sizeof(float), false);
+        // NVFP4 keeps the routing weight in full-pool metadata because the ring slot may
+        // be reused before combine. The older BF16/MXFP8 kernels still use this ring buffer.
+        const auto l1_topk_weights_layout = layout::Data(
+            num_mma_elem_bits == 4 ? 0 : sizeof(float), false);
 
         // Input buffers
         input_token_buffer = Buffer(

--- a/deep_gemm/include/deep_gemm/layout/mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/layout/mega_moe.cuh
@@ -361,24 +361,34 @@ struct MegaMoEBuffer {
                   const uint32_t& num_ring_tokens,
                   const uint32_t& num_sf_ring_tokens,
                   const bool& with_sf,
-                  const uint32_t& num_shared_experts = 0) {
+                  const uint32_t& num_shared_experts = 0,
+                  const uint32_t& num_mma_elem_bits_opt = 0,
+                  const uint32_t& sf_gran_k = 32,
+                  const uint32_t& shared_num_mma_elem_bits_opt = 0) {
         // Workspace
         workspace = Workspace(base, num_ranks, num_experts,
                               num_max_tokens_per_rank, num_topk, num_ring_tokens);
 
-        // Shared
-        const auto shared_intermediate_hidden = intermediate_hidden * num_shared_experts;
-        const auto num_max_shared_sf_tokens = with_sf ? get_num_max_shared_sf_tokens(num_max_tokens_per_rank) : 0u;
-
         // Layouts
-        const uint32_t num_mma_elem_bytes = with_sf ? 1 : 2;
-        const auto input_token_layout = layout::Data(hidden * num_mma_elem_bytes);
+        // NOTES: element sizes are in bits to support sub-byte packed NVFP4 (4 bits);
+        // `num_mma_elem_bits_opt == 0` keeps the legacy behavior (FP8 with SF, BF16 without)
+        const uint32_t num_mma_elem_bits = num_mma_elem_bits_opt != 0 ? num_mma_elem_bits_opt : (with_sf ? 8 : 16);
+
+        // Shared
+        // NOTES: shared experts may use a different (wider) dtype than routed experts,
+        // e.g. BF16 shared experts inside the NVFP4 kernel; 16-bit shared experts carry no SF
+        const uint32_t shared_num_mma_elem_bits = shared_num_mma_elem_bits_opt != 0 ? shared_num_mma_elem_bits_opt : num_mma_elem_bits;
+        const bool shared_with_sf = with_sf and shared_num_mma_elem_bits < 16;
+        const auto shared_intermediate_hidden = intermediate_hidden * num_shared_experts;
+        const auto num_max_shared_sf_tokens = shared_with_sf ? get_num_max_shared_sf_tokens(num_max_tokens_per_rank) : 0u;
+
+        const auto input_token_layout = layout::Data(hidden * num_mma_elem_bits / 8);
         const auto bf16_token_layout = layout::Data(hidden * 2);
-        const auto intermediate_token_layout = layout::Data(intermediate_hidden * num_mma_elem_bytes);
-        const auto shared_intermediate_token_layout = layout::Data(shared_intermediate_hidden * num_mma_elem_bytes);
-        const auto input_sf_layout = layout::Data(with_sf ? hidden / 32 : 0);
-        const auto intermediate_sf_layout = layout::Data(with_sf ? intermediate_hidden / 32 : 0);
-        const auto shared_intermediate_sf_layout = layout::Data(with_sf ? shared_intermediate_hidden / 32 : 0);
+        const auto intermediate_token_layout = layout::Data(intermediate_hidden * num_mma_elem_bits / 8);
+        const auto shared_intermediate_token_layout = layout::Data(shared_intermediate_hidden * shared_num_mma_elem_bits / 8);
+        const auto input_sf_layout = layout::Data(with_sf ? hidden / sf_gran_k : 0);
+        const auto intermediate_sf_layout = layout::Data(with_sf ? intermediate_hidden / sf_gran_k : 0);
+        const auto shared_intermediate_sf_layout = layout::Data(shared_with_sf ? shared_intermediate_hidden / sf_gran_k : 0);
         const auto input_topk_idx_layout = layout::Data(num_topk * sizeof(int64_t), false);
         const auto input_topk_weights_layout = layout::Data(num_topk * sizeof(float), false);
         const auto l1_topk_weights_layout = layout::Data(sizeof(float), false);

--- a/deep_gemm/include/deep_gemm/layout/mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/layout/mega_moe.cuh
@@ -41,6 +41,8 @@ struct TokenSrcMetadata {
     uint32_t rank_idx;
     uint32_t token_idx;
     uint32_t topk_idx;
+    // Full-pool storage keeps this alive until L2 finishes, unlike the L1 ring.
+    float topk_weight;
 };
 
 struct Workspace {
@@ -386,13 +388,10 @@ struct MegaMoEBuffer {
         const auto bf16_token_layout = layout::Data(hidden * 2);
         const auto intermediate_token_layout = layout::Data(intermediate_hidden * num_mma_elem_bits / 8);
         const auto shared_intermediate_token_layout = layout::Data(shared_intermediate_hidden * shared_num_mma_elem_bits / 8);
-        // SF buffers are MN-major: an individual logical token row need not be
-        // 16-byte aligned. Their complete allocations remain aligned through
-        // the token-count constraints checked by the host API.
-        const auto input_sf_layout = layout::Data(with_sf ? hidden / sf_gran_k : 0, false);
-        const auto intermediate_sf_layout = layout::Data(with_sf ? intermediate_hidden / sf_gran_k : 0, false);
+        const auto input_sf_layout = layout::Data(with_sf ? hidden / sf_gran_k : 0);
+        const auto intermediate_sf_layout = layout::Data(with_sf ? intermediate_hidden / sf_gran_k : 0);
         const auto shared_intermediate_sf_layout = layout::Data(
-            shared_with_sf ? shared_intermediate_hidden / sf_gran_k : 0, false);
+            shared_with_sf ? shared_intermediate_hidden / sf_gran_k : 0);
         const auto input_topk_idx_layout = layout::Data(num_topk * sizeof(int64_t), false);
         const auto input_topk_weights_layout = layout::Data(num_topk * sizeof(float), false);
         const auto l1_topk_weights_layout = layout::Data(sizeof(float), false);

--- a/deep_gemm/include/deep_gemm/ptx/tcgen05.cuh
+++ b/deep_gemm/include/deep_gemm/ptx/tcgen05.cuh
@@ -139,6 +139,30 @@ struct SM100_MMA_MXF4_SS {
     }
 };
 
+struct SM100_MMA_MXF4NVF4_2x1SM_SS {
+    CUTLASS_DEVICE static void
+    fma(uint64_t const& desc_a,
+        uint64_t const& desc_b,
+        uint32_t const& tmem_c,
+        uint32_t const& scale_c,
+        uint64_t const& desc,
+        uint32_t const& tmem_sfa,
+        uint32_t const& tmem_sfb) {
+        asm volatile(
+            "{\n\t"
+            ".reg .pred p;\n\t"
+            "setp.ne.b32 p, %4, 0;\n\t"
+#if (__CUDACC_VER_MAJOR__ > 12) || (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 9)
+            "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.block16 [%0], %1, %2, %3, [%5], [%6], p; \n\t"
+#else
+            "tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X [%0], %1, %2, %3, [%5], [%6], p; \n\t"
+#endif
+            "}\n"
+            :: "r"(tmem_c), "l"(desc_a), "l"(desc_b), "r"(static_cast<uint32_t>(desc >> 32)), "r"(scale_c),
+               "r"(tmem_sfa), "r"(tmem_sfb));
+    }
+};
+
 struct SM100_MMA_F16BF16_WS_SS {
     CUTLASS_DEVICE static void
     fma(uint64_t const& desc_a,

--- a/deep_gemm/include/deep_gemm/scheduler/mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/scheduler/mega_moe.cuh
@@ -144,6 +144,7 @@ template <uint32_t BLOCK_M, uint32_t BLOCK_N, uint32_t BLOCK_K,
           uint32_t kNumSMs, uint32_t kNumRanks,
           uint32_t kNumRingBlocks,
           uint32_t kNumSharedExperts = 0,
+          uint32_t SHARED_BLOCK_K = BLOCK_K,
           uint32_t kNumExpertsPerLane = math::constexpr_ceil_div(kNumExpertsPerRank, 32u),
           uint32_t kNumL1BlockNs = L1_SHAPE_N / BLOCK_N,
           uint32_t kNumL2BlockNs = L2_SHAPE_N / BLOCK_N,
@@ -163,8 +164,8 @@ struct MegaMoEScheduler {
     DG_STATIC_ASSERT(L2_SHAPE_K % BLOCK_K == 0, "Invalid shape");
     DG_STATIC_ASSERT(SHARED_L1_SHAPE_N % (BLOCK_N * 2) == 0, "Invalid shared shape");
     DG_STATIC_ASSERT(SHARED_L2_SHAPE_N % (BLOCK_N * 2) == 0, "Invalid shared shape");
-    DG_STATIC_ASSERT(SHARED_L1_SHAPE_K % BLOCK_K == 0, "Invalid shared shape");
-    DG_STATIC_ASSERT(SHARED_L2_SHAPE_K % BLOCK_K == 0, "Invalid shared shape");
+    DG_STATIC_ASSERT(SHARED_L1_SHAPE_K % SHARED_BLOCK_K == 0, "Invalid shared shape");
+    DG_STATIC_ASSERT(SHARED_L2_SHAPE_K % SHARED_BLOCK_K == 0, "Invalid shared shape");
 
     // NOTES: N block counts must be even so that 2 adjacent CTAs in a cluster
     // always land on the same m_block_idx with n_block_idx differing by 1

--- a/deep_gemm/mega/__init__.py
+++ b/deep_gemm/mega/__init__.py
@@ -31,6 +31,9 @@ class SymmBuffer:
         self.num_topk = num_topk
         self.hidden = hidden
         self.intermediate_hidden = intermediate_hidden
+        self.num_shared_experts = num_shared_experts
+        self.mma_type = mma_type
+        self.activation = activation
 
         # Allocate a symmetric buffer
         num_bytes, slice_input_buffers = _C.get_symm_buffer_size_for_mega_moe(
@@ -211,7 +214,15 @@ def fp4_fp4_mega_moe(y: torch.Tensor,
     CUDA Graph replay must reuse the captured ``x_bf16`` allocation and token
     count because both are encoded in the captured shared-input tensor map.
     """
+    assert sym_buffer.mma_type == 'fp4xfp4', \
+        f'NVFP4 MegaMoE requires an fp4xfp4 symmetric buffer, got {sym_buffer.mma_type!r}'
+    assert sym_buffer.activation == activation, \
+        f'Activation mismatch: buffer={sym_buffer.activation!r}, call={activation!r}'
     assert (shared_l1_weights is None) == (shared_l2_weights is None) == (x_bf16 is None)
+    num_shared_experts = 0 if shared_l2_weights is None else \
+        shared_l2_weights.size(1) // sym_buffer.intermediate_hidden
+    assert sym_buffer.num_shared_experts == num_shared_experts, \
+        f'Shared-expert layout mismatch: buffer={sym_buffer.num_shared_experts}, call={num_shared_experts}'
     _C.fp4_fp4_mega_moe(
         y,
         l1_weights, l2_weights,

--- a/deep_gemm/mega/__init__.py
+++ b/deep_gemm/mega/__init__.py
@@ -181,6 +181,53 @@ def fp8_fp4_mega_moe(y: torch.Tensor,
         situ_beta, situ_linear_beta
     )
 
+def fp4_fp4_mega_moe(y: torch.Tensor,
+                     l1_weights: Tuple[torch.Tensor, torch.Tensor],
+                     l2_weights: Tuple[torch.Tensor, torch.Tensor],
+                     sym_buffer: SymmBuffer,
+                     shared_l1_weights: Optional[torch.Tensor] = None,
+                     shared_l2_weights: Optional[torch.Tensor] = None,
+                     x_bf16: Optional[torch.Tensor] = None,
+                     cumulative_local_expert_recv_stats: Optional[torch.Tensor] = None,
+                     recipe: Tuple[int, int, int] = (1, 1, 16),
+                     activation: str = 'swiglu',
+                     activation_clamp: Optional[float] = None,
+                     fast_math: bool = True,
+                     l1_alphas: Optional[torch.Tensor] = None,
+                     l2_alphas: Optional[torch.Tensor] = None,
+                     a2_scales: Optional[torch.Tensor] = None):
+    # NVFP4 x NVFP4 fused MoE: weights and activations are packed E2M1 with
+    # per-16-element E4M3 SFs. `l1_alphas`/`l2_alphas` are optional per-local-expert
+    # scales (e.g. modelopt's `weight_scale_2`), applied before the activation
+    # function (L1) and before the combine write-back (L2). `l1_alphas` is FP32 with
+    # shape `(num_local_experts, 2)` holding separate gate/up factors; `l2_alphas`
+    # is FP32 with shape `(num_local_experts, )`.
+    # `a2_scales` is an optional FP32 `(num_local_experts, )` per-expert down-proj
+    # input scale (modelopt's `input_scale`): the kernel normalizes the in-kernel
+    # intermediate NVFP4 requant block SFs by `1 / a2_scale` (keeping them in E4M3's
+    # well-represented range) and folds `a2_scale` back into the L2 alpha. Matches
+    # flashinfer/TRT-LLM's recipe; omit (or `None`) for the plain unit-scale recipe.
+    # Shared experts run in BF16 (no quantization): `shared_l1_weights` is
+    # `(2 * shared_intermediate, hidden)`, `shared_l2_weights` is
+    # `(hidden, shared_intermediate)`, and `x_bf16` provides the BF16 activations of
+    # the local tokens (the buffer's `x` is packed FP4 and cannot be reused).
+    # Under CUDA graphs, `x_bf16` must have a stable address, like `y`
+    assert (shared_l1_weights is None) == (shared_l2_weights is None) == (x_bf16 is None)
+    _C.fp4_fp4_mega_moe(
+        y,
+        l1_weights, l2_weights,
+        shared_l1_weights, shared_l2_weights, x_bf16,
+        cumulative_local_expert_recv_stats,
+        sym_buffer.buffer,
+        sym_buffer.handle.buffer_ptrs, sym_buffer.group.rank(),
+        sym_buffer.num_max_tokens_per_rank,
+        sym_buffer.num_experts, sym_buffer.num_topk,
+        recipe,
+        activation, activation_clamp,
+        fast_math,
+        l1_alphas, l2_alphas, a2_scales
+    )
+
 def bf16_mega_moe(y: torch.Tensor,
                   l1_weights: torch.Tensor,
                   l2_weights: torch.Tensor,

--- a/deep_gemm/mega/__init__.py
+++ b/deep_gemm/mega/__init__.py
@@ -214,15 +214,19 @@ def fp4_fp4_mega_moe(y: torch.Tensor,
     CUDA Graph replay must reuse the captured ``x_bf16`` allocation and token
     count because both are encoded in the captured shared-input tensor map.
     """
-    assert sym_buffer.mma_type == 'fp4xfp4', \
-        f'NVFP4 MegaMoE requires an fp4xfp4 symmetric buffer, got {sym_buffer.mma_type!r}'
-    assert sym_buffer.activation == activation, \
-        f'Activation mismatch: buffer={sym_buffer.activation!r}, call={activation!r}'
-    assert (shared_l1_weights is None) == (shared_l2_weights is None) == (x_bf16 is None)
+    if sym_buffer.mma_type != 'fp4xfp4':
+        raise ValueError(
+            f'NVFP4 MegaMoE requires an fp4xfp4 symmetric buffer, got {sym_buffer.mma_type!r}')
+    if sym_buffer.activation != activation:
+        raise ValueError(
+            f'Activation mismatch: buffer={sym_buffer.activation!r}, call={activation!r}')
+    if not ((shared_l1_weights is None) == (shared_l2_weights is None) == (x_bf16 is None)):
+        raise ValueError('Shared L1 weights, shared L2 weights, and x_bf16 must be provided together')
     num_shared_experts = 0 if shared_l2_weights is None else \
         shared_l2_weights.size(1) // sym_buffer.intermediate_hidden
-    assert sym_buffer.num_shared_experts == num_shared_experts, \
-        f'Shared-expert layout mismatch: buffer={sym_buffer.num_shared_experts}, call={num_shared_experts}'
+    if sym_buffer.num_shared_experts != num_shared_experts:
+        raise ValueError(
+            f'Shared-expert layout mismatch: buffer={sym_buffer.num_shared_experts}, call={num_shared_experts}')
     _C.fp4_fp4_mega_moe(
         y,
         l1_weights, l2_weights,

--- a/deep_gemm/mega/__init__.py
+++ b/deep_gemm/mega/__init__.py
@@ -197,24 +197,13 @@ def fp4_fp4_mega_moe(y: torch.Tensor,
                      l2_alphas: Optional[torch.Tensor] = None,
                      a2_scales: Optional[torch.Tensor] = None,
                      routed_scaling_factor: float = 1.0):
-    # NVFP4 x NVFP4 fused MoE: weights and activations are packed E2M1 with
-    # per-16-element E4M3 SFs. `l1_alphas`/`l2_alphas` are optional per-local-expert
-    # scales (e.g. modelopt's `weight_scale_2`), applied before the activation
-    # function (L1) and before the combine write-back (L2). `l1_alphas` is FP32 with
-    # shape `(num_local_experts, 2)` holding separate gate/up factors; `l2_alphas`
-    # is FP32 with shape `(num_local_experts, )`.
-    # `a2_scales` is an optional FP32 `(num_local_experts, )` per-expert down-proj
-    # input scale (modelopt's `input_scale`): the kernel normalizes the in-kernel
-    # intermediate NVFP4 requant block SFs by `1 / a2_scale` (keeping them in E4M3's
-    # well-represented range) and folds `a2_scale` back into the L2 alpha. Matches
-    # flashinfer/TRT-LLM's recipe; omit (or `None`) for the plain unit-scale recipe.
-    # Shared experts run in BF16 (no quantization): `shared_l1_weights` is
-    # `(2 * shared_intermediate, hidden)`, `shared_l2_weights` is
-    # `(hidden, shared_intermediate)`, and `x_bf16` provides the BF16 activations of
-    # the local tokens (the buffer's `x` is packed FP4 and cannot be reused).
-    # `routed_scaling_factor` is applied to the reduced routed contribution
-    # before adding shared output, matching the unfused BF16 execution order.
-    # Under CUDA graphs, `x_bf16` must have a stable address, like `y`.
+    """Run NVFP4 routed experts, optionally fused with BF16 shared experts.
+
+    NVFP4 operands use packed E2M1 values and per-16-element E4M3 scales.
+    ``l1_alphas``, ``l2_alphas`` and ``a2_scales`` carry optional per-expert
+    model scales. Shared weights and ``x_bf16`` must be provided together;
+    ``routed_scaling_factor`` is applied before adding their BF16 output.
+    """
     assert (shared_l1_weights is None) == (shared_l2_weights is None) == (x_bf16 is None)
     _C.fp4_fp4_mega_moe(
         y,

--- a/deep_gemm/mega/__init__.py
+++ b/deep_gemm/mega/__init__.py
@@ -139,7 +139,8 @@ def transform_weights_for_mega_moe(
     assert activation != 'situ' or (isinstance(l1_weights, tuple) and isinstance(l2_weights, tuple)), \
         '`situ` requires FP8xFP4 `(weight, sf)` tuples for both L1 and L2 weights'
     if isinstance(l1_weights, tuple):
-        # FP8: interleave gate/up for weight and SF, then transpose L1 SF for UTCCP
+        # Scaled FP8xFP4/NVFP4: both formats use the same MN-major SF layout.
+        # Interleave gate/up for weight and SF, then transpose L1 SF for UTCCP.
         l1_w = _interleave_weights(l1_weights[0])
         l1_sf = _transpose_sf_for_utccp(_interleave_weights(l1_weights[1]))
         l1_transformed = (l1_w, l1_sf)
@@ -200,9 +201,14 @@ def fp4_fp4_mega_moe(y: torch.Tensor,
     """Run NVFP4 routed experts, optionally fused with BF16 shared experts.
 
     NVFP4 operands use packed E2M1 values and per-16-element E4M3 scales.
-    ``l1_alphas``, ``l2_alphas`` and ``a2_scales`` carry optional per-expert
-    model scales. Shared weights and ``x_bf16`` must be provided together;
+    ``l1_alphas`` and ``l2_alphas`` carry optional per-expert model scales.
+    The caller must fold the FC1 input global scale into ``l1_alphas``;
+    ``a2_scales`` is separate because the FC2 input is produced and requantized
+    inside this kernel. Shared weights and ``x_bf16`` must be provided together;
     ``routed_scaling_factor`` is applied before adding their BF16 output.
+
+    CUDA Graph replay must reuse the captured ``x_bf16`` allocation and token
+    count because both are encoded in the captured shared-input tensor map.
     """
     assert (shared_l1_weights is None) == (shared_l2_weights is None) == (x_bf16 is None)
     _C.fp4_fp4_mega_moe(

--- a/deep_gemm/mega/__init__.py
+++ b/deep_gemm/mega/__init__.py
@@ -195,7 +195,8 @@ def fp4_fp4_mega_moe(y: torch.Tensor,
                      fast_math: bool = True,
                      l1_alphas: Optional[torch.Tensor] = None,
                      l2_alphas: Optional[torch.Tensor] = None,
-                     a2_scales: Optional[torch.Tensor] = None):
+                     a2_scales: Optional[torch.Tensor] = None,
+                     routed_scaling_factor: float = 1.0):
     # NVFP4 x NVFP4 fused MoE: weights and activations are packed E2M1 with
     # per-16-element E4M3 SFs. `l1_alphas`/`l2_alphas` are optional per-local-expert
     # scales (e.g. modelopt's `weight_scale_2`), applied before the activation
@@ -211,7 +212,9 @@ def fp4_fp4_mega_moe(y: torch.Tensor,
     # `(2 * shared_intermediate, hidden)`, `shared_l2_weights` is
     # `(hidden, shared_intermediate)`, and `x_bf16` provides the BF16 activations of
     # the local tokens (the buffer's `x` is packed FP4 and cannot be reused).
-    # Under CUDA graphs, `x_bf16` must have a stable address, like `y`
+    # `routed_scaling_factor` is applied to the reduced routed contribution
+    # before adding shared output, matching the unfused BF16 execution order.
+    # Under CUDA graphs, `x_bf16` must have a stable address, like `y`.
     assert (shared_l1_weights is None) == (shared_l2_weights is None) == (x_bf16 is None)
     _C.fp4_fp4_mega_moe(
         y,
@@ -225,7 +228,7 @@ def fp4_fp4_mega_moe(y: torch.Tensor,
         recipe,
         activation, activation_clamp,
         fast_math,
-        l1_alphas, l2_alphas, a2_scales
+        l1_alphas, l2_alphas, a2_scales, routed_scaling_factor
     )
 
 def bf16_mega_moe(y: torch.Tensor,

--- a/deep_gemm/mega/__init__.py
+++ b/deep_gemm/mega/__init__.py
@@ -204,7 +204,8 @@ def fp4_fp4_mega_moe(y: torch.Tensor,
     ``l1_alphas`` and ``l2_alphas`` carry optional per-expert model scales.
     The caller must fold the FC1 input global scale into ``l1_alphas``;
     ``a2_scales`` is separate because the FC2 input is produced and requantized
-    inside this kernel. Shared weights and ``x_bf16`` must be provided together;
+    inside this kernel; when provided, every entry must be finite and strictly
+    positive. Shared weights and ``x_bf16`` must be provided together;
     ``routed_scaling_factor`` is applied before adding their BF16 output.
 
     CUDA Graph replay must reuse the captured ``x_bf16`` allocation and token

--- a/deep_gemm/utils/math.py
+++ b/deep_gemm/utils/math.py
@@ -1,5 +1,5 @@
 import torch
-from typing import Optional, Tuple
+from typing import Tuple
 
 
 def ceil_div(x: int, y: int) -> int:
@@ -120,54 +120,6 @@ def per_token_cast_to_fp4(x: torch.Tensor, use_ue8m0: bool, gran_k: int = 128,
             sf = torch.nn.functional.pad(sf, (0, pad), value=1.0)
         return packed[:, :n // 2].contiguous(), pack_ue8m0_to_int(sf)
     return packed[:, :n // 2].contiguous(), sf
-
-
-def _quantize_to_fp4_e2m1_rne(x: torch.Tensor) -> torch.Tensor:
-    # Round-to-nearest-even on the E2M1 grid, matching `cvt.rn.satfinite.e2m1x2.f32`
-    # {0, 0.5, 1, 1.5, 2, 3, 4, 6}; ties at 0.75, 1.75 and 3.5 round up (to even codes)
-    ax = x.abs()
-    code = torch.zeros_like(x, dtype=torch.uint8)
-    for boundary in (0.25, 1.25, 2.5, 5.0):
-        code += (ax > boundary).to(torch.uint8)
-    for boundary in (0.75, 1.75, 3.5):
-        code += (ax >= boundary).to(torch.uint8)
-    sign = (x < 0) & (code != 0)
-    code = code | (sign.to(torch.uint8) << 3)
-    return code.view(torch.int8)
-
-
-def per_token_cast_to_nvfp4(x: torch.Tensor, gran_k: int = 16,
-                            use_packed_e4m3: bool = False,
-                            global_scale: Optional[float] = None) -> Tuple[torch.Tensor, torch.Tensor]:
-    # NVFP4: packed E2M1 values with one E4M3 SF per `gran_k` elements. By default the
-    # block SF is `e4m3(amax / 6)` (unit global scale). When `global_scale` (a per-tensor
-    # `input_scale`, modelopt convention) is given, the block SF is normalized into E4M3's
-    # well-represented range as `e4m3(amax / 6 / global_scale)`, matching the kernel's
-    # `a2_scale` recipe; the returned SF is the normalized one, so dequantizing needs an
-    # extra `* global_scale` (or fold it into the GEMM alpha).
-    # With `use_packed_e4m3`, the SF is returned with 4 E4M3 bytes packed per `int32`
-    m, n = x.shape
-    assert n % (gran_k * 4) == 0
-    x_view = x.float().view(m, n // gran_k, gran_k)
-    x_amax = x_view.abs().amax(dim=2)
-    inv_global = 1.0 if global_scale is None else 1.0 / global_scale
-    # 2^-9 is the smallest E4M3 subnormal, keeping the SF away from zero
-    sf_e4m3 = (x_amax * (1.0 / 6.0) * inv_global).clamp_min(2.0 ** -9).to(torch.float8_e4m3fn)
-    sf = sf_e4m3.float()
-    # Element quant divisor = sf * global_scale (== sf when unit-scaled)
-    elem_scale = sf if global_scale is None else sf * global_scale
-    x_scaled = x_view / elem_scale.unsqueeze(2)
-    codes = _quantize_to_fp4_e2m1_rne(x_scaled).view(m, n)
-    codes2 = codes.view(m, n // 2, 2)
-    packed = ((codes2[:, :, 0] & 0x0F) | ((codes2[:, :, 1] & 0x0F) << 4)).contiguous()
-    if use_packed_e4m3:
-        return packed, sf_e4m3.view(torch.uint8).contiguous().view(torch.int32)
-    return packed, sf
-
-
-def unpack_e4m3_sf_from_int(packed_sf: torch.Tensor) -> torch.Tensor:
-    assert packed_sf.dtype == torch.int32
-    return packed_sf.contiguous().view(torch.uint8).view(torch.float8_e4m3fn).float()
 
 
 def transpose_packed_fp4(a: torch.Tensor) -> torch.Tensor:

--- a/deep_gemm/utils/math.py
+++ b/deep_gemm/utils/math.py
@@ -1,5 +1,5 @@
 import torch
-from typing import Tuple
+from typing import Optional, Tuple
 
 
 def ceil_div(x: int, y: int) -> int:
@@ -120,6 +120,54 @@ def per_token_cast_to_fp4(x: torch.Tensor, use_ue8m0: bool, gran_k: int = 128,
             sf = torch.nn.functional.pad(sf, (0, pad), value=1.0)
         return packed[:, :n // 2].contiguous(), pack_ue8m0_to_int(sf)
     return packed[:, :n // 2].contiguous(), sf
+
+
+def _quantize_to_fp4_e2m1_rne(x: torch.Tensor) -> torch.Tensor:
+    # Round-to-nearest-even on the E2M1 grid, matching `cvt.rn.satfinite.e2m1x2.f32`
+    # {0, 0.5, 1, 1.5, 2, 3, 4, 6}; ties at 0.75, 1.75 and 3.5 round up (to even codes)
+    ax = x.abs()
+    code = torch.zeros_like(x, dtype=torch.uint8)
+    for boundary in (0.25, 1.25, 2.5, 5.0):
+        code += (ax > boundary).to(torch.uint8)
+    for boundary in (0.75, 1.75, 3.5):
+        code += (ax >= boundary).to(torch.uint8)
+    sign = (x < 0) & (code != 0)
+    code = code | (sign.to(torch.uint8) << 3)
+    return code.view(torch.int8)
+
+
+def per_token_cast_to_nvfp4(x: torch.Tensor, gran_k: int = 16,
+                            use_packed_e4m3: bool = False,
+                            global_scale: Optional[float] = None) -> Tuple[torch.Tensor, torch.Tensor]:
+    # NVFP4: packed E2M1 values with one E4M3 SF per `gran_k` elements. By default the
+    # block SF is `e4m3(amax / 6)` (unit global scale). When `global_scale` (a per-tensor
+    # `input_scale`, modelopt convention) is given, the block SF is normalized into E4M3's
+    # well-represented range as `e4m3(amax / 6 / global_scale)`, matching the kernel's
+    # `a2_scale` recipe; the returned SF is the normalized one, so dequantizing needs an
+    # extra `* global_scale` (or fold it into the GEMM alpha).
+    # With `use_packed_e4m3`, the SF is returned with 4 E4M3 bytes packed per `int32`
+    m, n = x.shape
+    assert n % (gran_k * 4) == 0
+    x_view = x.float().view(m, n // gran_k, gran_k)
+    x_amax = x_view.abs().amax(dim=2)
+    inv_global = 1.0 if global_scale is None else 1.0 / global_scale
+    # 2^-9 is the smallest E4M3 subnormal, keeping the SF away from zero
+    sf_e4m3 = (x_amax * (1.0 / 6.0) * inv_global).clamp_min(2.0 ** -9).to(torch.float8_e4m3fn)
+    sf = sf_e4m3.float()
+    # Element quant divisor = sf * global_scale (== sf when unit-scaled)
+    elem_scale = sf if global_scale is None else sf * global_scale
+    x_scaled = x_view / elem_scale.unsqueeze(2)
+    codes = _quantize_to_fp4_e2m1_rne(x_scaled).view(m, n)
+    codes2 = codes.view(m, n // 2, 2)
+    packed = ((codes2[:, :, 0] & 0x0F) | ((codes2[:, :, 1] & 0x0F) << 4)).contiguous()
+    if use_packed_e4m3:
+        return packed, sf_e4m3.view(torch.uint8).contiguous().view(torch.int32)
+    return packed, sf
+
+
+def unpack_e4m3_sf_from_int(packed_sf: torch.Tensor) -> torch.Tensor:
+    assert packed_sf.dtype == torch.int32
+    return packed_sf.contiguous().view(torch.uint8).view(torch.float8_e4m3fn).float()
 
 
 def transpose_packed_fp4(a: torch.Tensor) -> torch.Tensor:

--- a/tests/test_nvfp4_mega_moe.py
+++ b/tests/test_nvfp4_mega_moe.py
@@ -151,6 +151,13 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     scores = torch.randn((num_tokens, num_experts), dtype=torch.float, device='cuda')
     topk_weights, topk_idx = torch.topk(scores, num_topk, dim=-1, largest=True, sorted=False)
     topk_weights = topk_weights.softmax(dim=-1)
+    if args.routing_hot_rank >= 0:
+        assert args.routing_hot_rank < num_ranks
+        assert num_experts_per_rank >= num_topk
+        first_expert = args.routing_hot_rank * num_experts_per_rank
+        topk_idx = (first_expert + torch.arange(
+            num_topk, dtype=torch.long, device='cuda'
+        )).expand(num_tokens, -1).contiguous()
     if args.masked_ratio > 0:
         rand_mask = torch.rand_like(topk_idx, dtype=torch.float)
         topk_idx.masked_fill_(rand_mask < args.masked_ratio, -1)
@@ -379,6 +386,8 @@ if __name__ == '__main__':
     parser.add_argument('--num-experts', type=int, default=256, help='Number of experts')
     parser.add_argument('--num-topk', type=int, default=8, help='Number of expert selections')
     parser.add_argument('--masked-ratio', type=float, default=0.0, help='Mask some expert selections')
+    parser.add_argument('--routing-hot-rank', type=int, default=-1,
+                        help='Route every token slot to one EP rank to stress ring reuse (-1 disables)')
     parser.add_argument('--fast-math', type=int, default=0, help='Enable fast math (0 or 1, default: 0 for exactness)')
     parser.add_argument('--per-expert-alphas', type=int, default=1,
                         help='Test per-local-expert L1/L2 scales (0 or 1)')

--- a/tests/test_nvfp4_mega_moe.py
+++ b/tests/test_nvfp4_mega_moe.py
@@ -1,0 +1,334 @@
+import argparse
+import os
+import random
+import torch
+import torch.distributed as dist
+from typing import Tuple
+
+import deep_gemm
+from deep_gemm.utils import per_token_cast_to_nvfp4, unpack_e4m3_sf_from_int, cast_back_from_fp4
+from deep_gemm.utils.dist import dist_print, init_dist
+from deep_gemm.testing import bench_kineto, calc_diff
+
+
+def _quantize_weights_to_nvfp4(bf16_weights: torch.Tensor) -> Tuple[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]:
+    # Cast per-expert weights into packed E2M1 with per-16-element E4M3 SF.
+    # Returns `((packed_weights, mn_major_packed_sf), dequantized_weights)`
+    num_groups, n, k = bf16_weights.shape
+    w = torch.empty((num_groups, n, k // 2), device='cuda', dtype=torch.int8)
+    w_sf = torch.empty((num_groups, n, k // 64), device='cuda', dtype=torch.int32)
+    w_dq = torch.empty((num_groups, n, k), device='cuda', dtype=torch.float)
+    for i in range(num_groups):
+        w[i], w_sf[i] = per_token_cast_to_nvfp4(bf16_weights[i], gran_k=16, use_packed_e4m3=True)
+        w_dq[i] = cast_back_from_fp4(w[i], unpack_e4m3_sf_from_int(w_sf[i]).view(n, k // 16), gran_k=16)
+    # The kernel expects TMA-aligned MN-major SF
+    w_sf = w_sf.transpose(-1, -2).contiguous().transpose(-1, -2)
+    return (w, w_sf), w_dq
+
+
+def _reference_expert_ffn(x_dq: torch.Tensor,
+                          w1_dq: torch.Tensor, w2_dq: torch.Tensor,
+                          topk_weights: torch.Tensor,
+                          intermediate_hidden: int,
+                          activation_clamp: float,
+                          l1_alpha: torch.Tensor, l2_alpha: torch.Tensor,
+                          use_l2_input_scale: bool = False) -> Tuple[torch.Tensor, float]:
+    # Mirror the kernel semantics: FP32 GEMM -> BF16 round -> clamp -> SwiGLU (FP32)
+    # -> top-k weight -> NVFP4 quantization -> FP32 GEMM -> BF16 partials.
+    # Returns `(partial, a2_scale)` where `a2_scale` is the down-proj input scale used
+    # for the intermediate NVFP4 requant (1.0 when disabled).
+    h1 = x_dq @ w1_dq.t()
+    gate = (h1[:, :intermediate_hidden] * l1_alpha[0]).bfloat16()
+    up = (h1[:, intermediate_hidden:] * l1_alpha[1]).bfloat16()
+    if activation_clamp is not None and activation_clamp != float('inf'):
+        gate = gate.clamp_max(activation_clamp)
+        up = up.clamp(-activation_clamp, activation_clamp)
+    gate = gate.float()
+    # Unweighted intermediate: the top-k routing weight is applied AFTER L2 (at combine),
+    # not folded in before the NVFP4 requant. Folding it in before would couple the small
+    # per-token weight into the E4M3 block-SF rounding (a systematic error); the kernel and
+    # a standard/flashinfer MoE both apply it post-L2.
+    act = (gate / (1.0 + torch.exp(-gate))) * up.float()
+
+    # Per-expert down-proj input scale (modelopt's `input_scale`), calibrated from the
+    # intermediate amax: normalizes the block SF into E4M3's well-represented range.
+    if use_l2_input_scale:
+        act_amax = act.abs().amax().item()
+        a2_scale = act_amax / (448.0 * 6.0) if act_amax > 0 else 1.0
+    else:
+        a2_scale = None
+
+    # NVFP4 quantization of the intermediate activations (as done by the L1 epilogue)
+    act_packed, act_sf = per_token_cast_to_nvfp4(act, gran_k=16, global_scale=a2_scale)
+    act_dq = cast_back_from_fp4(act_packed, act_sf, gran_k=16)
+    if a2_scale is not None:
+        act_dq = act_dq * a2_scale  # undo the block-SF normalization (folded into L2 alpha in-kernel)
+
+    # L2 GEMM -> BF16 partial (fc2 * l2_alpha), THEN apply the top-k weight post-L2 in FP32
+    # -> BF16 (mirrors the kernel's combine-write scaling); the combine sums in FP32.
+    partial = ((act_dq @ w2_dq.t()) * l2_alpha).bfloat16()
+    weighted = (partial.float() * topk_weights.unsqueeze(1)).bfloat16()
+    return weighted, (a2_scale if a2_scale is not None else 1.0)
+
+
+# noinspection PyShadowingNames
+def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
+    rank_idx, num_ranks, group = init_dist(local_rank, num_local_ranks)
+    torch.manual_seed(rank_idx)
+    random.seed(rank_idx)
+
+    # Settings (defaults follow `nvidia/GLM-5.2-NVFP4` MoE shapes)
+    num_max_tokens_per_rank = args.num_max_tokens_per_rank
+    num_tokens = max(1, args.num_max_tokens_per_rank - random.randint(0, args.num_max_removed_tokens)) \
+        if args.num_tokens == 0 else args.num_tokens
+    hidden, intermediate_hidden = args.hidden, args.intermediate_hidden
+    num_experts, num_topk = args.num_experts, args.num_topk
+    num_experts_per_rank = num_experts // num_ranks
+    activation_clamp = args.activation_clamp
+    assert num_tokens <= num_max_tokens_per_rank
+
+    # Allocate symmetric memory
+    num_shared_experts = args.num_shared_experts
+    buffer = deep_gemm.get_symm_buffer_for_mega_moe(
+        group, num_experts,
+        num_max_tokens_per_rank, num_topk,
+        hidden, intermediate_hidden,
+        num_shared_experts=num_shared_experts,
+        mma_type='fp4xfp4'
+    )
+
+    dist_print('Config:', once_in_node=True)
+    dist_print(f' > MMA: fp4xfp4 (NVFP4 x NVFP4)', once_in_node=True)
+    dist_print(f' > Tokens: {num_tokens}/{num_max_tokens_per_rank}', once_in_node=True)
+    dist_print(f' > Hidden: {hidden}', once_in_node=True)
+    dist_print(f' > Intermediate: {intermediate_hidden}', once_in_node=True)
+    dist_print(f' > Experts: {num_topk}/{num_experts}', once_in_node=True)
+    dist_print(f' > Alphas: {"per-expert" if args.per_expert_alphas else "none"}', once_in_node=True)
+    dist_print(f' > Shared experts: {num_shared_experts} (BF16)', once_in_node=True)
+    dist_print(f' > Buffer: {buffer.buffer.nbytes / 2 ** 30:.3f} GiB', once_in_node=True)
+    dist_print(once_in_node=True)
+
+    # Create inputs
+    x = torch.randn((num_tokens, hidden), dtype=torch.bfloat16, device='cuda')
+    l1_weights_bf16 = 0.1 * torch.randn(
+        (num_experts_per_rank, intermediate_hidden * 2, hidden), dtype=torch.bfloat16, device='cuda')
+    l2_weights_bf16 = 0.1 * torch.randn(
+        (num_experts_per_rank, hidden, intermediate_hidden), dtype=torch.bfloat16, device='cuda')
+    scores = torch.randn((num_tokens, num_experts), dtype=torch.float, device='cuda')
+    topk_weights, topk_idx = torch.topk(scores, num_topk, dim=-1, largest=True, sorted=False)
+    topk_weights = topk_weights.softmax(dim=-1)
+    if args.masked_ratio > 0:
+        rand_mask = torch.rand_like(topk_idx, dtype=torch.float)
+        topk_idx.masked_fill_(rand_mask < args.masked_ratio, -1)
+        topk_weights.masked_fill_(topk_idx < 0, 0)
+
+    # Quantize inputs and weights into NVFP4
+    x_packed, x_sf_packed = per_token_cast_to_nvfp4(x, gran_k=16, use_packed_e4m3=True)
+    x_dq = cast_back_from_fp4(x_packed, unpack_e4m3_sf_from_int(x_sf_packed).view(num_tokens, hidden // 16), gran_k=16)
+    l1_weights, l1_weights_dq = _quantize_weights_to_nvfp4(l1_weights_bf16)
+    l2_weights, l2_weights_dq = _quantize_weights_to_nvfp4(l2_weights_bf16)
+    transformed_l1_weights, transformed_l2_weights = (
+        deep_gemm.transform_weights_for_mega_moe(l1_weights, l2_weights))
+
+    # Optional per-local-expert scales (mirroring modelopt's `weight_scale_2`)
+    if args.per_expert_alphas:
+        l1_alphas = (0.5 + torch.rand((num_experts_per_rank, 2), dtype=torch.float, device='cuda'))
+        l2_alphas = (0.5 + torch.rand((num_experts_per_rank, ), dtype=torch.float, device='cuda'))
+    else:
+        l1_alphas, l2_alphas = None, None
+
+    # Optional BF16 shared expert (not quantized; folded on N for L1, K for L2)
+    if num_shared_experts > 0:
+        shared_intermediate_hidden = intermediate_hidden * num_shared_experts
+        shared_l1_weights = 0.1 * torch.randn(
+            (shared_intermediate_hidden * 2, hidden), dtype=torch.bfloat16, device='cuda')
+        shared_l2_weights = 0.1 * torch.randn(
+            (hidden, shared_intermediate_hidden), dtype=torch.bfloat16, device='cuda')
+        transformed_shared_l1_weights, transformed_shared_l2_weights = (
+            deep_gemm.transform_weights_for_mega_moe(shared_l1_weights, shared_l2_weights))
+    else:
+        shared_l1_weights, shared_l2_weights = None, None
+        transformed_shared_l1_weights, transformed_shared_l2_weights = None, None
+
+    cumulative_local_expert_recv_stats_fused = torch.randint(
+        0, 100, (num_experts_per_rank, ), dtype=torch.int, device='cuda')
+    cumulative_stats_initial = cumulative_local_expert_recv_stats_fused.clone()
+
+    # Per-expert down-proj input scale (`a2_scale`) for the intermediate NVFP4 requant.
+    # Computed by the reference from the intermediate amax, then fed to the kernel so both
+    # use identical scales (mirroring a calibrated static `input_scale`).
+    a2_scales_for_kernel = None
+
+    # Run fused mega MoE
+    # NOTES: copy inputs into the buffer before each call because debug mode zeros the entire buffer
+    def run_fused():
+        buffer.x[:num_tokens].copy_(x_packed.view(torch.uint8))
+        buffer.x_sf[:num_tokens].copy_(x_sf_packed)
+        buffer.topk_idx[:num_tokens].copy_(topk_idx)
+        buffer.topk_weights[:num_tokens].copy_(topk_weights)
+
+        y = torch.empty((num_tokens, hidden), dtype=torch.bfloat16, device='cuda')
+        deep_gemm.fp4_fp4_mega_moe(
+            y=y, l1_weights=transformed_l1_weights, l2_weights=transformed_l2_weights,
+            sym_buffer=buffer,
+            shared_l1_weights=transformed_shared_l1_weights,
+            shared_l2_weights=transformed_shared_l2_weights,
+            x_bf16=x if num_shared_experts > 0 else None,
+            cumulative_local_expert_recv_stats=cumulative_local_expert_recv_stats_fused,
+            activation_clamp=activation_clamp,
+            fast_math=bool(args.fast_math),
+            l1_alphas=l1_alphas, l2_alphas=l2_alphas,
+            a2_scales=a2_scales_for_kernel)
+        return y
+
+    # Torch reference: gather all ranks' tokens, compute the local experts' contributions,
+    # and reduce the (disjoint) BF16 partials across ranks in FP32 (exactly as combine does)
+    def run_reference():
+        nonlocal a2_scales_for_kernel
+        # Gather token counts and inputs
+        counts = torch.zeros(num_ranks, dtype=torch.long, device='cuda')
+        counts[rank_idx] = num_tokens
+        dist.all_reduce(counts, group=group)
+        counts = counts.tolist()
+        offsets = [0]
+        for c in counts:
+            offsets.append(offsets[-1] + c)
+        num_global_tokens = offsets[-1]
+
+        def gather(t, pad_rows):
+            padded = torch.zeros((pad_rows, ) + tuple(t.shape[1:]), dtype=t.dtype, device='cuda')
+            padded[:t.size(0)] = t
+            out = [torch.empty_like(padded) for _ in range(num_ranks)]
+            dist.all_gather(out, padded, group=group)
+            return torch.cat([o[:counts[i]] for i, o in enumerate(out)], dim=0)
+
+        pad_rows = max(counts)
+        g_x_dq = gather(x_dq, pad_rows)
+        g_topk_idx = gather(topk_idx, pad_rows)
+        g_topk_weights = gather(topk_weights, pad_rows)
+
+        # Each (token, slot) pair is written by exactly one rank, so a FP32 all-reduce
+        # sums disjoint contributions exactly
+        partials = torch.zeros((num_global_tokens, num_topk, hidden), dtype=torch.float, device='cuda')
+        num_recv_per_expert = torch.zeros((num_experts_per_rank, ), dtype=torch.int, device='cuda')
+        use_a2 = bool(args.per_expert_a2)
+        a2_scales = torch.ones((num_experts_per_rank, ), dtype=torch.float, device='cuda') if use_a2 else None
+        for local_e in range(num_experts_per_rank):
+            global_e = rank_idx * num_experts_per_rank + local_e
+            token_sel, slot_sel = (g_topk_idx == global_e).nonzero(as_tuple=True)
+            num_recv_per_expert[local_e] = token_sel.numel()
+            if token_sel.numel() == 0:
+                continue
+            ones2 = torch.ones(2, device='cuda')
+            partial, a2 = _reference_expert_ffn(
+                g_x_dq[token_sel],
+                l1_weights_dq[local_e], l2_weights_dq[local_e],
+                g_topk_weights[token_sel, slot_sel],
+                intermediate_hidden, activation_clamp,
+                l1_alphas[local_e] if l1_alphas is not None else ones2,
+                l2_alphas[local_e] if l2_alphas is not None else ones2[0],
+                use_l2_input_scale=use_a2)
+            partials[token_sel, slot_sel] = partial.float()
+            if use_a2:
+                a2_scales[local_e] = a2
+        dist.all_reduce(partials, group=group)
+        a2_scales_for_kernel = a2_scales
+
+        # Combine: FP32 sum of BF16 partials, cast into BF16
+        y_local = partials[offsets[rank_idx]: offsets[rank_idx] + num_tokens].sum(dim=1)
+
+        # BF16 shared expert on the local tokens (mirror the kernel: FP32 GEMM accumulate
+        # -> BF16 gate/up round -> clamp -> SwiGLU in FP32 -> BF16 intermediate
+        # -> FP32 GEMM accumulate -> BF16 partial summed by the combine in FP32)
+        if num_shared_experts > 0:
+            sih = intermediate_hidden * num_shared_experts
+            h1 = x.float() @ shared_l1_weights.float().t()
+            gate, up = h1[:, :sih].bfloat16(), h1[:, sih:].bfloat16()
+            if activation_clamp is not None and activation_clamp != float('inf'):
+                gate = gate.clamp_max(activation_clamp)
+                up = up.clamp(-activation_clamp, activation_clamp)
+            gate = gate.float()
+            act = ((gate / (1.0 + torch.exp(-gate))) * up.float()).bfloat16()
+            shared_partial = (act.float() @ shared_l2_weights.float().t()).bfloat16()
+            y_local = y_local + shared_partial.float()
+
+        y_ref = y_local.bfloat16()
+        return y_ref, num_recv_per_expert
+
+    # Correctness
+    dist_print('Running correctness tests:', once_in_node=True)
+    y_ref, num_recv_per_expert = run_reference()
+    for i in range(args.num_correctness_tests):
+        y_fused = run_fused()
+        diff = calc_diff(y_fused, y_ref)
+        max_abs_diff = (y_fused.float() - y_ref.float()).abs().max().item()
+        if diff >= 1e-3 and int(os.getenv('DG_TEST_DEBUG', '0')):
+            err = (y_fused.float() - y_ref.float()).abs().max(dim=1).values
+            bad = (err > 1.0).nonzero().flatten()
+            print(f'DBG rank {rank_idx}: bad tokens {bad.numel()}/{num_tokens}, '
+                  f'first {bad[:24].tolist()}', flush=True)
+            if bad.numel() > 0:
+                t = int(bad[0].item())
+                col_err = (y_fused[t].float() - y_ref[t].float()).abs()
+                bad_cols = (col_err > 1.0).nonzero().flatten()
+                print(f'DBG rank {rank_idx}: token {t} bad cols {bad_cols.numel()}/{hidden}, '
+                      f'first {bad_cols[:16].tolist()}', flush=True)
+        assert diff < 1e-3, f'Rank {rank_idx}: diff {diff} is too large (max abs {max_abs_diff})'
+        dist.barrier()
+        if i == 0:
+            dist_print(f' > Output diff: {diff:.3e} (max abs diff: {max_abs_diff:.3e})')
+
+    # Check cumulative stats: `num_correctness_tests` accumulations over the initial values
+    expected_stats = cumulative_stats_initial + args.num_correctness_tests * num_recv_per_expert
+    assert torch.equal(cumulative_local_expert_recv_stats_fused, expected_stats), \
+        f'Rank {rank_idx}: cumulative stats mismatch'
+    dist_print(' > All correctness tests passed', once_in_node=True)
+    dist_print(once_in_node=True)
+
+    # Benchmark
+    t_fused = bench_kineto(run_fused, 'mega_moe', barrier=lambda: dist.barrier())
+
+    # Count locally received tokens for FLOP statistics
+    num_recv_tokens = num_recv_per_expert.sum().item()
+    safe_div = lambda a, b: float('nan') if b == 0 else a / b
+    tflops = safe_div(2 * num_recv_tokens * (hidden * intermediate_hidden * 3) / 1e12, t_fused)
+    dist_print('Performance:', once_in_node=True)
+    dist_print(f' > EP: {rank_idx:2}/{num_ranks} | {tflops:4.0f} TFLOPS | {t_fused * 1e6:4.0f} us')
+
+    # Exit
+    dist.barrier()
+    buffer.destroy()
+    dist.destroy_process_group()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Test NVFP4 x NVFP4 Mega MoE')
+
+    # Resource settings
+    parser.add_argument('--num-processes', type=int, default=4, help='Number of processes to spawn (default: 4)')
+
+    # Model settings: defaults follow `nvidia/GLM-5.2-NVFP4`
+    # (hidden 6144, MoE intermediate 2048, 256 routed experts, top-8, NVFP4 with group size 16)
+    parser.add_argument('--num-max-tokens-per-rank', type=int, default=1536, help='Number of maximum tokens per rank')
+    parser.add_argument('--num-tokens', type=int, default=0, help='Number of tokens per rank (follow max minus removed if 0)')
+    parser.add_argument('--num-max-removed-tokens', type=int, default=0, help='Maximum number of tokens to remove')
+    parser.add_argument('--hidden', type=int, default=6144, help='Hidden size')
+    parser.add_argument('--intermediate-hidden', type=int, default=2048, help='MoE intermediate hidden size')
+    parser.add_argument('--activation-clamp', type=float, default=10, help='Clamp value for activation')
+    parser.add_argument('--num-experts', type=int, default=256, help='Number of experts')
+    parser.add_argument('--num-topk', type=int, default=8, help='Number of expert selections')
+    parser.add_argument('--masked-ratio', type=float, default=0.0, help='Mask some expert selections')
+    parser.add_argument('--fast-math', type=int, default=0, help='Enable fast math (0 or 1, default: 0 for exactness)')
+    parser.add_argument('--per-expert-alphas', type=int, default=0,
+                        help='Test per-local-expert L1/L2 scales (0 or 1)')
+    parser.add_argument('--per-expert-a2', type=int, default=0,
+                        help='Test per-local-expert down-proj input scale for the intermediate '
+                             'NVFP4 requant (0 or 1)')
+    parser.add_argument('--num-shared-experts', type=int, default=0,
+                        help='Number of fused BF16 shared experts (0 disables)')
+
+    # Test settings
+    parser.add_argument('--num-correctness-tests', type=int, default=4, help='Number of correctness test rounds')
+    args = parser.parse_args()
+
+    torch.multiprocessing.spawn(test, args=(args.num_processes, args), nprocs=args.num_processes)

--- a/tests/test_nvfp4_mega_moe.py
+++ b/tests/test_nvfp4_mega_moe.py
@@ -3,12 +3,43 @@ import os
 import random
 import torch
 import torch.distributed as dist
-from typing import Tuple
+from typing import Optional, Tuple
 
 import deep_gemm
-from deep_gemm.utils import per_token_cast_to_nvfp4, unpack_e4m3_sf_from_int, cast_back_from_fp4
+from deep_gemm.utils import cast_back_from_fp4
 from deep_gemm.utils.dist import dist_print, init_dist
 from deep_gemm.testing import bench_kineto, calc_diff
+
+
+def _quantize_to_fp4_e2m1_rne(x: torch.Tensor) -> torch.Tensor:
+    # Match `cvt.rn.satfinite.e2m1x2.f32` on the E2M1 grid.
+    ax = x.abs()
+    code = torch.zeros_like(x, dtype=torch.uint8)
+    for boundary in (0.25, 1.25, 2.5, 5.0):
+        code += (ax > boundary).to(torch.uint8)
+    for boundary in (0.75, 1.75, 3.5):
+        code += (ax >= boundary).to(torch.uint8)
+    code |= (((x < 0) & (code != 0)).to(torch.uint8) << 3)
+    return code.view(torch.int8)
+
+
+def _cast_to_nvfp4(x: torch.Tensor, global_scale: Optional[float] = None,
+                    pack_sf: bool = False) -> Tuple[torch.Tensor, torch.Tensor]:
+    gran_k = 16
+    m, n = x.shape
+    assert n % (gran_k * 4) == 0
+    blocks = x.float().view(m, n // gran_k, gran_k)
+    inv_global = 1.0 if global_scale is None else 1.0 / global_scale
+    sf_e4m3 = (blocks.abs().amax(dim=2) / 6.0 * inv_global).clamp_min(2.0 ** -9).to(torch.float8_e4m3fn)
+    sf = sf_e4m3.float()
+    elem_scale = sf if global_scale is None else sf * global_scale
+    codes = _quantize_to_fp4_e2m1_rne(blocks / elem_scale.unsqueeze(2)).view(m, n // 2, 2)
+    packed = ((codes[:, :, 0] & 0x0F) | ((codes[:, :, 1] & 0x0F) << 4)).contiguous()
+    return (packed, sf_e4m3.view(torch.uint8).contiguous().view(torch.int32)) if pack_sf else (packed, sf)
+
+
+def _unpack_sf(packed_sf: torch.Tensor) -> torch.Tensor:
+    return packed_sf.contiguous().view(torch.uint8).view(torch.float8_e4m3fn).float()
 
 
 def _quantize_weights_to_nvfp4(bf16_weights: torch.Tensor) -> Tuple[Tuple[torch.Tensor, torch.Tensor], torch.Tensor]:
@@ -19,8 +50,8 @@ def _quantize_weights_to_nvfp4(bf16_weights: torch.Tensor) -> Tuple[Tuple[torch.
     w_sf = torch.empty((num_groups, n, k // 64), device='cuda', dtype=torch.int32)
     w_dq = torch.empty((num_groups, n, k), device='cuda', dtype=torch.float)
     for i in range(num_groups):
-        w[i], w_sf[i] = per_token_cast_to_nvfp4(bf16_weights[i], gran_k=16, use_packed_e4m3=True)
-        w_dq[i] = cast_back_from_fp4(w[i], unpack_e4m3_sf_from_int(w_sf[i]).view(n, k // 16), gran_k=16)
+        w[i], w_sf[i] = _cast_to_nvfp4(bf16_weights[i], pack_sf=True)
+        w_dq[i] = cast_back_from_fp4(w[i], _unpack_sf(w_sf[i]).view(n, k // 16), gran_k=16)
     # The kernel expects TMA-aligned MN-major SF
     w_sf = w_sf.transpose(-1, -2).contiguous().transpose(-1, -2)
     return (w, w_sf), w_dq
@@ -59,7 +90,7 @@ def _reference_expert_ffn(x_dq: torch.Tensor,
         a2_scale = None
 
     # NVFP4 quantization of the intermediate activations (as done by the L1 epilogue)
-    act_packed, act_sf = per_token_cast_to_nvfp4(act, gran_k=16, global_scale=a2_scale)
+    act_packed, act_sf = _cast_to_nvfp4(act, global_scale=a2_scale)
     act_dq = cast_back_from_fp4(act_packed, act_sf, gran_k=16)
     if a2_scale is not None:
         act_dq = act_dq * a2_scale  # undo the block-SF normalization (folded into L2 alpha in-kernel)
@@ -124,8 +155,8 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
         topk_weights.masked_fill_(topk_idx < 0, 0)
 
     # Quantize inputs and weights into NVFP4
-    x_packed, x_sf_packed = per_token_cast_to_nvfp4(x, gran_k=16, use_packed_e4m3=True)
-    x_dq = cast_back_from_fp4(x_packed, unpack_e4m3_sf_from_int(x_sf_packed).view(num_tokens, hidden // 16), gran_k=16)
+    x_packed, x_sf_packed = _cast_to_nvfp4(x, pack_sf=True)
+    x_dq = cast_back_from_fp4(x_packed, _unpack_sf(x_sf_packed).view(num_tokens, hidden // 16), gran_k=16)
     l1_weights, l1_weights_dq = _quantize_weights_to_nvfp4(l1_weights_bf16)
     l2_weights, l2_weights_dq = _quantize_weights_to_nvfp4(l2_weights_bf16)
     transformed_l1_weights, transformed_l2_weights = (

--- a/tests/test_nvfp4_mega_moe.py
+++ b/tests/test_nvfp4_mega_moe.py
@@ -110,8 +110,10 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
 
     # Settings (defaults follow `nvidia/GLM-5.2-NVFP4` MoE shapes)
     num_max_tokens_per_rank = args.num_max_tokens_per_rank
-    num_tokens = max(1, args.num_max_tokens_per_rank - random.randint(0, args.num_max_removed_tokens)) \
-        if args.num_tokens == 0 else args.num_tokens
+    num_tokens = args.num_max_tokens_per_rank - random.randint(0, args.num_max_removed_tokens) \
+        if args.num_tokens < 0 else args.num_tokens
+    if args.zero_token_rank == rank_idx:
+        num_tokens = 0
     hidden, intermediate_hidden = args.hidden, args.intermediate_hidden
     num_experts, num_topk = args.num_experts, args.num_topk
     num_experts_per_rank = num_experts // num_ranks
@@ -302,13 +304,18 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     y_ref, num_recv_per_expert = run_reference()
     for i in range(args.num_correctness_tests):
         y_fused = run_fused()
-        diff = calc_diff(y_fused, y_ref)
-        error = y_fused.float() - y_ref.float()
-        max_abs_diff = error.abs().max().item()
-        relative_l2 = (
-            torch.linalg.vector_norm(error)
-            / torch.linalg.vector_norm(y_ref.float()).clamp_min(1e-12)
-        ).item()
+        if y_ref.numel() == 0:
+            assert y_fused.shape == y_ref.shape
+            diff = max_abs_diff = relative_l2 = 0.0
+            error = y_fused.float() - y_ref.float()
+        else:
+            diff = calc_diff(y_fused, y_ref)
+            error = y_fused.float() - y_ref.float()
+            max_abs_diff = error.abs().max().item()
+            relative_l2 = (
+                torch.linalg.vector_norm(error)
+                / torch.linalg.vector_norm(y_ref.float()).clamp_min(1e-12)
+            ).item()
         if diff >= 1e-3 and int(os.getenv('DG_TEST_DEBUG', '0')):
             err = (y_fused.float() - y_ref.float()).abs().max(dim=1).values
             bad = (err > 1.0).nonzero().flatten()
@@ -360,8 +367,11 @@ if __name__ == '__main__':
 
     # Model settings: defaults follow `nvidia/GLM-5.2-NVFP4`
     # (hidden 6144, MoE intermediate 2048, 256 routed experts, top-8, NVFP4 with group size 16)
-    parser.add_argument('--num-max-tokens-per-rank', type=int, default=1536, help='Number of maximum tokens per rank')
-    parser.add_argument('--num-tokens', type=int, default=0, help='Number of tokens per rank (follow max minus removed if 0)')
+    parser.add_argument('--num-max-tokens-per-rank', type=int, default=64, help='Number of maximum tokens per rank')
+    parser.add_argument('--num-tokens', type=int, default=16,
+                        help='Number of tokens per rank (negative follows max minus removed)')
+    parser.add_argument('--zero-token-rank', type=int, default=-1,
+                        help='Force one EP rank to receive zero tokens (-1 disables)')
     parser.add_argument('--num-max-removed-tokens', type=int, default=0, help='Maximum number of tokens to remove')
     parser.add_argument('--hidden', type=int, default=6144, help='Hidden size')
     parser.add_argument('--intermediate-hidden', type=int, default=2048, help='MoE intermediate hidden size')
@@ -370,12 +380,12 @@ if __name__ == '__main__':
     parser.add_argument('--num-topk', type=int, default=8, help='Number of expert selections')
     parser.add_argument('--masked-ratio', type=float, default=0.0, help='Mask some expert selections')
     parser.add_argument('--fast-math', type=int, default=0, help='Enable fast math (0 or 1, default: 0 for exactness)')
-    parser.add_argument('--per-expert-alphas', type=int, default=0,
+    parser.add_argument('--per-expert-alphas', type=int, default=1,
                         help='Test per-local-expert L1/L2 scales (0 or 1)')
-    parser.add_argument('--per-expert-a2', type=int, default=0,
+    parser.add_argument('--per-expert-a2', type=int, default=1,
                         help='Test per-local-expert down-proj input scale for the intermediate '
                              'NVFP4 requant (0 or 1)')
-    parser.add_argument('--num-shared-experts', type=int, default=0,
+    parser.add_argument('--num-shared-experts', type=int, default=1,
                         help='Number of fused BF16 shared experts (0 disables)')
     parser.add_argument('--seed', type=int, default=0, help='Base random seed')
     parser.add_argument('--input-scale', type=float, default=1.0,
@@ -384,11 +394,11 @@ if __name__ == '__main__':
                         help='Scale applied to routed-expert weight samples')
     parser.add_argument('--shared-weight-scale', type=float, default=0.1,
                         help='Scale applied to shared-expert weight samples')
-    parser.add_argument('--routed-scaling-factor', type=float, default=1.0,
+    parser.add_argument('--routed-scaling-factor', type=float, default=0.75,
                         help='Scale routed BF16 output before adding shared output')
 
     # Test settings
-    parser.add_argument('--num-correctness-tests', type=int, default=4, help='Number of correctness test rounds')
+    parser.add_argument('--num-correctness-tests', type=int, default=2, help='Number of correctness test rounds')
     args = parser.parse_args()
 
     torch.multiprocessing.spawn(test, args=(args.num_processes, args), nprocs=args.num_processes)

--- a/tests/test_nvfp4_mega_moe.py
+++ b/tests/test_nvfp4_mega_moe.py
@@ -130,6 +130,18 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
         mma_type='fp4xfp4'
     )
 
+    # The FP4 API must reject a buffer sliced with another MMA layout before
+    # entering C++; an FP8 buffer may be large enough to pass a byte-size check
+    # while still placing every FP4 input at the wrong offset.
+    buffer.mma_type = 'fp8xfp4'
+    try:
+        deep_gemm.fp4_fp4_mega_moe(None, None, None, buffer)
+        assert False, 'FP4 API accepted an FP8-layout symmetric buffer'
+    except AssertionError as exception:
+        assert 'requires an fp4xfp4 symmetric buffer' in str(exception)
+    finally:
+        buffer.mma_type = 'fp4xfp4'
+
     dist_print('Config:', once_in_node=True)
     dist_print(f' > MMA: fp4xfp4 (NVFP4 x NVFP4)', once_in_node=True)
     dist_print(f' > Tokens: {num_tokens}/{num_max_tokens_per_rank}', once_in_node=True)

--- a/tests/test_nvfp4_mega_moe.py
+++ b/tests/test_nvfp4_mega_moe.py
@@ -8,7 +8,7 @@ from typing import Optional, Tuple
 import deep_gemm
 from deep_gemm.utils import cast_back_from_fp4
 from deep_gemm.utils.dist import dist_print, init_dist
-from deep_gemm.testing import bench_kineto, calc_diff
+from deep_gemm.testing import calc_diff
 
 
 def _quantize_to_fp4_e2m1_rne(x: torch.Tensor) -> torch.Tensor:
@@ -349,16 +349,6 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
         f'Rank {rank_idx}: cumulative stats mismatch'
     dist_print(' > All correctness tests passed', once_in_node=True)
     dist_print(once_in_node=True)
-
-    # Benchmark
-    t_fused = bench_kineto(run_fused, 'mega_moe', barrier=lambda: dist.barrier())
-
-    # Count locally received tokens for FLOP statistics
-    num_recv_tokens = num_recv_per_expert.sum().item()
-    safe_div = lambda a, b: float('nan') if b == 0 else a / b
-    tflops = safe_div(2 * num_recv_tokens * (hidden * intermediate_hidden * 3) / 1e12, t_fused)
-    dist_print('Performance:', once_in_node=True)
-    dist_print(f' > EP: {rank_idx:2}/{num_ranks} | {tflops:4.0f} TFLOPS | {t_fused * 1e6:4.0f} us')
 
     # Exit
     dist.barrier()

--- a/tests/test_nvfp4_mega_moe.py
+++ b/tests/test_nvfp4_mega_moe.py
@@ -136,8 +136,8 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     buffer.mma_type = 'fp8xfp4'
     try:
         deep_gemm.fp4_fp4_mega_moe(None, None, None, buffer)
-        assert False, 'FP4 API accepted an FP8-layout symmetric buffer'
-    except AssertionError as exception:
+        raise AssertionError('FP4 API accepted an FP8-layout symmetric buffer')
+    except ValueError as exception:
         assert 'requires an fp4xfp4 symmetric buffer' in str(exception)
     finally:
         buffer.mma_type = 'fp4xfp4'

--- a/tests/test_nvfp4_mega_moe.py
+++ b/tests/test_nvfp4_mega_moe.py
@@ -74,8 +74,8 @@ def _reference_expert_ffn(x_dq: torch.Tensor,
 # noinspection PyShadowingNames
 def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     rank_idx, num_ranks, group = init_dist(local_rank, num_local_ranks)
-    torch.manual_seed(rank_idx)
-    random.seed(rank_idx)
+    torch.manual_seed(args.seed + rank_idx)
+    random.seed(args.seed + rank_idx)
 
     # Settings (defaults follow `nvidia/GLM-5.2-NVFP4` MoE shapes)
     num_max_tokens_per_rank = args.num_max_tokens_per_rank
@@ -109,10 +109,11 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     dist_print(once_in_node=True)
 
     # Create inputs
-    x = torch.randn((num_tokens, hidden), dtype=torch.bfloat16, device='cuda')
-    l1_weights_bf16 = 0.1 * torch.randn(
+    x = args.input_scale * torch.randn(
+        (num_tokens, hidden), dtype=torch.bfloat16, device='cuda')
+    l1_weights_bf16 = args.routed_weight_scale * torch.randn(
         (num_experts_per_rank, intermediate_hidden * 2, hidden), dtype=torch.bfloat16, device='cuda')
-    l2_weights_bf16 = 0.1 * torch.randn(
+    l2_weights_bf16 = args.routed_weight_scale * torch.randn(
         (num_experts_per_rank, hidden, intermediate_hidden), dtype=torch.bfloat16, device='cuda')
     scores = torch.randn((num_tokens, num_experts), dtype=torch.float, device='cuda')
     topk_weights, topk_idx = torch.topk(scores, num_topk, dim=-1, largest=True, sorted=False)
@@ -140,9 +141,9 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     # Optional BF16 shared expert (not quantized; folded on N for L1, K for L2)
     if num_shared_experts > 0:
         shared_intermediate_hidden = intermediate_hidden * num_shared_experts
-        shared_l1_weights = 0.1 * torch.randn(
+        shared_l1_weights = args.shared_weight_scale * torch.randn(
             (shared_intermediate_hidden * 2, hidden), dtype=torch.bfloat16, device='cuda')
-        shared_l2_weights = 0.1 * torch.randn(
+        shared_l2_weights = args.shared_weight_scale * torch.randn(
             (hidden, shared_intermediate_hidden), dtype=torch.bfloat16, device='cuda')
         transformed_shared_l1_weights, transformed_shared_l2_weights = (
             deep_gemm.transform_weights_for_mega_moe(shared_l1_weights, shared_l2_weights))
@@ -178,7 +179,8 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
             activation_clamp=activation_clamp,
             fast_math=bool(args.fast_math),
             l1_alphas=l1_alphas, l2_alphas=l2_alphas,
-            a2_scales=a2_scales_for_kernel)
+            a2_scales=a2_scales_for_kernel,
+            routed_scaling_factor=args.routed_scaling_factor)
         return y
 
     # Torch reference: gather all ranks' tokens, compute the local experts' contributions,
@@ -234,8 +236,17 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
         dist.all_reduce(partials, group=group)
         a2_scales_for_kernel = a2_scales
 
-        # Combine: FP32 sum of BF16 partials, cast into BF16
-        y_local = partials[offsets[rank_idx]: offsets[rank_idx] + num_tokens].sum(dim=1)
+        # Match vLLM's serial ordering exactly: reduce routed BF16 partials in
+        # FP32, cast routed output to BF16, apply routed scaling and round to
+        # BF16 again, then add the BF16 shared result.
+        y_local = partials[
+            offsets[rank_idx]: offsets[rank_idx] + num_tokens
+        ].sum(dim=1).bfloat16()
+        if args.routed_scaling_factor != 1.0:
+            y_local = (
+                y_local.float() * args.routed_scaling_factor
+            ).bfloat16()
+        y_local = y_local.float()
 
         # BF16 shared expert on the local tokens (mirror the kernel: FP32 GEMM accumulate
         # -> BF16 gate/up round -> clamp -> SwiGLU in FP32 -> BF16 intermediate
@@ -261,7 +272,12 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
     for i in range(args.num_correctness_tests):
         y_fused = run_fused()
         diff = calc_diff(y_fused, y_ref)
-        max_abs_diff = (y_fused.float() - y_ref.float()).abs().max().item()
+        error = y_fused.float() - y_ref.float()
+        max_abs_diff = error.abs().max().item()
+        relative_l2 = (
+            torch.linalg.vector_norm(error)
+            / torch.linalg.vector_norm(y_ref.float()).clamp_min(1e-12)
+        ).item()
         if diff >= 1e-3 and int(os.getenv('DG_TEST_DEBUG', '0')):
             err = (y_fused.float() - y_ref.float()).abs().max(dim=1).values
             bad = (err > 1.0).nonzero().flatten()
@@ -274,9 +290,13 @@ def test(local_rank: int, num_local_ranks: int, args: argparse.Namespace):
                 print(f'DBG rank {rank_idx}: token {t} bad cols {bad_cols.numel()}/{hidden}, '
                       f'first {bad_cols[:16].tolist()}', flush=True)
         assert diff < 1e-3, f'Rank {rank_idx}: diff {diff} is too large (max abs {max_abs_diff})'
+        assert relative_l2 < 2e-2, (
+            f'Rank {rank_idx}: relative L2 {relative_l2} is too large '
+            f'(max abs {max_abs_diff})')
         dist.barrier()
         if i == 0:
-            dist_print(f' > Output diff: {diff:.3e} (max abs diff: {max_abs_diff:.3e})')
+            dist_print(f' > Output diff: {diff:.3e} (relative L2: {relative_l2:.3e}, '
+                       f'max abs diff: {max_abs_diff:.3e})')
 
     # Check cumulative stats: `num_correctness_tests` accumulations over the initial values
     expected_stats = cumulative_stats_initial + args.num_correctness_tests * num_recv_per_expert
@@ -326,6 +346,15 @@ if __name__ == '__main__':
                              'NVFP4 requant (0 or 1)')
     parser.add_argument('--num-shared-experts', type=int, default=0,
                         help='Number of fused BF16 shared experts (0 disables)')
+    parser.add_argument('--seed', type=int, default=0, help='Base random seed')
+    parser.add_argument('--input-scale', type=float, default=1.0,
+                        help='Scale applied to BF16 input samples')
+    parser.add_argument('--routed-weight-scale', type=float, default=0.1,
+                        help='Scale applied to routed-expert weight samples')
+    parser.add_argument('--shared-weight-scale', type=float, default=0.1,
+                        help='Scale applied to shared-expert weight samples')
+    parser.add_argument('--routed-scaling-factor', type=float, default=1.0,
+                        help='Scale routed BF16 output before adding shared output')
 
     # Test settings
     parser.add_argument('--num-correctness-tests', type=int, default=4, help='Number of correctness test rounds')


### PR DESCRIPTION
## Summary

- Add a dedicated SM100 NVFP4 x NVFP4 MegaMoE kernel.
- Fuse the optional BF16 shared expert into the same persistent MegaMoE kernel.
- Apply routed scaling after the routed top-k reduction and before adding the shared-expert output.
- Preserve ModelOpt NVFP4 scales without affecting the existing BF16 or FP8 x FP4 MegaMoE paths.

## Design highlights

- **Native NVFP4 routed path.** Both routed activations and weights use packed E2M1 data with per-16-element E4M3 scale factors. This requires a bit-aware symmetric-buffer layout, NVFP4-specific TMA/UTCCP handling, and an in-kernel L1 requantization epilogue.

- **Post-L2 top-k weighting.** Top-k routing weights are stored in a new NVFP4-specific buffer and applied to the BF16 routed output after L2, immediately before the combine write. Applying top-k weights directly in the L1 epilogue can reduce the intermediate magnitude before NVFP4 quantization and introduce additional precision loss.

- **ModelOpt scale handling.** Per-expert gate/up scales are applied before SwiGLU. The down-projection input scale normalizes the in-kernel NVFP4 intermediate quantization and is folded back into the L2 output scale: `l2_scale = l2_alpha * a2_scale`.

- **Correct routed/shared ordering.** The kernel accumulates the routed top-k outputs, rounds the routed sum to BF16, applies `routed_scaling_factor`, and then adds the BF16 shared-expert output.

- **BF16 shared expert inside MegaMoE.** Optional BF16 shared L1 and L2 work is inserted into the existing scheduler as `SharedLinear1` and `SharedLinear2` phases. These tasks reuse the existing TMA-load, MMA, and epilogue warp roles; shared computation uses ordinary BF16 UMMA without scale factors or UTCCP.

- **Separate shared K tiling.** Routed NVFP4 and shared BF16 tasks reuse the same shared-memory byte tiles but contain different numbers of elements, so `SHARED_BLOCK_K` describes the BF16 K extent independently from the routed NVFP4 K extent.

- **Fused shared epilogues.** Shared L1 applies SwiGLU and stores a BF16 intermediate. Shared L2 writes to an additional local combine slot, allowing the final combine phase to perform routed scaling and the shared add without separate shared-expert launches.

- **Compatibility.** The new NVFP4 path does not affect the existing BF16 or FP8 x FP4 MegaMoE paths.

## Validation

| Test | Result |
|---|---:|
| Boundary/adversarial accuracy, 42 cases | PASS; max rel-L2 0.005421 |
| Random fuzz, 22 cases | PASS; max rel-L2 0.002655 |
| Shared-only accuracy, 10 cases | PASS; max rel-L2 0.001134 |
| GLM-5.2 layer replay, 75 layers | PASS; fused closer to FP32 in 69/75 |
| GLM-5.2 deterministic E2E, 0/8K context | PASS; serial 32/32, fused 32/32 |
| Clean GB300 build and 4-rank correctness | PASS; max rel-L2 0.001315 |

## Performance

Pure CUDA-kernel time on 8x GB300 with EP8. All three arms have the same BF16-input to BF16-output model boundary and include routed computation, dispatch/combine, routed scaling, the BF16 shared expert, and the final add.

- **FlashInfer modular baseline:** FlashInfer one-sided All-to-All dispatch -> TRT-LLM NVFP4 routed experts -> FlashInfer one-sided All-to-All combine -> routed scaling -> serial DeepGEMM BF16 shared expert -> add. This arm does not call MegaMoE. Optimized FlashInfer configurations are used, and the NVFP4 expert tactic is autotuned independently for each workload size. For each M, the table reports the lowest audited latency among runs with the correct tactic and identical timing boundary.
- **DG unfused:** routed-only `sm100_fp4_fp4_mega_moe` -> routed scaling -> serial DeepGEMM BF16 shared expert -> add.
- **DG fused:** one `sm100_fp4_fp4_mega_moe` kernel containing the routed path, routed scaling, BF16 shared expert, and final add.


| M/rank | FlashInfer modular, no MegaMoE (us) | DG routed-only + serial shared (us) | DG fused shared (us) | Fused vs FI | Fusion gain |
|---:|---:|---:|---:|---:|---:|
| 1 | 132.064 | 131.584 | 105.504 | 20.11% | 19.82% |
| 2 | 154.096 | 146.608 | 124.784 | 19.02% | 14.89% |
| 4 | 168.720 | 164.816 | 140.464 | 16.75% | 14.78% |
| 8 | 189.232 | 183.104 | 160.512 | 15.18% | 12.34% |
| 16 | 199.360 | 190.528 | 166.672 | 16.40% | 12.52% |
| 32 | 203.792 | 192.400 | 168.464 | 17.34% | 12.44% |
| 64 | 209.184 | 195.232 | 171.200 | 18.16% | 12.31% |
| 128 | 257.328 | 203.536 | 179.216 | 30.36% | 11.95% |
| 256 | 268.633 | 221.920 | 190.960 | 28.91% | 13.95% |
| 512 | 346.718 | 275.192 | 234.177 | 32.46% | 14.90% |
| 1024 | 539.041 | 417.849 | 365.346 | 32.22% | 12.57% |
| 2048 | 918.737 | 690.976 | 604.784 | 34.17% | 12.47% |
| 4096 | 1721.712 | 1400.384 | 1248.720 | 27.47% | 10.83% |
| 8192 | 3345.690 | 2539.136 | 2218.608 | 33.69% | 12.62% |
| 16384 | 6559.996 | 5400.112 | 4871.792 | 25.73% | 9.78% |

`Fusion gain` compares the two DeepGEMM arms. `Fused vs FI` compares against the modular, non-MegaMoE FlashInfer baseline.

<details>
<summary>Complete test recipe</summary>

### Revisions and environment

- Hardware: 8x GB300, two hosts x four GPUs, EP8
- CUDA 13, PyTorch `2.13.0+cu130`, vLLM `0.17.2rc1.dev4473+g3ada0d7f1`, FlashInfer `0.6.16rc5`

### Build and correctness

```bash

CUDA_VISIBLE_DEVICES=0,1,2,3 \
python tests/test_nvfp4_mega_moe.py \
  --num-processes 4 \
  --num-max-tokens-per-rank 128 \
  --num-tokens 128 \
  --hidden 6144 \
  --intermediate-hidden 2048 \
  --num-experts 256 \
  --num-topk 8 \
  --num-shared-experts 1 \
  --per-expert-alphas 1 \
  --per-expert-a2 1 \
  --routed-scaling-factor 0.75 \
  --num-correctness-tests 2
```

The boundary, zero-token, masked-routing, and shared-only cases use the same command with the corresponding `--num-tokens`, `--zero-token-rank`, `--masked-ratio`, `--routing-hot-rank`, and `--num-shared-experts` settings.

### Performance shape and inputs

- Hidden size: `6144`
- Routed/shared intermediate size: `2048`
- Routed experts: `256`; top-k: `8`; BF16 shared experts: `1`
- Routed scaling factor: `0.75`
- M/rank: `1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384`
- Symmetric-buffer token capacity per rank: `16512`
- Deterministic seed: `20260811`
- All arms use identical BF16 inputs, top-k metadata, ModelOpt NVFP4 weights/scales, and BF16 shared weights.
- Data generation, weight conversion, JIT compilation, and backend autotuning are completed before measurement.

### Timed call graphs

```text
FI modular:
  BF16->NVFP4 quantization
  -> FlashInfer one-sided dispatch prepare/sanitize/dispatch
  -> TRT-LLM routing + NVFP4 BMM1 + NVFP4 BMM2 + finalize
  -> FlashInfer combine prepare/combine
  -> routed BF16 scale
  -> DeepGEMM BF16 shared L1 + SwiGLU + BF16 shared L2
  -> BF16 add

DG unfused:
  routed-only sm100_fp4_fp4_mega_moe
  -> routed BF16 scale
  -> DeepGEMM BF16 shared L1 + SwiGLU + BF16 shared L2
  -> BF16 add

DG fused:
  sm100_fp4_fp4_mega_moe with routed scaling and BF16 shared expert enabled
```

### Timing

- Timing follows `deep_gemm.testing.bench_kineto` and reports selected CUDA-kernel time only.
- Perform five untimed warmup calls before profiling.
- Use Kineto schedule `wait=0, warmup=1, active=1` with 30 calls in the measured phase.
- Before each measured call, evict L2 with the repository benchmark's 8 GB eviction buffer. Eviction, CUDA sleep, distributed barriers, CPU launch gaps, router/top-k selection, data generation, weight conversion, JIT compilation, and autotuning are excluded.
- FI backend-internal quantization, routing, dispatch, expert, finalize, and combine CUDA kernels are included.
- Sum the selected CUDA rows per rank and report the maximum across all eight ranks.

</details>

