### PR TITLE
[SM100][MegaMoE] Fuse and publish Kimi K3's BF16 shared expert

### DIFF
--- a/csrc/apis/mega.hpp
+++ b/csrc/apis/mega.hpp
@@ -600,6 +600,8 @@ static void fp8_fp4_mega_moe_bf16_shared(
         DG_HOST_ASSERT(shared_rs_workspace.size(1) >= num_tokens);
         DG_HOST_ASSERT(shared_rs_workspace.size(2) == static_cast<int64_t>(sym_buffer_ptrs.size()));
         DG_HOST_ASSERT(shared_rs_workspace.size(3) * shared_rs_workspace.size(2) == shared_hidden);
+        // Cross-repository ABI with the ReduceScatter consumer: flags[0] is
+        // the generation index and flags[2] is the byte stride per generation.
         DG_HOST_ASSERT(shared_rs_flags.is_cuda());
         DG_HOST_ASSERT(shared_rs_flags.scalar_type() == torch::kInt);
         DG_HOST_ASSERT(shared_rs_flags.is_contiguous() and shared_rs_flags.numel() >= 9);

--- a/csrc/apis/mega.hpp
+++ b/csrc/apis/mega.hpp
@@ -514,6 +514,148 @@ static void fp4_fp4_mega_moe(
         sym_buffer.zero_();
 }
 
+static void fp8_fp4_mega_moe_bf16_shared(
+    const torch::Tensor& y,
+    const torch::Tensor& shared_y,
+    const std::tuple<torch::Tensor, torch::Tensor>& l1_weights_tuple,
+    const std::tuple<torch::Tensor, torch::Tensor>& l2_weights_tuple,
+    const torch::Tensor& shared_x,
+    const torch::Tensor& shared_l2_acts,
+    const torch::Tensor& shared_l1_weights,
+    const torch::Tensor& shared_l2_weights,
+    const torch::Tensor& rms_weight,
+    const float& rms_epsilon,
+    const std::optional<torch::Tensor>& cumulative_local_expert_recv_stats,
+    const torch::Tensor& sym_buffer,
+    const std::vector<int64_t>& sym_buffer_ptrs, const int& rank_idx,
+    const int& num_max_tokens_per_rank,
+    const int& num_experts, const int& num_topk,
+    const std::tuple<int, int, int>& recipe,
+    const std::string& activation,
+    const bool& fast_math,
+    const std::optional<float>& situ_beta_opt,
+    const std::optional<float>& situ_linear_beta_opt
+) {
+    const auto [l1_weights, l1_weights_sf] = l1_weights_tuple;
+    const auto [l2_weights, l2_weights_sf] = l2_weights_tuple;
+    const auto num_tokens = static_cast<int>(y.size(0));
+    const auto [rm, rn, rk] = recipe;
+    DG_HOST_ASSERT(rm == 1 and rn == 1 and rk == 32);
+    DG_HOST_ASSERT(activation == "situ");
+    DG_HOST_ASSERT(std::isfinite(rms_epsilon) and rms_epsilon > 0);
+    const auto situ_beta = situ_beta_opt.value_or(0.0f);
+    const auto situ_linear_beta = situ_linear_beta_opt.value_or(0.0f);
+    DG_HOST_ASSERT(std::isfinite(situ_beta) and situ_beta > 0);
+    DG_HOST_ASSERT(std::isfinite(situ_linear_beta) and situ_linear_beta > 0);
+
+    // Routed FP8 x FP4 tensors.
+    DG_HOST_ASSERT(get_major_type_ab(l1_weights) == cute::UMMA::Major::K);
+    DG_HOST_ASSERT(get_major_type_ab(l2_weights) == cute::UMMA::Major::K);
+    const auto arch_major = device_runtime->get_arch_major();
+    const auto [num_experts_per_rank, intermediate_hidden_2, hidden] =
+        check_grouped_ab_fp8_fp4(l1_weights, cute::UMMA::Major::K, arch_major);
+    const auto [num_experts_per_rank_, hidden_, intermediate_hidden] =
+        check_grouped_ab_fp8_fp4(l2_weights, cute::UMMA::Major::K, arch_major);
+    DG_HOST_ASSERT(l1_weights.scalar_type() == kPackedFP4);
+    DG_HOST_ASSERT(l2_weights.scalar_type() == kPackedFP4);
+    DG_HOST_ASSERT(num_tokens <= num_max_tokens_per_rank);
+    DG_HOST_ASSERT(num_experts_per_rank == num_experts_per_rank_);
+    DG_HOST_ASSERT(hidden == hidden_);
+    DG_HOST_ASSERT(intermediate_hidden_2 == 2 * intermediate_hidden);
+    DG_HOST_ASSERT(l1_weights.is_contiguous() and l2_weights.is_contiguous());
+    constexpr int kGranMN = 1, kGranK = 32;
+    check_sf_layout(l1_weights_sf, intermediate_hidden * 2, hidden, kGranMN, kGranK,
+                    num_experts_per_rank, true, false, torch::kInt);
+    check_sf_layout(l2_weights_sf, hidden, intermediate_hidden, kGranMN, kGranK,
+                    num_experts_per_rank, true, false, torch::kInt);
+
+    // Independent BF16 shared expert. Its input/output width intentionally does
+    // not have to match the routed latent width.
+    DG_HOST_ASSERT(y.is_cuda() and y.scalar_type() == torch::kBFloat16 and y.is_contiguous());
+    DG_HOST_ASSERT(y.dim() == 2 and y.size(1) == hidden);
+    DG_HOST_ASSERT(shared_x.is_cuda() and shared_x.scalar_type() == torch::kBFloat16 and shared_x.is_contiguous());
+    DG_HOST_ASSERT(shared_x.dim() == 2 and shared_x.size(0) >= num_tokens);
+    const auto shared_hidden = static_cast<int>(shared_x.size(1));
+    DG_HOST_ASSERT(shared_y.is_cuda() and shared_y.scalar_type() == torch::kBFloat16 and shared_y.is_contiguous());
+    DG_HOST_ASSERT(shared_y.dim() == 2 and shared_y.size(0) == num_tokens and shared_y.size(1) == shared_hidden);
+    DG_HOST_ASSERT(shared_l2_acts.is_cuda() and shared_l2_acts.scalar_type() == torch::kBFloat16 and shared_l2_acts.is_contiguous());
+    DG_HOST_ASSERT(shared_l2_acts.dim() == 2 and shared_l2_acts.size(0) >= num_tokens);
+    const auto shared_intermediate_hidden = static_cast<int>(shared_l2_acts.size(1));
+    DG_HOST_ASSERT(shared_intermediate_hidden > 0);
+    DG_HOST_ASSERT(shared_l1_weights.is_cuda() and shared_l1_weights.scalar_type() == torch::kBFloat16 and shared_l1_weights.is_contiguous());
+    DG_HOST_ASSERT(shared_l2_weights.is_cuda() and shared_l2_weights.scalar_type() == torch::kBFloat16 and shared_l2_weights.is_contiguous());
+    DG_HOST_ASSERT(shared_l1_weights.dim() == 2 and shared_l1_weights.size(0) == shared_intermediate_hidden * 2 and shared_l1_weights.size(1) == shared_hidden);
+    DG_HOST_ASSERT(shared_l2_weights.dim() == 2 and shared_l2_weights.size(0) == shared_hidden and shared_l2_weights.size(1) == shared_intermediate_hidden);
+    DG_HOST_ASSERT(get_major_type_ab(shared_l1_weights) == cute::UMMA::Major::K);
+    DG_HOST_ASSERT(get_major_type_ab(shared_l2_weights) == cute::UMMA::Major::K);
+    DG_HOST_ASSERT(rms_weight.is_cuda() and rms_weight.scalar_type() == torch::kBFloat16 and rms_weight.is_contiguous());
+    DG_HOST_ASSERT(rms_weight.dim() == 1 and rms_weight.size(0) == hidden);
+
+    const auto output_device = y.device();
+    const auto is_local_cuda_tensor = [&output_device](const torch::Tensor& tensor) {
+        return tensor.is_cuda() and tensor.device() == output_device;
+    };
+    DG_HOST_ASSERT(is_local_cuda_tensor(l1_weights) and is_local_cuda_tensor(l2_weights));
+    DG_HOST_ASSERT(is_local_cuda_tensor(l1_weights_sf) and is_local_cuda_tensor(l2_weights_sf));
+    DG_HOST_ASSERT(is_local_cuda_tensor(shared_x) and is_local_cuda_tensor(shared_y));
+    DG_HOST_ASSERT(is_local_cuda_tensor(shared_l2_acts));
+    DG_HOST_ASSERT(is_local_cuda_tensor(shared_l1_weights) and is_local_cuda_tensor(shared_l2_weights));
+    DG_HOST_ASSERT(is_local_cuda_tensor(rms_weight) and is_local_cuda_tensor(sym_buffer));
+
+    if (cumulative_local_expert_recv_stats.has_value()) {
+        DG_HOST_ASSERT(cumulative_local_expert_recv_stats->scalar_type() == torch::kInt);
+        DG_HOST_ASSERT(cumulative_local_expert_recv_stats->numel() == num_experts_per_rank);
+        DG_HOST_ASSERT(cumulative_local_expert_recv_stats->is_contiguous());
+        DG_HOST_ASSERT(is_local_cuda_tensor(cumulative_local_expert_recv_stats.value()));
+    }
+
+    // The BF16 shared intermediate and output are external, so the symmetric
+    // communication buffer only needs routed slots.
+    const auto num_ranks = static_cast<int>(sym_buffer_ptrs.size());
+    const auto [num_required_bytes, slice] = get_symm_buffer_size_for_mega_moe(
+        num_ranks, num_experts,
+        num_max_tokens_per_rank, num_topk,
+        hidden, intermediate_hidden,
+        "fp8xfp4", activation, 0);
+    DG_HOST_ASSERT(sym_buffer.nbytes() >= static_cast<size_t>(num_required_bytes));
+    DG_HOST_ASSERT(num_experts == num_experts_per_rank * num_ranks);
+    const auto [x, x_sf, topk_idx, topk_weights,
+                unused_shared_l1_acts, unused_shared_l1_acts_sf,
+                unused_shared_l2_acts, unused_shared_l2_acts_sf,
+                l1_acts, l1_acts_sf, l2_acts, l2_acts_sf] = slice(sym_buffer);
+
+    if (arch_major == 10) {
+        sm100_fp8_fp4_mega_moe(
+            y,
+            l1_acts, l1_acts_sf,
+            l2_acts, l2_acts_sf,
+            unused_shared_l1_acts, unused_shared_l1_acts_sf,
+            unused_shared_l2_acts, unused_shared_l2_acts_sf,
+            l1_weights, l2_weights,
+            l1_weights_sf, l2_weights_sf,
+            torch::Tensor(), torch::Tensor(), torch::Tensor(), torch::Tensor(),
+            cumulative_local_expert_recv_stats,
+            sym_buffer_ptrs,
+            rank_idx, num_max_tokens_per_rank,
+            num_experts_per_rank,
+            /*num_shared_experts=*/ 1,
+            num_tokens, num_topk,
+            hidden, intermediate_hidden,
+            std::numeric_limits<float>::infinity(), fast_math,
+            /*use_situ=*/ true, situ_beta, situ_linear_beta,
+            shared_x, shared_l2_acts,
+            shared_l1_weights, shared_l2_weights,
+            shared_y, rms_weight, rms_epsilon,
+            /*use_bf16_shared=*/ true,
+            /*apply_rms_norm=*/ true);
+    } else {
+        DG_HOST_UNREACHABLE("Unsupported architecture");
+    }
+
+    if (get_env<int>("DG_COMM_KERNEL_DEBUG"))
+        sym_buffer.zero_();
+}
+
 static void bf16_mega_moe(
     const torch::Tensor& y,
     const torch::Tensor& l1_weights,
@@ -628,6 +770,7 @@ static void register_apis(pybind11::module_& m) {
     m.def("get_block_m_for_mega_moe", &get_block_m_for_mega_moe);
     m.def("get_symm_buffer_size_for_mega_moe", &get_symm_buffer_size_for_mega_moe);
     m.def("fp8_fp4_mega_moe", &fp8_fp4_mega_moe);
+    m.def("fp8_fp4_mega_moe_bf16_shared", &fp8_fp4_mega_moe_bf16_shared);
     m.def("fp4_fp4_mega_moe", &fp4_fp4_mega_moe);
     m.def("bf16_mega_moe", &bf16_mega_moe);
 #endif

--- a/csrc/apis/mega.hpp
+++ b/csrc/apis/mega.hpp
@@ -516,7 +516,7 @@ static void fp4_fp4_mega_moe(
 
 static void fp8_fp4_mega_moe_bf16_shared(
     const torch::Tensor& y,
-    const torch::Tensor& shared_y,
+    const std::optional<torch::Tensor>& shared_y_opt,
     const std::tuple<torch::Tensor, torch::Tensor>& l1_weights_tuple,
     const std::tuple<torch::Tensor, torch::Tensor>& l2_weights_tuple,
     const torch::Tensor& shared_x,
@@ -534,7 +534,10 @@ static void fp8_fp4_mega_moe_bf16_shared(
     const std::string& activation,
     const bool& fast_math,
     const std::optional<float>& situ_beta_opt,
-    const std::optional<float>& situ_linear_beta_opt
+    const std::optional<float>& situ_linear_beta_opt,
+    const std::optional<torch::Tensor>& shared_rs_workspace_opt,
+    const std::optional<torch::Tensor>& shared_rs_flags_opt,
+    const std::optional<torch::Tensor>& shared_rs_peer_ptrs_opt
 ) {
     const auto [l1_weights, l1_weights_sf] = l1_weights_tuple;
     const auto [l2_weights, l2_weights_sf] = l2_weights_tuple;
@@ -576,8 +579,40 @@ static void fp8_fp4_mega_moe_bf16_shared(
     DG_HOST_ASSERT(shared_x.is_cuda() and shared_x.scalar_type() == torch::kBFloat16 and shared_x.is_contiguous());
     DG_HOST_ASSERT(shared_x.dim() == 2 and shared_x.size(0) >= num_tokens);
     const auto shared_hidden = static_cast<int>(shared_x.size(1));
-    DG_HOST_ASSERT(shared_y.is_cuda() and shared_y.scalar_type() == torch::kBFloat16 and shared_y.is_contiguous());
-    DG_HOST_ASSERT(shared_y.dim() == 2 and shared_y.size(0) == num_tokens and shared_y.size(1) == shared_hidden);
+    const auto publish_shared_rs = shared_rs_workspace_opt.has_value();
+    DG_HOST_ASSERT(publish_shared_rs == shared_rs_flags_opt.has_value());
+    DG_HOST_ASSERT(publish_shared_rs == shared_rs_peer_ptrs_opt.has_value());
+    DG_HOST_ASSERT(publish_shared_rs != shared_y_opt.has_value());
+    torch::Tensor shared_y;
+    torch::Tensor shared_rs_workspace;
+    torch::Tensor shared_rs_flags;
+    torch::Tensor shared_rs_peer_ptrs;
+    if (publish_shared_rs) {
+        shared_rs_workspace = shared_rs_workspace_opt.value();
+        shared_rs_flags = shared_rs_flags_opt.value();
+        shared_rs_peer_ptrs = shared_rs_peer_ptrs_opt.value();
+        DG_HOST_ASSERT(shared_hidden % static_cast<int>(sym_buffer_ptrs.size()) == 0);
+        DG_HOST_ASSERT(shared_rs_workspace.is_cuda());
+        DG_HOST_ASSERT(shared_rs_workspace.scalar_type() == torch::kBFloat16);
+        DG_HOST_ASSERT(shared_rs_workspace.is_contiguous());
+        DG_HOST_ASSERT(shared_rs_workspace.dim() == 4);
+        DG_HOST_ASSERT(shared_rs_workspace.size(0) >= 3);
+        DG_HOST_ASSERT(shared_rs_workspace.size(1) >= num_tokens);
+        DG_HOST_ASSERT(shared_rs_workspace.size(2) == static_cast<int64_t>(sym_buffer_ptrs.size()));
+        DG_HOST_ASSERT(shared_rs_workspace.size(3) * shared_rs_workspace.size(2) == shared_hidden);
+        DG_HOST_ASSERT(shared_rs_flags.is_cuda());
+        DG_HOST_ASSERT(shared_rs_flags.scalar_type() == torch::kInt);
+        DG_HOST_ASSERT(shared_rs_flags.is_contiguous() and shared_rs_flags.numel() >= 9);
+        DG_HOST_ASSERT(shared_rs_peer_ptrs.is_cuda());
+        DG_HOST_ASSERT(shared_rs_peer_ptrs.scalar_type() == torch::kInt64);
+        DG_HOST_ASSERT(shared_rs_peer_ptrs.is_contiguous());
+        DG_HOST_ASSERT(shared_rs_peer_ptrs.dim() == 1);
+        DG_HOST_ASSERT(shared_rs_peer_ptrs.numel() == static_cast<int64_t>(sym_buffer_ptrs.size()));
+    } else {
+        shared_y = shared_y_opt.value();
+        DG_HOST_ASSERT(shared_y.is_cuda() and shared_y.scalar_type() == torch::kBFloat16 and shared_y.is_contiguous());
+        DG_HOST_ASSERT(shared_y.dim() == 2 and shared_y.size(0) == num_tokens and shared_y.size(1) == shared_hidden);
+    }
     DG_HOST_ASSERT(shared_l2_acts.is_cuda() and shared_l2_acts.scalar_type() == torch::kBFloat16 and shared_l2_acts.is_contiguous());
     DG_HOST_ASSERT(shared_l2_acts.dim() == 2 and shared_l2_acts.size(0) >= num_tokens);
     const auto shared_intermediate_hidden = static_cast<int>(shared_l2_acts.size(1));
@@ -597,7 +632,11 @@ static void fp8_fp4_mega_moe_bf16_shared(
     };
     DG_HOST_ASSERT(is_local_cuda_tensor(l1_weights) and is_local_cuda_tensor(l2_weights));
     DG_HOST_ASSERT(is_local_cuda_tensor(l1_weights_sf) and is_local_cuda_tensor(l2_weights_sf));
-    DG_HOST_ASSERT(is_local_cuda_tensor(shared_x) and is_local_cuda_tensor(shared_y));
+    DG_HOST_ASSERT(is_local_cuda_tensor(shared_x));
+    DG_HOST_ASSERT(publish_shared_rs ?
+        (is_local_cuda_tensor(shared_rs_workspace) and is_local_cuda_tensor(shared_rs_flags) and
+         is_local_cuda_tensor(shared_rs_peer_ptrs)) :
+        is_local_cuda_tensor(shared_y));
     DG_HOST_ASSERT(is_local_cuda_tensor(shared_l2_acts));
     DG_HOST_ASSERT(is_local_cuda_tensor(shared_l1_weights) and is_local_cuda_tensor(shared_l2_weights));
     DG_HOST_ASSERT(is_local_cuda_tensor(rms_weight) and is_local_cuda_tensor(sym_buffer));
@@ -647,7 +686,9 @@ static void fp8_fp4_mega_moe_bf16_shared(
             shared_l1_weights, shared_l2_weights,
             shared_y, rms_weight, rms_epsilon,
             /*use_bf16_shared=*/ true,
-            /*apply_rms_norm=*/ true);
+            /*apply_rms_norm=*/ true,
+            shared_rs_flags, shared_rs_peer_ptrs,
+            publish_shared_rs);
     } else {
         DG_HOST_UNREACHABLE("Unsupported architecture");
     }

--- a/csrc/apis/mega.hpp
+++ b/csrc/apis/mega.hpp
@@ -537,11 +537,13 @@ static void fp8_fp4_mega_moe_bf16_shared(
     const std::optional<float>& situ_linear_beta_opt,
     const std::optional<torch::Tensor>& shared_rs_workspace_opt,
     const std::optional<torch::Tensor>& shared_rs_flags_opt,
-    const std::optional<torch::Tensor>& shared_rs_peer_ptrs_opt
+    const std::optional<torch::Tensor>& shared_rs_peer_ptrs_opt,
+    const bool& publish_shared_sp_rs
 ) {
     const auto [l1_weights, l1_weights_sf] = l1_weights_tuple;
     const auto [l2_weights, l2_weights_sf] = l2_weights_tuple;
     const auto num_tokens = static_cast<int>(y.size(0));
+    const auto num_shared_tokens = static_cast<int>(shared_x.size(0));
     const auto [rm, rn, rk] = recipe;
     DG_HOST_ASSERT(rm == 1 and rn == 1 and rk == 32);
     DG_HOST_ASSERT(activation == "situ");
@@ -579,6 +581,7 @@ static void fp8_fp4_mega_moe_bf16_shared(
     DG_HOST_ASSERT(shared_x.is_cuda() and shared_x.scalar_type() == torch::kBFloat16 and shared_x.is_contiguous());
     DG_HOST_ASSERT(shared_x.dim() == 2 and shared_x.size(0) >= num_tokens);
     const auto shared_hidden = static_cast<int>(shared_x.size(1));
+    DG_HOST_ASSERT(num_shared_tokens <= num_max_tokens_per_rank);
     const auto publish_shared_rs = shared_rs_workspace_opt.has_value();
     DG_HOST_ASSERT(publish_shared_rs == shared_rs_flags_opt.has_value());
     DG_HOST_ASSERT(publish_shared_rs == shared_rs_peer_ptrs_opt.has_value());
@@ -591,15 +594,21 @@ static void fp8_fp4_mega_moe_bf16_shared(
         shared_rs_workspace = shared_rs_workspace_opt.value();
         shared_rs_flags = shared_rs_flags_opt.value();
         shared_rs_peer_ptrs = shared_rs_peer_ptrs_opt.value();
-        DG_HOST_ASSERT(shared_hidden % static_cast<int>(sym_buffer_ptrs.size()) == 0);
+        const auto num_ranks = static_cast<int>(sym_buffer_ptrs.size());
+        DG_HOST_ASSERT(not publish_shared_sp_rs or num_shared_tokens % num_ranks == 0);
+        DG_HOST_ASSERT(publish_shared_sp_rs or shared_hidden % num_ranks == 0);
         DG_HOST_ASSERT(shared_rs_workspace.is_cuda());
         DG_HOST_ASSERT(shared_rs_workspace.scalar_type() == torch::kBFloat16);
         DG_HOST_ASSERT(shared_rs_workspace.is_contiguous());
         DG_HOST_ASSERT(shared_rs_workspace.dim() == 4);
-        DG_HOST_ASSERT(shared_rs_workspace.size(0) >= 3);
-        DG_HOST_ASSERT(shared_rs_workspace.size(1) >= num_tokens);
+        DG_HOST_ASSERT(shared_rs_workspace.size(0) >=
+                       (publish_shared_sp_rs ? 1 : 3));
+        DG_HOST_ASSERT(shared_rs_workspace.size(1) >=
+                       (publish_shared_sp_rs ? num_shared_tokens / num_ranks : num_shared_tokens));
         DG_HOST_ASSERT(shared_rs_workspace.size(2) == static_cast<int64_t>(sym_buffer_ptrs.size()));
-        DG_HOST_ASSERT(shared_rs_workspace.size(3) * shared_rs_workspace.size(2) == shared_hidden);
+        DG_HOST_ASSERT(publish_shared_sp_rs ?
+            shared_rs_workspace.size(3) == shared_hidden :
+            shared_rs_workspace.size(3) * shared_rs_workspace.size(2) == shared_hidden);
         // Cross-repository ABI with the ReduceScatter consumer: flags[0] is
         // the generation index and flags[2] is the byte stride per generation.
         DG_HOST_ASSERT(shared_rs_flags.is_cuda());
@@ -613,10 +622,10 @@ static void fp8_fp4_mega_moe_bf16_shared(
     } else {
         shared_y = shared_y_opt.value();
         DG_HOST_ASSERT(shared_y.is_cuda() and shared_y.scalar_type() == torch::kBFloat16 and shared_y.is_contiguous());
-        DG_HOST_ASSERT(shared_y.dim() == 2 and shared_y.size(0) == num_tokens and shared_y.size(1) == shared_hidden);
+        DG_HOST_ASSERT(shared_y.dim() == 2 and shared_y.size(0) == num_shared_tokens and shared_y.size(1) == shared_hidden);
     }
     DG_HOST_ASSERT(shared_l2_acts.is_cuda() and shared_l2_acts.scalar_type() == torch::kBFloat16 and shared_l2_acts.is_contiguous());
-    DG_HOST_ASSERT(shared_l2_acts.dim() == 2 and shared_l2_acts.size(0) >= num_tokens);
+    DG_HOST_ASSERT(shared_l2_acts.dim() == 2 and shared_l2_acts.size(0) >= num_shared_tokens);
     const auto shared_intermediate_hidden = static_cast<int>(shared_l2_acts.size(1));
     DG_HOST_ASSERT(shared_intermediate_hidden > 0);
     DG_HOST_ASSERT(shared_l1_weights.is_cuda() and shared_l1_weights.scalar_type() == torch::kBFloat16 and shared_l1_weights.is_contiguous());
@@ -690,7 +699,7 @@ static void fp8_fp4_mega_moe_bf16_shared(
             /*use_bf16_shared=*/ true,
             /*apply_rms_norm=*/ true,
             shared_rs_flags, shared_rs_peer_ptrs,
-            publish_shared_rs);
+            publish_shared_rs, publish_shared_sp_rs);
     } else {
         DG_HOST_UNREACHABLE("Unsupported architecture");
     }

--- a/csrc/jit_kernels/impls/sm100_fp8_fp4_mega_moe.hpp
+++ b/csrc/jit_kernels/impls/sm100_fp8_fp4_mega_moe.hpp
@@ -27,10 +27,15 @@ public:
         bool fast_math;
         bool use_situ;
         float situ_beta, situ_linear_beta;
+        int shared_hidden, shared_intermediate_hidden;
+        bool use_bf16_shared, apply_rms_norm;
         MegaMoEConfig config;
 
         // Runtime arguments
         void* y;
+        void* shared_y;
+        const void* rms_weight;
+        float rms_epsilon;
         int* cumulative_local_expert_recv_stats;
         int num_tokens;
         layout::SymBuffer<> sym_buffer_ptrs;
@@ -84,7 +89,9 @@ static void __instantiate_kernel() {{
         {},
         {},
         {},
-        {}
+        {},
+        {}, {},
+        {}, {}
     >);
 }};
 )", args.num_max_tokens_per_rank,
@@ -103,13 +110,19 @@ static void __instantiate_kernel() {{
     to_string(args.activation_clamp),
     args.fast_math ? "true" : "false",
     args.use_situ ? "true" : "false",
-    to_string(args.situ_beta), to_string(args.situ_linear_beta));
+    to_string(args.situ_beta), to_string(args.situ_linear_beta),
+    args.shared_hidden, args.shared_intermediate_hidden,
+    args.use_bf16_shared ? "true" : "false",
+    args.apply_rms_norm ? "true" : "false");
     }
 
     static void launch_impl(const KernelHandle& kernel, const LaunchConfigHandle& config, Args args) {
         // TODO: optimize `args` copy
         DG_CUDA_UNIFIED_CHECK(launch_kernel(kernel, config,
             args.y,
+            args.shared_y,
+            args.rms_weight,
+            args.rms_epsilon,
             args.cumulative_local_expert_recv_stats,
             args.num_tokens,
             args.sym_buffer_ptrs,
@@ -156,13 +169,26 @@ static void sm100_fp8_fp4_mega_moe(
     const bool& fast_math,
     const bool& use_situ,
     const float& situ_beta,
-    const float& situ_linear_beta
+    const float& situ_linear_beta,
+    const torch::Tensor& bf16_shared_l1_acts = torch::Tensor(),
+    const torch::Tensor& bf16_shared_l2_acts = torch::Tensor(),
+    const torch::Tensor& bf16_shared_l1_weights = torch::Tensor(),
+    const torch::Tensor& bf16_shared_l2_weights = torch::Tensor(),
+    const torch::Tensor& bf16_shared_y = torch::Tensor(),
+    const torch::Tensor& rms_weight = torch::Tensor(),
+    const float& rms_epsilon = 0.0f,
+    const bool& use_bf16_shared = false,
+    const bool& apply_rms_norm = false
 ) {
     const auto num_ranks = static_cast<int>(sym_buffer_ptrs.size());
     const auto num_experts = num_experts_per_rank * num_ranks;
     const auto num_ring_tokens = static_cast<int>(l1_acts.size(0));
     const auto num_sf_ring_tokens = static_cast<int>(l1_acts_sf.size(0));
-    const auto shared_intermediate_hidden = intermediate_hidden * num_shared_experts;
+    const auto shared_hidden = use_bf16_shared ?
+        static_cast<int>(bf16_shared_l1_acts.size(1)) : hidden;
+    const auto shared_intermediate_hidden = use_bf16_shared ?
+        static_cast<int>(bf16_shared_l2_acts.size(1)) :
+        intermediate_hidden * num_shared_experts;
 
     // Heuristics
     const auto config = get_mega_moe_config(
@@ -223,57 +249,65 @@ static void sm100_fp8_fp4_mega_moe(
                                                            num_experts_per_rank, 0, 0, false,
                                                         sf_smem_outer_dim);
 
-    const auto tensor_map_shared_l1_acts = num_shared_experts > 0 ? make_tma_2d_desc(
-        shared_l1_acts,
-        hidden, num_max_tokens_per_rank,
-        config.block_k, config.load_block_m,
-        static_cast<int>(shared_l1_acts.stride(-2)),
+    // BF16 shared tiles use half of routed K so that their two-byte elements
+    // fit the existing FP8/expanded-FP4 shared-memory tiles.
+    const auto shared_block_k = use_bf16_shared ? config.block_k / 2 : config.block_k;
+    const auto has_shared_work = num_shared_experts > 0 and num_tokens > 0;
+    const auto& actual_shared_l1_acts = use_bf16_shared ? bf16_shared_l1_acts : shared_l1_acts;
+    const auto& actual_shared_l2_acts = use_bf16_shared ? bf16_shared_l2_acts : shared_l2_acts;
+    const auto& actual_shared_l1_weights = use_bf16_shared ? bf16_shared_l1_weights : shared_l1_weights;
+    const auto& actual_shared_l2_weights = use_bf16_shared ? bf16_shared_l2_weights : shared_l2_weights;
+    const auto tensor_map_shared_l1_acts = has_shared_work ? make_tma_2d_desc(
+        actual_shared_l1_acts,
+        shared_hidden, use_bf16_shared ? num_tokens : num_max_tokens_per_rank,
+        shared_block_k, config.load_block_m,
+        static_cast<int>(actual_shared_l1_acts.stride(-2)),
         config.swizzle_acts_mode) : tensor_map_l1_acts;
-    const auto tensor_map_shared_l1_acts_sf = num_shared_experts > 0 ? make_tma_sf_desc(
+    const auto tensor_map_shared_l1_acts_sf = has_shared_work and not use_bf16_shared ? make_tma_sf_desc(
         cute::UMMA::Major::MN, shared_l1_acts_sf,
         static_cast<int>(shared_l1_acts_sf.size(0)), hidden,
         config.sf_block_m, kGranK,
         1, 0, 0, false,
         sf_smem_outer_dim) : tensor_map_l1_acts_sf;
-    const auto tensor_map_shared_l1_weights = num_shared_experts > 0 ? make_tma_2d_desc(
-        shared_l1_weights,
-        hidden, shared_intermediate_hidden * 2,
-        config.block_k, config.load_block_n,
-        static_cast<int>(shared_l1_weights.stride(-2)),
+    const auto tensor_map_shared_l1_weights = has_shared_work ? make_tma_2d_desc(
+        actual_shared_l1_weights,
+        shared_hidden, shared_intermediate_hidden * 2,
+        shared_block_k, config.load_block_n,
+        static_cast<int>(actual_shared_l1_weights.stride(-2)),
         config.swizzle_weights_mode) : tensor_map_l1_weights;
-    const auto tensor_map_shared_l1_weights_sf = num_shared_experts > 0 ? make_tma_sf_desc(
+    const auto tensor_map_shared_l1_weights_sf = has_shared_work and not use_bf16_shared ? make_tma_sf_desc(
         cute::UMMA::Major::MN, shared_l1_weights_sf,
-        shared_intermediate_hidden * 2, hidden,
+        shared_intermediate_hidden * 2, shared_hidden,
         config.block_n, kGranK,
         1, 0, 0, false,
         sf_smem_outer_dim) : tensor_map_l1_weights_sf;
-    const auto tensor_map_shared_l1_output = num_shared_experts > 0 ? make_tma_2d_desc(
-        shared_l2_acts,
+    const auto tensor_map_shared_l1_output = has_shared_work ? make_tma_2d_desc(
+        actual_shared_l2_acts,
         shared_intermediate_hidden, num_max_tokens_per_rank,
         config.block_n / 2, config.store_block_m,
-        static_cast<int>(shared_l2_acts.stride(-2)),
-        config.swizzle_acts_mode / 2) : tensor_map_l1_output;
-    const auto tensor_map_shared_l2_acts = num_shared_experts > 0 ? make_tma_2d_desc(
-        shared_l2_acts,
+        static_cast<int>(actual_shared_l2_acts.stride(-2)),
+        use_bf16_shared ? config.swizzle_acts_mode : config.swizzle_acts_mode / 2) : tensor_map_l1_output;
+    const auto tensor_map_shared_l2_acts = has_shared_work ? make_tma_2d_desc(
+        actual_shared_l2_acts,
         shared_intermediate_hidden, num_max_tokens_per_rank,
-        config.block_k, config.load_block_m,
-        static_cast<int>(shared_l2_acts.stride(-2)),
+        shared_block_k, config.load_block_m,
+        static_cast<int>(actual_shared_l2_acts.stride(-2)),
         config.swizzle_acts_mode) : tensor_map_l2_acts;
-    const auto tensor_map_shared_l2_acts_sf = num_shared_experts > 0 ? make_tma_sf_desc(
+    const auto tensor_map_shared_l2_acts_sf = has_shared_work and not use_bf16_shared ? make_tma_sf_desc(
         cute::UMMA::Major::MN, shared_l2_acts_sf,
         static_cast<int>(shared_l2_acts_sf.size(0)), shared_intermediate_hidden,
         config.sf_block_m, kGranK,
         1, 0, 0, false,
         sf_smem_outer_dim) : tensor_map_l2_acts_sf;
-    const auto tensor_map_shared_l2_weights = num_shared_experts > 0 ? make_tma_2d_desc(
-        shared_l2_weights,
-        shared_intermediate_hidden, hidden,
-        config.block_k, config.load_block_n,
-        static_cast<int>(shared_l2_weights.stride(-2)),
+    const auto tensor_map_shared_l2_weights = has_shared_work ? make_tma_2d_desc(
+        actual_shared_l2_weights,
+        shared_intermediate_hidden, shared_hidden,
+        shared_block_k, config.load_block_n,
+        static_cast<int>(actual_shared_l2_weights.stride(-2)),
         config.swizzle_weights_mode) : tensor_map_l2_weights;
-    const auto tensor_map_shared_l2_weights_sf = num_shared_experts > 0 ? make_tma_sf_desc(
+    const auto tensor_map_shared_l2_weights_sf = has_shared_work and not use_bf16_shared ? make_tma_sf_desc(
         cute::UMMA::Major::MN, shared_l2_weights_sf,
-        hidden, shared_intermediate_hidden,
+        shared_hidden, shared_intermediate_hidden,
         config.block_n, kGranK,
         1, 0, 0, false,
         sf_smem_outer_dim) : tensor_map_l2_weights_sf;
@@ -296,8 +330,15 @@ static void sm100_fp8_fp4_mega_moe(
         .use_situ = use_situ,
         .situ_beta = situ_beta,
         .situ_linear_beta = situ_linear_beta,
+        .shared_hidden = shared_hidden,
+        .shared_intermediate_hidden = shared_intermediate_hidden,
+        .use_bf16_shared = use_bf16_shared,
+        .apply_rms_norm = apply_rms_norm,
         .config = config,
         .y = y.data_ptr(),
+        .shared_y = use_bf16_shared ? bf16_shared_y.data_ptr() : nullptr,
+        .rms_weight = apply_rms_norm ? rms_weight.data_ptr() : nullptr,
+        .rms_epsilon = rms_epsilon,
         .cumulative_local_expert_recv_stats = cumulative_local_expert_recv_stats_ptr,
         .num_tokens = num_tokens,
         .sym_buffer_ptrs = layout::SymBuffer<>(sym_buffer_ptrs, rank_idx),

--- a/csrc/jit_kernels/impls/sm100_fp8_fp4_mega_moe.hpp
+++ b/csrc/jit_kernels/impls/sm100_fp8_fp4_mega_moe.hpp
@@ -28,7 +28,8 @@ public:
         bool use_situ;
         float situ_beta, situ_linear_beta;
         int shared_hidden, shared_intermediate_hidden;
-        bool use_bf16_shared, apply_rms_norm, publish_shared_rs;
+        bool use_bf16_shared, apply_rms_norm;
+        bool publish_shared_rs, publish_shared_sp_rs;
         MegaMoEConfig config;
 
         // Runtime arguments
@@ -40,6 +41,7 @@ public:
         float rms_epsilon;
         int* cumulative_local_expert_recv_stats;
         int num_tokens;
+        int num_shared_tokens;
         layout::SymBuffer<> sym_buffer_ptrs;
 
         // Tensormap
@@ -93,7 +95,7 @@ static void __instantiate_kernel() {{
         {},
         {},
         {}, {},
-        {}, {}, {}
+        {}, {}, {}, {}
     >);
 }};
 )", args.num_max_tokens_per_rank,
@@ -116,7 +118,8 @@ static void __instantiate_kernel() {{
     args.shared_hidden, args.shared_intermediate_hidden,
     args.use_bf16_shared ? "true" : "false",
     args.apply_rms_norm ? "true" : "false",
-    args.publish_shared_rs ? "true" : "false");
+    args.publish_shared_rs ? "true" : "false",
+    args.publish_shared_sp_rs ? "true" : "false");
     }
 
     static void launch_impl(const KernelHandle& kernel, const LaunchConfigHandle& config, Args args) {
@@ -130,6 +133,7 @@ static void __instantiate_kernel() {{
             args.rms_epsilon,
             args.cumulative_local_expert_recv_stats,
             args.num_tokens,
+            args.num_shared_tokens,
             args.sym_buffer_ptrs,
             args.tensor_map_l1_acts,
             args.tensor_map_l1_acts_sf,
@@ -186,7 +190,8 @@ static void sm100_fp8_fp4_mega_moe(
     const bool& apply_rms_norm = false,
     const torch::Tensor& shared_rs_flags = torch::Tensor(),
     const torch::Tensor& shared_rs_peer_ptrs = torch::Tensor(),
-    const bool& publish_shared_rs = false
+    const bool& publish_shared_rs = false,
+    const bool& publish_shared_sp_rs = false
 ) {
     const auto num_ranks = static_cast<int>(sym_buffer_ptrs.size());
     const auto num_experts = num_experts_per_rank * num_ranks;
@@ -197,6 +202,8 @@ static void sm100_fp8_fp4_mega_moe(
     const auto shared_intermediate_hidden = use_bf16_shared ?
         static_cast<int>(bf16_shared_l2_acts.size(1)) :
         intermediate_hidden * num_shared_experts;
+    const auto num_shared_tokens = use_bf16_shared ?
+        static_cast<int>(bf16_shared_l1_acts.size(0)) : num_tokens;
 
     // Heuristics
     const auto config = get_mega_moe_config(
@@ -260,14 +267,14 @@ static void sm100_fp8_fp4_mega_moe(
     // BF16 shared tiles use half of routed K so that their two-byte elements
     // fit the existing FP8/expanded-FP4 shared-memory tiles.
     const auto shared_block_k = use_bf16_shared ? config.block_k / 2 : config.block_k;
-    const auto has_shared_work = num_shared_experts > 0 and num_tokens > 0;
+    const auto has_shared_work = num_shared_experts > 0 and num_shared_tokens > 0;
     const auto& actual_shared_l1_acts = use_bf16_shared ? bf16_shared_l1_acts : shared_l1_acts;
     const auto& actual_shared_l2_acts = use_bf16_shared ? bf16_shared_l2_acts : shared_l2_acts;
     const auto& actual_shared_l1_weights = use_bf16_shared ? bf16_shared_l1_weights : shared_l1_weights;
     const auto& actual_shared_l2_weights = use_bf16_shared ? bf16_shared_l2_weights : shared_l2_weights;
     const auto tensor_map_shared_l1_acts = has_shared_work ? make_tma_2d_desc(
         actual_shared_l1_acts,
-        shared_hidden, use_bf16_shared ? num_tokens : num_max_tokens_per_rank,
+        shared_hidden, use_bf16_shared ? num_shared_tokens : num_max_tokens_per_rank,
         shared_block_k, config.load_block_m,
         static_cast<int>(actual_shared_l1_acts.stride(-2)),
         config.swizzle_acts_mode) : tensor_map_l1_acts;
@@ -343,6 +350,7 @@ static void sm100_fp8_fp4_mega_moe(
         .use_bf16_shared = use_bf16_shared,
         .apply_rms_norm = apply_rms_norm,
         .publish_shared_rs = publish_shared_rs,
+        .publish_shared_sp_rs = publish_shared_sp_rs,
         .config = config,
         .y = y.data_ptr(),
         .shared_y = use_bf16_shared and not publish_shared_rs ? bf16_shared_y.data_ptr() : nullptr,
@@ -354,6 +362,7 @@ static void sm100_fp8_fp4_mega_moe(
         .rms_epsilon = rms_epsilon,
         .cumulative_local_expert_recv_stats = cumulative_local_expert_recv_stats_ptr,
         .num_tokens = num_tokens,
+        .num_shared_tokens = num_shared_tokens,
         .sym_buffer_ptrs = layout::SymBuffer<>(sym_buffer_ptrs, rank_idx),
         .tensor_map_l1_acts = tensor_map_l1_acts,
         .tensor_map_l1_acts_sf = tensor_map_l1_acts_sf,

--- a/csrc/jit_kernels/impls/sm100_fp8_fp4_mega_moe.hpp
+++ b/csrc/jit_kernels/impls/sm100_fp8_fp4_mega_moe.hpp
@@ -28,12 +28,14 @@ public:
         bool use_situ;
         float situ_beta, situ_linear_beta;
         int shared_hidden, shared_intermediate_hidden;
-        bool use_bf16_shared, apply_rms_norm;
+        bool use_bf16_shared, apply_rms_norm, publish_shared_rs;
         MegaMoEConfig config;
 
         // Runtime arguments
         void* y;
         void* shared_y;
+        const uint32_t* shared_rs_flags;
+        const int64_t* shared_rs_peer_ptrs;
         const void* rms_weight;
         float rms_epsilon;
         int* cumulative_local_expert_recv_stats;
@@ -91,7 +93,7 @@ static void __instantiate_kernel() {{
         {},
         {},
         {}, {},
-        {}, {}
+        {}, {}, {}
     >);
 }};
 )", args.num_max_tokens_per_rank,
@@ -113,7 +115,8 @@ static void __instantiate_kernel() {{
     to_string(args.situ_beta), to_string(args.situ_linear_beta),
     args.shared_hidden, args.shared_intermediate_hidden,
     args.use_bf16_shared ? "true" : "false",
-    args.apply_rms_norm ? "true" : "false");
+    args.apply_rms_norm ? "true" : "false",
+    args.publish_shared_rs ? "true" : "false");
     }
 
     static void launch_impl(const KernelHandle& kernel, const LaunchConfigHandle& config, Args args) {
@@ -121,6 +124,8 @@ static void __instantiate_kernel() {{
         DG_CUDA_UNIFIED_CHECK(launch_kernel(kernel, config,
             args.y,
             args.shared_y,
+            args.shared_rs_flags,
+            args.shared_rs_peer_ptrs,
             args.rms_weight,
             args.rms_epsilon,
             args.cumulative_local_expert_recv_stats,
@@ -178,7 +183,10 @@ static void sm100_fp8_fp4_mega_moe(
     const torch::Tensor& rms_weight = torch::Tensor(),
     const float& rms_epsilon = 0.0f,
     const bool& use_bf16_shared = false,
-    const bool& apply_rms_norm = false
+    const bool& apply_rms_norm = false,
+    const torch::Tensor& shared_rs_flags = torch::Tensor(),
+    const torch::Tensor& shared_rs_peer_ptrs = torch::Tensor(),
+    const bool& publish_shared_rs = false
 ) {
     const auto num_ranks = static_cast<int>(sym_buffer_ptrs.size());
     const auto num_experts = num_experts_per_rank * num_ranks;
@@ -334,9 +342,14 @@ static void sm100_fp8_fp4_mega_moe(
         .shared_intermediate_hidden = shared_intermediate_hidden,
         .use_bf16_shared = use_bf16_shared,
         .apply_rms_norm = apply_rms_norm,
+        .publish_shared_rs = publish_shared_rs,
         .config = config,
         .y = y.data_ptr(),
-        .shared_y = use_bf16_shared ? bf16_shared_y.data_ptr() : nullptr,
+        .shared_y = use_bf16_shared and not publish_shared_rs ? bf16_shared_y.data_ptr() : nullptr,
+        .shared_rs_flags = publish_shared_rs ?
+            reinterpret_cast<const uint32_t*>(shared_rs_flags.data_ptr<int32_t>()) : nullptr,
+        .shared_rs_peer_ptrs = publish_shared_rs ?
+            shared_rs_peer_ptrs.data_ptr<int64_t>() : nullptr,
         .rms_weight = apply_rms_norm ? rms_weight.data_ptr() : nullptr,
         .rms_epsilon = rms_epsilon,
         .cumulative_local_expert_recv_stats = cumulative_local_expert_recv_stats_ptr,

--- a/deep_gemm/__init__.py
+++ b/deep_gemm/__init__.py
@@ -89,6 +89,7 @@ from .mega import (
     transform_weights_for_mega_moe,
     fp8_fp4_mega_moe,
     fp8_fp4_mega_moe_bf16_shared,
+    fp8_fp4_mega_moe_bf16_shared_rs,
     fp4_fp4_mega_moe,
     bf16_mega_moe,
 )

--- a/deep_gemm/__init__.py
+++ b/deep_gemm/__init__.py
@@ -88,6 +88,7 @@ from .mega import (
     get_symm_buffer_for_mega_moe,
     transform_weights_for_mega_moe,
     fp8_fp4_mega_moe,
+    fp8_fp4_mega_moe_bf16_shared,
     fp4_fp4_mega_moe,
     bf16_mega_moe,
 )

--- a/deep_gemm/__init__.py
+++ b/deep_gemm/__init__.py
@@ -90,6 +90,8 @@ from .mega import (
     fp8_fp4_mega_moe,
     fp8_fp4_mega_moe_bf16_shared,
     fp8_fp4_mega_moe_bf16_shared_rs,
+    fp8_fp4_mega_moe_bf16_shared_sp_rs,
+    supports_bf16_shared_independent_tokens,
     fp4_fp4_mega_moe,
     bf16_mega_moe,
 )

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
@@ -42,6 +42,7 @@ template <
     uint32_t kSharedIntermediateHidden,
     bool kUseBF16Shared,
     bool kApplyRMSNorm,
+    bool kPublishSharedRS,
     bool kHasShared = (kNumSharedExperts > 0),
     uint32_t L1_SHAPE_N = kIntermediateHidden * 2,
     uint32_t L1_SHAPE_K = kHidden,
@@ -62,6 +63,8 @@ template <
 CUTLASS_GLOBAL __launch_bounds__(kNumThreads, 1) void
 sm100_fp8_fp4_mega_moe_impl(void* y,
                             void* shared_y,
+                            const uint32_t* shared_rs_flags,
+                            const int64_t* shared_rs_peer_ptrs,
                             const void* rms_weight,
                             const float rms_epsilon,
                             int* cumulative_local_expert_recv_stats,
@@ -97,6 +100,10 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
     DG_STATIC_ASSERT(not kUseSiTU or (kSiTUBeta > 0 and kSiTULinearBeta > 0), "Invalid SiTU beta");
     DG_STATIC_ASSERT(not kUseBF16Shared or kNumSharedExperts > 0, "BF16 shared mode requires shared work");
     DG_STATIC_ASSERT(not kApplyRMSNorm or kUseBF16Shared, "Fused RMSNorm is only supported with BF16 shared mode");
+    DG_STATIC_ASSERT(not kPublishSharedRS or kUseBF16Shared, "Shared ReduceScatter publication requires BF16 shared mode");
+    DG_STATIC_ASSERT(not kPublishSharedRS or kSharedHidden % kNumRanks == 0, "Shared hidden must shard evenly across ranks");
+    DG_STATIC_ASSERT(not kPublishSharedRS or (kSharedHidden / kNumRanks) % 8 == 0,
+                     "Shared ReduceScatter shards must align to vector stores");
 
     // Thread indices
     const bool is_leader_cta = cute::block_rank_in_cluster() == 0;
@@ -1571,10 +1578,31 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
 
                         if constexpr (kUseBF16Shared) {
                             if (task_info.is_shared()) {
+                                void* shared_output_base = shared_y;
+                                uint64_t shared_output_offset = 0;
+                                uint64_t shared_column_offset = n_idx;
+                                if constexpr (kPublishSharedRS) {
+                                    const auto current_index = __ldg(shared_rs_flags);
+                                    const auto bytes_per_buffer = __ldg(shared_rs_flags + 2);
+                                    constexpr uint32_t kSharedShard =
+                                        kSharedHidden / kNumRanks;
+                                    const auto vector_n =
+                                        n_idx + (lane_idx % 16) * 8;
+                                    const auto destination_rank =
+                                        vector_n / kSharedShard;
+                                    shared_output_base = reinterpret_cast<void*>(
+                                        __ldg(shared_rs_peer_ptrs + destination_rank));
+                                    shared_output_offset =
+                                        static_cast<uint64_t>(current_index) * bytes_per_buffer
+                                        + static_cast<uint64_t>(sym_buffer.rank_idx) * kSharedShard
+                                              * sizeof(nv_bfloat16);
+                                    shared_column_offset = n_idx - destination_rank * kSharedShard;
+                                }
                                 const auto dst_ptr = math::advance_ptr<float4>(
-                                    shared_y,
-                                    static_cast<uint64_t>(dst_token_idx) * kSharedHidden * sizeof(nv_bfloat16)
-                                    + n_idx * sizeof(nv_bfloat16)
+                                    shared_output_base,
+                                    shared_output_offset
+                                    + static_cast<uint64_t>(dst_token_idx) * kSharedHidden * sizeof(nv_bfloat16)
+                                    + shared_column_offset * sizeof(nv_bfloat16)
                                     + (lane_idx % 16) * sizeof(float4));
                                 *dst_ptr = packed;
                                 continue;

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
@@ -38,6 +38,10 @@ template <
     bool kUseSiTU,
     float kSiTUBeta,
     float kSiTULinearBeta,
+    uint32_t kSharedHidden,
+    uint32_t kSharedIntermediateHidden,
+    bool kUseBF16Shared,
+    bool kApplyRMSNorm,
     bool kHasShared = (kNumSharedExperts > 0),
     uint32_t L1_SHAPE_N = kIntermediateHidden * 2,
     uint32_t L1_SHAPE_K = kHidden,
@@ -57,6 +61,9 @@ template <
 >
 CUTLASS_GLOBAL __launch_bounds__(kNumThreads, 1) void
 sm100_fp8_fp4_mega_moe_impl(void* y,
+                            void* shared_y,
+                            const void* rms_weight,
+                            const float rms_epsilon,
                             int* cumulative_local_expert_recv_stats,
                             const uint32_t num_tokens,
                             const __grid_constant__ layout::SymBuffer<kNumRanks> sym_buffer,
@@ -88,6 +95,8 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
     DG_STATIC_ASSERT(kNumEpilogueThreads % 128 == 0, "Invalid number of MMA epilogue and combine threads");
     DG_STATIC_ASSERT(kNumExperts % kNumRanks == 0, "Invalid number of experts or ranks");
     DG_STATIC_ASSERT(not kUseSiTU or (kSiTUBeta > 0 and kSiTULinearBeta > 0), "Invalid SiTU beta");
+    DG_STATIC_ASSERT(not kUseBF16Shared or kNumSharedExperts > 0, "BF16 shared mode requires shared work");
+    DG_STATIC_ASSERT(not kApplyRMSNorm or kUseBF16Shared, "Fused RMSNorm is only supported with BF16 shared mode");
 
     // Thread indices
     const bool is_leader_cta = cute::block_rank_in_cluster() == 0;
@@ -126,7 +135,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
         kNumMaxTokensPerRank, kNumTopk,
         kNumRingTokens, kNumSFRingTokens,
         /*with_sf=*/ true,
-        kNumSharedExperts
+        kUseBF16Shared ? 0u : kNumSharedExperts
     );
     const auto workspace = buffer.workspace;
 
@@ -148,6 +157,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
     using a_dtype_t = cutlass::float_e4m3_t;
     using b_dtype_t = cutlass::detail::float_e2m1_unpacksmem_t;
     using shared_b_dtype_t = cutlass::float_e4m3_t;
+    using bf16_shared_dtype_t = cutlass::bfloat16_t;
 
     // MMA configs
     // NOTES: always swap A/B, 2-CTA MMA, and matrices are K-major
@@ -156,10 +166,16 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
     constexpr uint32_t UMMA_N = BLOCK_M;  // Swap AB
     constexpr uint32_t UMMA_BLOCK_K = 128;
     constexpr uint32_t UMMA_K = 32;
+    constexpr uint32_t SHARED_BLOCK_K = kUseBF16Shared ? BLOCK_K / 2 : BLOCK_K;
+    constexpr uint32_t SHARED_UMMA_BLOCK_K = UMMA_BLOCK_K / 2;
+    constexpr uint32_t SHARED_UMMA_K = 16;
     constexpr uint32_t LOAD_BLOCK_M = BLOCK_M / 2;  // Multicast on A
     constexpr uint32_t LOAD_BLOCK_N = BLOCK_N;
     DG_STATIC_ASSERT(BLOCK_M % 16 == 0, "Invalid block M");
     DG_STATIC_ASSERT(BLOCK_N == LAYOUT_AD_M, "Invalid block N");
+    DG_STATIC_ASSERT(not kUseBF16Shared or BLOCK_K % 2 == 0, "Invalid BF16 shared block K");
+    DG_STATIC_ASSERT(not kUseBF16Shared or kSharedHidden % SHARED_BLOCK_K == 0, "Invalid BF16 shared hidden");
+    DG_STATIC_ASSERT(not kUseBF16Shared or kSharedIntermediateHidden % SHARED_BLOCK_K == 0, "Invalid BF16 shared intermediate hidden");
 
     // Swizzle configs
     constexpr uint32_t kSwizzleAMode = 128;
@@ -189,6 +205,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
         alignas(kSharedMemoryAlignment) uint8_t dispatch_send_buffer[kNumDispatchWarps][kNumBytesPerPull];
         union {
             alignas(kSharedMemoryAlignment) cutlass::float_e4m3_t l1[kNumEpilogueWarpgroups][kNumTMAStoreStages][STORE_BLOCK_M * L1_OUT_BLOCK_N];
+            alignas(kSharedMemoryAlignment) nv_bfloat16 shared_l1[kNumEpilogueWarpgroups][kNumTMAStoreStages][STORE_BLOCK_M * L1_OUT_BLOCK_N];
             alignas(kSharedMemoryAlignment) nv_bfloat16 l2[kNumEpilogueWarpgroups][STORE_BLOCK_M * BLOCK_N];
         } smem_d;
         alignas(kSharedMemoryAlignment) a_dtype_t smem_a[kNumStages][LOAD_BLOCK_M * BLOCK_K];
@@ -286,7 +303,10 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
         kNumExpertsPerRank,
         kNumSMs, kNumRanks,
         kNumRingBlocks,
-        kNumSharedExperts>(
+        kNumSharedExperts,
+        kSharedIntermediateHidden * 2, kSharedHidden,
+        kSharedHidden, kSharedIntermediateHidden,
+        SHARED_BLOCK_K>(
             workspace,
             shared_storage.task_info_full_barriers,
             shared_storage.task_info_empty_barriers,
@@ -660,6 +680,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                 }
                 __syncwarp();
             }
+
         }
 
         // Wait for all ranks to finish cleaning
@@ -685,7 +706,8 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                                             task_info.block_phase == sched::BlockPhase::Linear2 ? &tensor_map_l2_acts_sf :
                                             task_info.block_phase == sched::BlockPhase::SharedLinear1 ? &tensor_map_shared_l1_acts_sf :
                                           /*task_info.block_phase == sched::BlockPhase::SharedLinear2*/ &tensor_map_shared_l2_acts_sf;
-            const auto num_k_blocks = math::ceil_div(task_info.shape_k, BLOCK_K);
+            const auto task_block_k = task_info.is_shared() ? SHARED_BLOCK_K : BLOCK_K;
+            const auto num_k_blocks = math::ceil_div(task_info.shape_k, task_block_k);
 
             // Compute pool block offset for this expert
             const uint32_t pool_block_idx = task_info.pool_block_idx;
@@ -703,8 +725,10 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                 while (ptx::ld_acq(ptr) != num_expected_blocks);
             } else if (task_info.block_phase == sched::BlockPhase::SharedLinear2) {
                 const auto ptr = workspace.get_shared_l2_full_count_ptr(block_idx);
-                const auto num_expected_blocks = (SHARED_L2_SHAPE_K / BLOCK_N) * 2;
-                while (ptx::ld_acq(ptr) != num_expected_blocks);
+                constexpr uint32_t kSharedL2ShapeK = kUseBF16Shared ?
+                    kSharedIntermediateHidden : SHARED_L2_SHAPE_K;
+                const auto num_expected_blocks = (kSharedL2ShapeK / BLOCK_N) * 2;
+                while (ptx::ld_acq(ptr) < num_expected_blocks);
             }
 
             for (uint32_t k_block_idx = 0; k_block_idx < num_k_blocks; advance_pipeline(k_block_idx)) {
@@ -713,7 +737,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
 
                 // Compute token offsets from block index
                 uint32_t m_idx = block_idx * BLOCK_M;
-                uint32_t k_idx = k_block_idx * BLOCK_K;
+                uint32_t k_idx = k_block_idx * task_block_k;
                 const uint32_t sfa_m_idx = block_idx * SF_BLOCK_M;
                 uint32_t sfa_k_idx = k_block_idx * (BLOCK_K / 128);
 
@@ -723,18 +747,44 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
 
                 // TMA copy tokens and SFA, then arrive at full barrier
                 if (cute::elect_one_sync()) {
-                    tma::copy<BLOCK_K, LOAD_BLOCK_M, kSwizzleAMode, a_dtype_t>(
-                        tensor_map_a_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_a[stage_idx], k_idx, m_idx, 2);
-                    tma::copy<SF_BLOCK_M, 1, 0>(
-                        tensor_map_sfa_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_sfa[stage_idx], sfa_m_idx, sfa_k_idx, 2);
-                    if (is_leader_cta) {
-                        shared_storage.full_barriers[stage_idx].arrive_and_expect_tx(sizeof(SharedStorage::smem_a[0]) * 2 + sizeof(SharedStorage::smem_sfa[0]) * 2);
+                    if constexpr (kUseBF16Shared) {
+                        if (task_info.is_shared()) {
+                            tma::copy<SHARED_BLOCK_K, LOAD_BLOCK_M, kSwizzleAMode, bf16_shared_dtype_t>(
+                                tensor_map_a_ptr, &shared_storage.full_barriers[stage_idx],
+                                reinterpret_cast<bf16_shared_dtype_t*>(shared_storage.smem_a[stage_idx]),
+                                k_idx, m_idx, 2);
+                            if (is_leader_cta) {
+                                shared_storage.full_barriers[stage_idx].arrive_and_expect_tx(
+                                    LOAD_BLOCK_M * SHARED_BLOCK_K * sizeof(bf16_shared_dtype_t) * 2);
+                            } else {
+                                shared_storage.full_barriers[stage_idx].arrive(0u);
+                            }
+                        } else {
+                            tma::copy<BLOCK_K, LOAD_BLOCK_M, kSwizzleAMode, a_dtype_t>(
+                                tensor_map_a_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_a[stage_idx], k_idx, m_idx, 2);
+                            tma::copy<SF_BLOCK_M, 1, 0>(
+                                tensor_map_sfa_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_sfa[stage_idx], sfa_m_idx, sfa_k_idx, 2);
+                            if (is_leader_cta) {
+                                shared_storage.full_barriers[stage_idx].arrive_and_expect_tx(sizeof(SharedStorage::smem_a[0]) * 2 + sizeof(SharedStorage::smem_sfa[0]) * 2);
+                            } else {
+                                shared_storage.full_barriers[stage_idx].arrive(0u);
+                            }
+                        }
                     } else {
-                        shared_storage.full_barriers[stage_idx].arrive(0u);
+                        tma::copy<BLOCK_K, LOAD_BLOCK_M, kSwizzleAMode, a_dtype_t>(
+                            tensor_map_a_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_a[stage_idx], k_idx, m_idx, 2);
+                        tma::copy<SF_BLOCK_M, 1, 0>(
+                            tensor_map_sfa_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_sfa[stage_idx], sfa_m_idx, sfa_k_idx, 2);
+                        if (is_leader_cta) {
+                            shared_storage.full_barriers[stage_idx].arrive_and_expect_tx(sizeof(SharedStorage::smem_a[0]) * 2 + sizeof(SharedStorage::smem_sfa[0]) * 2);
+                        } else {
+                            shared_storage.full_barriers[stage_idx].arrive(0u);
+                        }
                     }
                 }
                 __syncwarp();
             }
+
         }
     } else if (warp_idx == kNumDispatchWarps + 1) {
         // Adjust registers
@@ -756,7 +806,8 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
             const auto shape_n = task_info.shape_n;
             const auto shape_sfb_k = math::ceil_div(shape_k, kGranK * 4u);
             const auto n_block_idx = task_info.n_cluster_idx * 2 + (is_leader_cta ? 0u : 1u);
-            const auto num_k_blocks = math::ceil_div(shape_k, BLOCK_K);
+            const auto task_block_k = task_info.is_shared() ? SHARED_BLOCK_K : BLOCK_K;
+            const auto num_k_blocks = math::ceil_div(shape_k, task_block_k);
 
             for (uint32_t k_block_idx = 0; k_block_idx < num_k_blocks; advance_pipeline(k_block_idx)) {
                 // Wait consumer release
@@ -764,13 +815,36 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
 
                 // Compute weight offset
                 uint32_t n_idx = task_info.is_shared() ? n_block_idx * BLOCK_N : task_info.local_expert_idx * shape_n + n_block_idx * BLOCK_N;
-                uint32_t k_idx = k_block_idx * BLOCK_K;
+                uint32_t k_idx = k_block_idx * task_block_k;
                 uint32_t sfb_n_idx = n_block_idx * BLOCK_N;
                 uint32_t sfb_k_idx = task_info.is_shared() ? k_block_idx * (BLOCK_K / 128) : task_info.local_expert_idx * shape_sfb_k + k_block_idx * (BLOCK_K / 128);
 
                 // TMA copy weights with SF
                 if (cute::elect_one_sync()) {
-                    if (task_info.is_shared()) {
+                    if constexpr (kUseBF16Shared) {
+                        if (task_info.is_shared()) {
+                            tma::copy<SHARED_BLOCK_K, LOAD_BLOCK_N, kSwizzleBMode, bf16_shared_dtype_t>(
+                                tensor_map_b_ptr, &shared_storage.full_barriers[stage_idx],
+                                reinterpret_cast<bf16_shared_dtype_t*>(shared_storage.smem_b[stage_idx]),
+                                k_idx, n_idx, 2);
+                            if (is_leader_cta) {
+                                shared_storage.full_barriers[stage_idx].arrive_and_expect_tx(
+                                    LOAD_BLOCK_N * SHARED_BLOCK_K * sizeof(bf16_shared_dtype_t) * 2);
+                            } else {
+                                shared_storage.full_barriers[stage_idx].arrive(0u);
+                            }
+                        } else {
+                            tma::copy<BLOCK_K, LOAD_BLOCK_N, kSwizzleBMode, b_dtype_t>(
+                                tensor_map_b_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_b[stage_idx], k_idx, n_idx, 2);
+                            tma::copy<BLOCK_N, 1, 0>(
+                                tensor_map_sfb_ptr, &shared_storage.full_barriers[stage_idx], shared_storage.smem_sfb[stage_idx], sfb_n_idx, sfb_k_idx, 2);
+                            if (is_leader_cta) {
+                                shared_storage.full_barriers[stage_idx].arrive_and_expect_tx(sizeof(SharedStorage::smem_b[0]) + sizeof(SharedStorage::smem_sfb[0]) * 2);
+                            } else {
+                                shared_storage.full_barriers[stage_idx].arrive(0u);
+                            }
+                        }
+                    } else if (task_info.is_shared()) {
                         tma::copy<BLOCK_K, LOAD_BLOCK_N, kSwizzleBMode, shared_b_dtype_t>(
                             tensor_map_b_ptr, &shared_storage.full_barriers[stage_idx], reinterpret_cast<shared_b_dtype_t*>(shared_storage.smem_b[stage_idx]), k_idx, n_idx, 2);
                         tma::copy<BLOCK_N, 1, 0>(
@@ -813,15 +887,26 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                 UMMA_M, UMMA_N,
                 cute::UMMA::Major::K, cute::UMMA::Major::K
             >();
+            auto bf16_shared_instr_desc = cute::UMMA::make_instr_desc<
+                bf16_shared_dtype_t, bf16_shared_dtype_t, float,
+                UMMA_M, UMMA_N,
+                cute::UMMA::Major::K, cute::UMMA::Major::K
+            >();
             auto sf_desc = mma::sm100::make_sf_desc(nullptr);
 
             DG_STATIC_ASSERT(kNumStages <= 32, "Too many stages");
             auto a_desc = mma::sm100::make_umma_desc<cute::UMMA::Major::K, LOAD_BLOCK_M, UMMA_BLOCK_K, kSwizzleAMode>(shared_storage.smem_a[0], 0, 0);
             auto b_desc = mma::sm100::make_umma_desc<cute::UMMA::Major::K, LOAD_BLOCK_N, UMMA_BLOCK_K, kSwizzleBMode>(shared_storage.smem_b[0], 0, 0);
             auto shared_b_desc = mma::sm100::make_umma_desc<cute::UMMA::Major::K, LOAD_BLOCK_N, UMMA_BLOCK_K, kSwizzleBMode>(reinterpret_cast<shared_b_dtype_t*>(shared_storage.smem_b[0]), 0, 0);
+            auto bf16_shared_a_desc = mma::sm100::make_umma_desc<cute::UMMA::Major::K, LOAD_BLOCK_M, SHARED_UMMA_BLOCK_K, kSwizzleAMode>(
+                reinterpret_cast<bf16_shared_dtype_t*>(shared_storage.smem_a[0]), 0, 0);
+            auto bf16_shared_b_desc = mma::sm100::make_umma_desc<cute::UMMA::Major::K, LOAD_BLOCK_N, SHARED_UMMA_BLOCK_K, kSwizzleBMode>(
+                reinterpret_cast<bf16_shared_dtype_t*>(shared_storage.smem_b[0]), 0, 0);
             uint32_t a_desc_lo = lane_idx < kNumStages ? a_desc.lo + lane_idx * sizeof(SharedStorage::smem_a[0]) / 16 : 0u;
             uint32_t b_desc_lo = lane_idx < kNumStages ? b_desc.lo + lane_idx * sizeof(SharedStorage::smem_b[0]) / 16 : 0u;
             uint32_t shared_b_desc_lo = lane_idx < kNumStages ? shared_b_desc.lo + lane_idx * sizeof(SharedStorage::smem_b[0]) / 16 : 0u;
+            uint32_t bf16_shared_a_desc_lo = lane_idx < kNumStages ? bf16_shared_a_desc.lo + lane_idx * sizeof(SharedStorage::smem_a[0]) / 16 : 0u;
+            uint32_t bf16_shared_b_desc_lo = lane_idx < kNumStages ? bf16_shared_b_desc.lo + lane_idx * sizeof(SharedStorage::smem_b[0]) / 16 : 0u;
 
             // Checks for MMA instructions
             DG_STATIC_ASSERT((UMMA_M == 64  and UMMA_N %  8 == 0 and  8 <= UMMA_N and UMMA_N <= 256) or
@@ -833,11 +918,23 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
             uint32_t current_iter_idx = 0;
             task_info_t task_info;
             while (scheduler.get_next_task(task_info)) {
-                const auto num_k_blocks = task_info.shape_k / BLOCK_K;
+                const auto num_k_blocks = task_info.shape_k /
+                    (task_info.is_shared() ? SHARED_BLOCK_K : BLOCK_K);
 
                 // Dynamic update of UMMA N based on effective M
                 auto& instr_desc = task_info.is_shared() ? shared_instr_desc : routed_instr_desc;
-                mma::sm100::update_instr_desc_with_umma_n(instr_desc, task_info.get_umma_aligned_valid_m());
+                if constexpr (kUseBF16Shared) {
+                    if (task_info.is_shared()) {
+                        mma::sm100::update_instr_desc_with_umma_n(
+                            bf16_shared_instr_desc, task_info.get_umma_aligned_valid_m());
+                    } else {
+                        mma::sm100::update_instr_desc_with_umma_n(
+                            routed_instr_desc, task_info.get_umma_aligned_valid_m());
+                    }
+                } else {
+                    mma::sm100::update_instr_desc_with_umma_n(
+                        instr_desc, task_info.get_umma_aligned_valid_m());
+                }
 
                 // Wait tensor memory empty barrier arrival
                 const auto accum_stage_idx = current_iter_idx % kNumEpilogueStages;
@@ -866,8 +963,47 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                     shared_storage.full_barriers[stage_idx].wait(phase);
                     ptx::tcgen05_after_thread_sync();
 
-                    const auto a_desc_base_lo = ptx::exchange(a_desc_lo, stage_idx);
-                    const auto b_desc_base_lo = ptx::exchange(task_info.is_shared() ? shared_b_desc_lo : b_desc_lo, stage_idx);
+                    const auto a_desc_base_lo = ptx::exchange(
+                        kUseBF16Shared and task_info.is_shared() ? bf16_shared_a_desc_lo : a_desc_lo,
+                        stage_idx);
+                    const auto b_desc_base_lo = ptx::exchange(
+                        kUseBF16Shared and task_info.is_shared() ? bf16_shared_b_desc_lo :
+                        (task_info.is_shared() ? shared_b_desc_lo : b_desc_lo),
+                        stage_idx);
+                    if constexpr (kUseBF16Shared) {
+                        if (task_info.is_shared()) {
+                            const auto bf16_runtime_instr_desc =
+                                static_cast<uint64_t>(static_cast<uint32_t>(bf16_shared_instr_desc)) << 32;
+                            if (cute::elect_one_sync()) {
+                                #pragma unroll
+                                for (uint32_t umma_k_block_idx = 0;
+                                     umma_k_block_idx < SHARED_BLOCK_K / SHARED_UMMA_BLOCK_K;
+                                     ++ umma_k_block_idx) {
+                                    #pragma unroll
+                                    for (uint32_t k = 0; k < SHARED_UMMA_BLOCK_K / SHARED_UMMA_K; ++ k) {
+                                        bf16_shared_a_desc.lo = mma::sm100::advance_umma_desc_lo<
+                                            cute::UMMA::Major::K, LOAD_BLOCK_M, kSwizzleAMode, bf16_shared_dtype_t>(
+                                                a_desc_base_lo,
+                                                umma_k_block_idx * SHARED_UMMA_BLOCK_K * LOAD_BLOCK_M,
+                                                k * SHARED_UMMA_K);
+                                        bf16_shared_b_desc.lo = mma::sm100::advance_umma_desc_lo<
+                                            cute::UMMA::Major::K, LOAD_BLOCK_N, kSwizzleBMode, bf16_shared_dtype_t>(
+                                                b_desc_base_lo,
+                                                umma_k_block_idx * SHARED_UMMA_BLOCK_K * LOAD_BLOCK_N,
+                                                k * SHARED_UMMA_K);
+                                        ptx::SM100_MMA_F16BF16_2x1SM_SS::fma(
+                                            bf16_shared_b_desc, bf16_shared_a_desc,
+                                            accum_stage_idx * UMMA_N,
+                                            k_block_idx > 0 or umma_k_block_idx > 0 or k > 0,
+                                            bf16_runtime_instr_desc);
+                                    }
+                                }
+                            }
+                            __syncwarp();
+                            empty_barrier_arrive(k_block_idx == num_k_blocks - 1);
+                            continue;
+                        }
+                    }
                     if (cute::elect_one_sync()) {
                         #pragma unroll
                         for (uint32_t umma_k_block_idx = 0; umma_k_block_idx < BLOCK_K / UMMA_BLOCK_K; ++ umma_k_block_idx) {
@@ -987,6 +1123,121 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
             const uint32_t pool_m_idx = pool_block_idx * BLOCK_M;  // Full-pool offset for non-ring metadata
             const uint32_t n_block_idx = task_info.n_cluster_idx * 2 + (is_leader_cta ? 0u : 1u);
             uint32_t n_idx = n_block_idx * BLOCK_N;
+
+            if constexpr (kUseBF16Shared) {
+                if (task_info.block_phase == sched::BlockPhase::SharedLinear1) {
+                    // BF16 shared L1 epilogue: gated activation without routing
+                    // weights, followed by a BF16 TMA store for shared L2.
+                    constexpr uint32_t SHARED_L1_OUT_BLOCK_N = BLOCK_N / 2;
+
+                    #pragma unroll
+                    for (uint32_t s = 0; s < WG_BLOCK_M / STORE_BLOCK_M; ++ s) {
+                        if (epilogue_wg_idx * WG_BLOCK_M + s * STORE_BLOCK_M >= valid_m) {
+                            ptx::tcgen05_before_thread_sync();
+                            shared_storage.tmem_empty_barriers[accum_stage_idx].arrive(0u);
+                            break;
+                        }
+
+                        nv_bfloat162 bf16x2_output[kNumAtomsPerStore * 2];
+                        #pragma unroll
+                        for (uint32_t i = 0; i < kNumAtomsPerStore; ++ i) {
+                            const uint32_t j = s * kNumAtomsPerStore + i;
+                            uint32_t tmem_addr = accum_stage_idx * UMMA_N +
+                                epilogue_wg_idx * WG_BLOCK_M + j * ATOM_M;
+                            uint32_t values[ATOM_M];
+                            cute::SM100_TMEM_LOAD_16dp256b1x::copy(
+                                tmem_addr, values[0], values[1], values[2], values[3]);
+                            cute::SM100_TMEM_LOAD_16dp256b1x::copy(
+                                tmem_addr | 0x00100000,
+                                values[4], values[5], values[6], values[7]);
+                            cutlass::arch::fence_view_async_tmem_load();
+
+                            if (j == WG_BLOCK_M / ATOM_M - 1) {
+                                ptx::tcgen05_before_thread_sync();
+                                shared_storage.tmem_empty_barriers[accum_stage_idx].arrive(0u);
+                            }
+
+                            // Plain BF16 UMMA places gate/up pairs at
+                            // (0, 2), (1, 3), (4, 6), and (5, 7).
+                            auto fp32_values = reinterpret_cast<float*>(values);
+                            #pragma unroll
+                            for (uint32_t k = 0; k < 2; ++ k) {
+                                const auto bf16_gate = __float22bfloat162_rn(
+                                    make_float2(fp32_values[k * 4], fp32_values[k * 4 + 1]));
+                                const auto bf16_up = __float22bfloat162_rn(
+                                    make_float2(fp32_values[k * 4 + 2], fp32_values[k * 4 + 3]));
+                                const auto raw_gate = __bfloat1622float2(bf16_gate);
+                                const auto raw_up = __bfloat1622float2(bf16_up);
+                                float2 activated;
+                                if constexpr (kUseSiTU) {
+                                    const auto neg_gate_exp = make_float2(
+                                        kFastMath ? __expf(-raw_gate.x) : expf(-raw_gate.x),
+                                        kFastMath ? __expf(-raw_gate.y) : expf(-raw_gate.y));
+                                    const auto denom = __fadd2_rn({1.0f, 1.0f}, neg_gate_exp);
+                                    const float2 sigmoid = kFastMath ?
+                                        make_float2(math::fast_rcp(denom.x), math::fast_rcp(denom.y)) :
+                                        make_float2(1.0f / denom.x, 1.0f / denom.y);
+                                    const auto gate = __fmul2_rn(sigmoid, {
+                                        kSiTUBeta * tanhf(raw_gate.x / kSiTUBeta),
+                                        kSiTUBeta * tanhf(raw_gate.y / kSiTUBeta)});
+                                    const auto up = make_float2(
+                                        kSiTULinearBeta * tanhf(raw_up.x / kSiTULinearBeta),
+                                        kSiTULinearBeta * tanhf(raw_up.y / kSiTULinearBeta));
+                                    activated = __fmul2_rn(gate, up);
+                                } else {
+                                    const auto neg_gate_exp = make_float2(
+                                        kFastMath ? __expf(-raw_gate.x) : expf(-raw_gate.x),
+                                        kFastMath ? __expf(-raw_gate.y) : expf(-raw_gate.y));
+                                    const auto denom = __fadd2_rn({1.0f, 1.0f}, neg_gate_exp);
+                                    const float2 sigmoid = kFastMath ?
+                                        make_float2(math::fast_rcp(denom.x), math::fast_rcp(denom.y)) :
+                                        make_float2(1.0f / denom.x, 1.0f / denom.y);
+                                    activated = __fmul2_rn(__fmul2_rn(raw_gate, sigmoid), raw_up);
+                                }
+                                bf16x2_output[i * 2 + k] = __float22bfloat162_rn(activated);
+                            }
+                        }
+
+                        const uint32_t tma_stage_idx = s % kNumTMAStoreStages;
+                        ptx::tma_store_wait<kNumTMAStoreStages - 1>();
+                        ptx::sync_aligned(128, kEpilogueWGBarrierStartIdx + epilogue_wg_idx);
+
+                        #pragma unroll
+                        for (uint32_t i = 0; i < kNumAtomsPerStore; ++ i) {
+                            const uint32_t row = lane_idx % 8;
+                            const uint32_t col = warp_idx_in_wg * 2 + lane_idx / 8;
+                            const auto smem_ptr =
+                                shared_storage.smem_d.shared_l1[epilogue_wg_idx][tma_stage_idx]
+                                + (i * ATOM_M + row) * SHARED_L1_OUT_BLOCK_N
+                                + (col ^ row) * (kNumBankGroupBytes / sizeof(nv_bfloat16));
+                            ptx::SM90_U32x2_STSM_T<__nv_bfloat162>::copy(
+                                bf16x2_output[i * 2], bf16x2_output[i * 2 + 1], smem_ptr);
+                        }
+                        ptx::sync_aligned(128, kEpilogueWGBarrierStartIdx + epilogue_wg_idx);
+
+                        if (warp_idx_in_wg == 0 and cute::elect_one_sync()) {
+                            const uint32_t out_n_idx = n_block_idx * SHARED_L1_OUT_BLOCK_N;
+                            cute::tma_store_fence();
+                            cute::SM90_TMA_STORE_2D::copy(
+                                &tensor_map_shared_l1_output,
+                                shared_storage.smem_d.shared_l1[epilogue_wg_idx][tma_stage_idx],
+                                out_n_idx,
+                                m_idx + epilogue_wg_idx * WG_BLOCK_M + s * STORE_BLOCK_M);
+                            cute::tma_store_arrive();
+                        }
+                        __syncwarp();
+                    }
+
+                    ptx::tma_store_wait<0>();
+                    ptx::sync_aligned(kNumEpilogueThreads, kEpilogueFullBarrierIdx);
+                    if (epilogue_warp_idx == 0 and cute::elect_one_sync()) {
+                        ptx::red_add_rel(
+                            workspace.get_shared_l2_full_count_ptr(pool_block_idx), 1u);
+                    }
+                    __syncwarp();
+                    continue;
+                }
+            }
 
             if (task_info.block_phase == sched::BlockPhase::Linear1 or task_info.block_phase == sched::BlockPhase::SharedLinear1) {
                 if (not task_info.is_shared()) {
@@ -1303,7 +1554,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                         if (task_info.is_shared()) {
                             dst_rank_idx = sym_buffer.rank_idx;
                             dst_token_idx = pool_m_idx + m_idx_in_block;
-                            dst_topk_idx = kNumTopk;
+                            dst_topk_idx = kUseBF16Shared ? 0u : kNumTopk;
                         } else {
                             const auto src_metadata = *workspace.get_token_src_metadata_ptr(pool_m_idx + m_idx_in_block);
                             dst_rank_idx = src_metadata.rank_idx;
@@ -1317,6 +1568,18 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                             row_in_store * kSwizzleCDMode +
                             (bank_group_idx ^ row_in_atom) * kNumBankGroupBytes;
                         const auto packed = ptx::ld_shared(reinterpret_cast<float4*>(smem_ptr));
+
+                        if constexpr (kUseBF16Shared) {
+                            if (task_info.is_shared()) {
+                                const auto dst_ptr = math::advance_ptr<float4>(
+                                    shared_y,
+                                    static_cast<uint64_t>(dst_token_idx) * kSharedHidden * sizeof(nv_bfloat16)
+                                    + n_idx * sizeof(nv_bfloat16)
+                                    + (lane_idx % 16) * sizeof(float4));
+                                *dst_ptr = packed;
+                                continue;
+                            }
+                        }
 
                         // Write into remote
                         const auto dst_token = buffer.combine_token_buffer.get_rank_buffer(dst_topk_idx)
@@ -1370,7 +1633,8 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
         DG_STATIC_ASSERT(kNumChunkBytes % 16 == 0, "Combine chunk must be TMA-aligned (16 bytes)");
         DG_STATIC_ASSERT(kNumChunkBytes % sizeof(uint4) == 0, "Combine chunk must be divisible by 16 bytes");
         DG_STATIC_ASSERT(kNumChunkUint4 % 32 == 0, "Combine chunk must be a multiple of 32 16-byte elements (one per lane)");
-        DG_STATIC_ASSERT(kNumTopk + (kNumSharedExperts > 0 ? 1u : 0u) <= 32u, "Top-k + shared must fit in a single warp");
+        DG_STATIC_ASSERT(kNumTopk + (kNumSharedExperts > 0 and not kUseBF16Shared ? 1u : 0u) <= 32u,
+                         "Top-k + in-combine shared must fit in a single warp");
 
         // Verify combined shared memory budget at runtime
         DG_DEVICE_ASSERT(kNumChunkSlots * kNumEpilogueWarps * kNumChunkBytes <= kNumReusableSmemBytes);
@@ -1395,7 +1659,8 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
             // Read top-k slot indices: each lane reads one slot, then broadcast via exchange
             const int stored_topk_slot_idx = lane_idx < kNumTopk ?
                 static_cast<int>(__ldg(buffer.input_topk_idx_buffer.get_base_ptr<int64_t>() + token_idx * kNumTopk + lane_idx)) :
-                (kNumSharedExperts > 0 and lane_idx == kNumTopk ? static_cast<int>(kNumTopk) : -1);
+                (kNumSharedExperts > 0 and not kUseBF16Shared and lane_idx == kNumTopk ?
+                    static_cast<int>(kNumTopk) : -1);
             const uint32_t total_mask = __ballot_sync(0xffffffff, stored_topk_slot_idx >= 0);
 
             // Iterate all chunks
@@ -1474,6 +1739,52 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                         math::advance_ptr(y, static_cast<uint64_t>(token_idx) * kNumHiddenBytes + chunk_byte_offset),
                         combine_store_buffer, kNumChunkBytes);
                     cute::tma_store_arrive();
+                }
+                __syncwarp();
+            }
+
+            if constexpr (kApplyRMSNorm) {
+                // Preserve the unfused contract: combine first rounds routed
+                // values to BF16, then RMSNorm consumes those BF16 values.
+                ptx::tma_store_wait<0>();
+                __syncwarp();
+
+                constexpr uint32_t kNumTokenUint4 = kNumHiddenBytes / sizeof(uint4);
+                auto token_ptr = math::advance_ptr<uint4>(
+                    y, static_cast<uint64_t>(token_idx) * kNumHiddenBytes);
+                const auto gamma_ptr = reinterpret_cast<const uint4*>(rms_weight);
+                float local_sum_sq = 0.0f;
+                #pragma unroll
+                for (uint32_t vec_idx = lane_idx; vec_idx < kNumTokenUint4; vec_idx += 32) {
+                    const auto raw = token_ptr[vec_idx];
+                    const auto bf16x2 = reinterpret_cast<const nv_bfloat162*>(&raw);
+                    #pragma unroll
+                    for (uint32_t i = 0; i < kNumElemsPerUint4; ++ i) {
+                        const auto values = __bfloat1622float2(bf16x2[i]);
+                        local_sum_sq = fmaf(values.x, values.x, local_sum_sq);
+                        local_sum_sq = fmaf(values.y, values.y, local_sum_sq);
+                    }
+                }
+                const float sum_sq = math::warp_reduce_sum(local_sum_sq);
+                const float inv_rms = rsqrtf(
+                    sum_sq / static_cast<float>(kHidden) + rms_epsilon);
+
+                #pragma unroll
+                for (uint32_t vec_idx = lane_idx; vec_idx < kNumTokenUint4; vec_idx += 32) {
+                    const auto raw = token_ptr[vec_idx];
+                    const auto gamma_raw = gamma_ptr[vec_idx];
+                    const auto bf16x2 = reinterpret_cast<const nv_bfloat162*>(&raw);
+                    const auto gamma_bf16x2 = reinterpret_cast<const nv_bfloat162*>(&gamma_raw);
+                    uint4 normalized;
+                    auto normalized_bf16x2 = reinterpret_cast<nv_bfloat162*>(&normalized);
+                    #pragma unroll
+                    for (uint32_t i = 0; i < kNumElemsPerUint4; ++ i) {
+                        const auto values = __bfloat1622float2(bf16x2[i]);
+                        const auto gamma = __bfloat1622float2(gamma_bf16x2[i]);
+                        normalized_bf16x2[i] = __float22bfloat162_rn(
+                            __fmul2_rn(__fmul2_rn(values, gamma), {inv_rms, inv_rms}));
+                    }
+                    token_ptr[vec_idx] = normalized;
                 }
                 __syncwarp();
             }

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
@@ -735,6 +735,8 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                 constexpr uint32_t kSharedL2ShapeK = kUseBF16Shared ?
                     kSharedIntermediateHidden : SHARED_L2_SHAPE_K;
                 const auto num_expected_blocks = (kSharedL2ShapeK / BLOCK_N) * 2;
+                // The counter is monotonic and another shared task may advance
+                // it past this task's readiness threshold before we observe it.
                 while (ptx::ld_acq(ptr) < num_expected_blocks);
             }
 
@@ -1580,7 +1582,8 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                             if (task_info.is_shared()) {
                                 void* shared_output_base = shared_y;
                                 uint64_t shared_output_offset = 0;
-                                uint64_t shared_column_offset = n_idx;
+                                uint64_t shared_column_offset =
+                                    n_idx + (lane_idx % 16) * 8;
                                 if constexpr (kPublishSharedRS) {
                                     const auto current_index = __ldg(shared_rs_flags);
                                     const auto bytes_per_buffer = __ldg(shared_rs_flags + 2);
@@ -1596,14 +1599,14 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                                         static_cast<uint64_t>(current_index) * bytes_per_buffer
                                         + static_cast<uint64_t>(sym_buffer.rank_idx) * kSharedShard
                                               * sizeof(nv_bfloat16);
-                                    shared_column_offset = n_idx - destination_rank * kSharedShard;
+                                    shared_column_offset =
+                                        vector_n - destination_rank * kSharedShard;
                                 }
                                 const auto dst_ptr = math::advance_ptr<float4>(
                                     shared_output_base,
                                     shared_output_offset
                                     + static_cast<uint64_t>(dst_token_idx) * kSharedHidden * sizeof(nv_bfloat16)
-                                    + shared_column_offset * sizeof(nv_bfloat16)
-                                    + (lane_idx % 16) * sizeof(float4));
+                                    + shared_column_offset * sizeof(nv_bfloat16));
                                 *dst_ptr = packed;
                                 continue;
                             }

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
@@ -43,6 +43,7 @@ template <
     bool kUseBF16Shared,
     bool kApplyRMSNorm,
     bool kPublishSharedRS,
+    bool kPublishSharedSPRS,
     bool kHasShared = (kNumSharedExperts > 0),
     uint32_t L1_SHAPE_N = kIntermediateHidden * 2,
     uint32_t L1_SHAPE_K = kHidden,
@@ -69,6 +70,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                             const float rms_epsilon,
                             int* cumulative_local_expert_recv_stats,
                             const uint32_t num_tokens,
+                            const uint32_t num_shared_tokens,
                             const __grid_constant__ layout::SymBuffer<kNumRanks> sym_buffer,
                             const __grid_constant__ cute::TmaDescriptor tensor_map_l1_acts,
                             const __grid_constant__ cute::TmaDescriptor tensor_map_l1_acts_sf,
@@ -101,8 +103,11 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
     DG_STATIC_ASSERT(not kUseBF16Shared or kNumSharedExperts > 0, "BF16 shared mode requires shared work");
     DG_STATIC_ASSERT(not kApplyRMSNorm or kUseBF16Shared, "Fused RMSNorm is only supported with BF16 shared mode");
     DG_STATIC_ASSERT(not kPublishSharedRS or kUseBF16Shared, "Shared ReduceScatter publication requires BF16 shared mode");
-    DG_STATIC_ASSERT(not kPublishSharedRS or kSharedHidden % kNumRanks == 0, "Shared hidden must shard evenly across ranks");
-    DG_STATIC_ASSERT(not kPublishSharedRS or (kSharedHidden / kNumRanks) % 8 == 0,
+    DG_STATIC_ASSERT(not kPublishSharedSPRS or kPublishSharedRS,
+                     "SP publication requires shared ReduceScatter publication");
+    DG_STATIC_ASSERT(not kPublishSharedRS or kPublishSharedSPRS or kSharedHidden % kNumRanks == 0,
+                     "Shared hidden must shard evenly across ranks");
+    DG_STATIC_ASSERT(not kPublishSharedRS or kPublishSharedSPRS or (kSharedHidden / kNumRanks) % 8 == 0,
                      "Shared ReduceScatter shards must align to vector stores");
 
     // Thread indices
@@ -1072,7 +1077,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
 
         // Do mainloop by the leader CTA
         if (is_leader_cta)
-            scheduler.mainloop(num_tokens);
+            scheduler.mainloop(num_tokens, num_shared_tokens);
     } else if (warp_idx >= kNumDispatchWarps + kNumMMANonEpilogueWarps) {
         // Adjust registers
         cutlass::arch::warpgroup_reg_alloc<kNumEpilogueRegisters>();
@@ -1582,6 +1587,7 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                             if (task_info.is_shared()) {
                                 void* shared_output_base = shared_y;
                                 uint64_t shared_output_offset = 0;
+                                uint32_t shared_output_row = dst_token_idx;
                                 uint64_t shared_column_offset =
                                     n_idx + (lane_idx % 16) * 8;
                                 if constexpr (kPublishSharedRS) {
@@ -1590,25 +1596,44 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                                     // completion signaling before consumption.
                                     const auto current_index = __ldg(shared_rs_flags);
                                     const auto bytes_per_buffer = __ldg(shared_rs_flags + 2);
-                                    constexpr uint32_t kSharedShard =
-                                        kSharedHidden / kNumRanks;
                                     const auto vector_n =
                                         n_idx + (lane_idx % 16) * 8;
-                                    const auto destination_rank =
-                                        vector_n / kSharedShard;
-                                    shared_output_base = reinterpret_cast<void*>(
-                                        __ldg(shared_rs_peer_ptrs + destination_rank));
-                                    shared_output_offset =
-                                        static_cast<uint64_t>(current_index) * bytes_per_buffer
-                                        + static_cast<uint64_t>(sym_buffer.rank_idx) * kSharedShard
-                                              * sizeof(nv_bfloat16);
-                                    shared_column_offset =
-                                        vector_n - destination_rank * kSharedShard;
+                                    if constexpr (kPublishSharedSPRS) {
+                                        const auto tokens_per_rank =
+                                            num_shared_tokens / kNumRanks;
+                                        const auto destination_rank =
+                                            dst_token_idx / tokens_per_rank;
+                                        const auto destination_token =
+                                            dst_token_idx - destination_rank * tokens_per_rank;
+                                        shared_output_base = reinterpret_cast<void*>(
+                                            __ldg(shared_rs_peer_ptrs + destination_rank));
+                                        shared_output_offset =
+                                            static_cast<uint64_t>(current_index) * bytes_per_buffer
+                                            + static_cast<uint64_t>(sym_buffer.rank_idx)
+                                                  * kSharedHidden * sizeof(nv_bfloat16);
+                                        shared_output_row = destination_token;
+                                        shared_column_offset = vector_n;
+                                    } else {
+                                        constexpr uint32_t kSharedShard =
+                                            kSharedHidden / kNumRanks;
+                                        const auto destination_rank =
+                                            vector_n / kSharedShard;
+                                        shared_output_base = reinterpret_cast<void*>(
+                                            __ldg(shared_rs_peer_ptrs + destination_rank));
+                                        shared_output_offset =
+                                            static_cast<uint64_t>(current_index) * bytes_per_buffer
+                                            + static_cast<uint64_t>(sym_buffer.rank_idx) * kSharedShard
+                                                  * sizeof(nv_bfloat16);
+                                        shared_column_offset =
+                                            vector_n - destination_rank * kSharedShard;
+                                    }
                                 }
                                 const auto dst_ptr = math::advance_ptr<float4>(
                                     shared_output_base,
                                     shared_output_offset
-                                    + static_cast<uint64_t>(dst_token_idx) * kSharedHidden * sizeof(nv_bfloat16)
+                                    + static_cast<uint64_t>(shared_output_row)
+                                          * (kPublishSharedSPRS ? kNumRanks : 1)
+                                          * kSharedHidden * sizeof(nv_bfloat16)
                                     + shared_column_offset * sizeof(nv_bfloat16));
                                 *dst_ptr = packed;
                                 continue;

--- a/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm100_fp8_fp4_mega_moe.cuh
@@ -1585,6 +1585,9 @@ sm100_fp8_fp4_mega_moe_impl(void* y,
                                 uint64_t shared_column_offset =
                                     n_idx + (lane_idx % 16) * 8;
                                 if constexpr (kPublishSharedRS) {
+                                    // This path publishes payload only. The
+                                    // caller owns cross-rank visibility and
+                                    // completion signaling before consumption.
                                     const auto current_index = __ldg(shared_rs_flags);
                                     const auto bytes_per_buffer = __ldg(shared_rs_flags + 2);
                                     constexpr uint32_t kSharedShard =

--- a/deep_gemm/include/deep_gemm/scheduler/mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/scheduler/mega_moe.cuh
@@ -381,13 +381,14 @@ struct MegaMoEScheduler {
         }
     }
 
-    CUTLASS_DEVICE void mainloop(const uint32_t& num_tokens) {
+    CUTLASS_DEVICE void mainloop(const uint32_t& num_tokens,
+                                 const uint32_t& num_shared_tokens) {
         const auto lane_idx = ptx::get_lane_idx();
 
         if constexpr (kHasShared) {
             // Shared expert L1 tasks do not depend on dispatch.
             shared_mainloop<BlockPhase::SharedLinear1, SHARED_L1_SHAPE_N, SHARED_L1_SHAPE_K>(
-                num_tokens, lane_idx, workspace.get_shared_l1_task_count_ptr());
+                num_shared_tokens, lane_idx, workspace.get_shared_l1_task_count_ptr());
         }
 
         // Wait dispatch's results
@@ -406,7 +407,7 @@ struct MegaMoEScheduler {
         if constexpr (kHasShared) {
             // Shared expert L2 tasks depend on SharedLinear1 completion.
             shared_mainloop<BlockPhase::SharedLinear2, SHARED_L2_SHAPE_N, SHARED_L2_SHAPE_K>(
-                num_tokens, lane_idx, workspace.get_shared_l2_task_count_ptr());
+                num_shared_tokens, lane_idx, workspace.get_shared_l2_task_count_ptr());
         }
 
         // Sentinel.

--- a/deep_gemm/include/deep_gemm/scheduler/mega_moe.cuh
+++ b/deep_gemm/include/deep_gemm/scheduler/mega_moe.cuh
@@ -144,6 +144,10 @@ template <uint32_t BLOCK_M, uint32_t BLOCK_N, uint32_t BLOCK_K,
           uint32_t kNumSMs, uint32_t kNumRanks,
           uint32_t kNumRingBlocks,
           uint32_t kNumSharedExperts = 0,
+          uint32_t SHARED_L1_SHAPE_N = L1_SHAPE_N * kNumSharedExperts,
+          uint32_t SHARED_L1_SHAPE_K = L1_SHAPE_K,
+          uint32_t SHARED_L2_SHAPE_N = L2_SHAPE_N,
+          uint32_t SHARED_L2_SHAPE_K = L2_SHAPE_K * kNumSharedExperts,
           uint32_t SHARED_BLOCK_K = BLOCK_K,
           uint32_t kNumExpertsPerLane = math::constexpr_ceil_div(kNumExpertsPerRank, 32u),
           uint32_t kNumL1BlockNs = L1_SHAPE_N / BLOCK_N,
@@ -152,10 +156,6 @@ template <uint32_t BLOCK_M, uint32_t BLOCK_N, uint32_t BLOCK_K,
           uint32_t kNumL2Clusters = kNumL2BlockNs / 2>
 struct MegaMoEScheduler {
     static constexpr bool kHasShared = kNumSharedExperts > 0;
-    static constexpr uint32_t SHARED_L1_SHAPE_N = L1_SHAPE_N * kNumSharedExperts;
-    static constexpr uint32_t SHARED_L1_SHAPE_K = L1_SHAPE_K;
-    static constexpr uint32_t SHARED_L2_SHAPE_N = L2_SHAPE_N;
-    static constexpr uint32_t SHARED_L2_SHAPE_K = L2_SHAPE_K * kNumSharedExperts;
     using task_info_t = TaskInfo<kHasShared>;
 
     DG_STATIC_ASSERT(L1_SHAPE_N % (BLOCK_N * 2) == 0, "Invalid shape");

--- a/deep_gemm/mega/__init__.py
+++ b/deep_gemm/mega/__init__.py
@@ -274,6 +274,10 @@ def fp8_fp4_mega_moe_bf16_shared(
         fast_math: bool = True,
         situ_beta: Optional[float] = None,
         situ_linear_beta: Optional[float] = None):
+    if sym_buffer.num_shared_experts != 0:
+        raise ValueError(
+            'BF16 shared MegaMoE requires num_shared_experts=0 because its '
+            'intermediate is stored outside the symmetric routed buffer')
     assert sym_buffer.shared_bf16_l2_acts is not None, \
         'SymmBuffer was not initialized with a BF16 shared intermediate'
     _C.fp8_fp4_mega_moe_bf16_shared(
@@ -312,7 +316,17 @@ def fp8_fp4_mega_moe_bf16_shared_rs(
         fast_math: bool = True,
         situ_beta: Optional[float] = None,
         situ_linear_beta: Optional[float] = None):
-    """Publish BF16 shared outputs into a symmetric ReduceScatter buffer."""
+    """Publish BF16 shared outputs into a symmetric ReduceScatter buffer.
+
+    ``shared_rs_flags[0]`` selects one of at least three workspace generations
+    and ``shared_rs_flags[2]`` is the byte stride between generations. This
+    kernel only writes the selected generation; the caller must make remote
+    stores visible and publish its own completion signal before consuming it.
+    """
+    if sym_buffer.num_shared_experts != 0:
+        raise ValueError(
+            'BF16 shared MegaMoE requires num_shared_experts=0 because its '
+            'intermediate is stored outside the symmetric routed buffer')
     assert sym_buffer.shared_bf16_l2_acts is not None, \
         'SymmBuffer was not initialized with a BF16 shared intermediate'
     _C.fp8_fp4_mega_moe_bf16_shared(

--- a/deep_gemm/mega/__init__.py
+++ b/deep_gemm/mega/__init__.py
@@ -288,7 +288,47 @@ def fp8_fp4_mega_moe_bf16_shared(
         sym_buffer.num_max_tokens_per_rank,
         sym_buffer.num_experts, sym_buffer.num_topk,
         recipe, activation, fast_math,
-        situ_beta, situ_linear_beta
+        situ_beta, situ_linear_beta,
+        None, None, None
+    )
+
+
+def fp8_fp4_mega_moe_bf16_shared_rs(
+        y: torch.Tensor,
+        l1_weights: Tuple[torch.Tensor, torch.Tensor],
+        l2_weights: Tuple[torch.Tensor, torch.Tensor],
+        shared_x: torch.Tensor,
+        shared_l1_weights: torch.Tensor,
+        shared_l2_weights: torch.Tensor,
+        rms_weight: torch.Tensor,
+        rms_epsilon: float,
+        shared_rs_workspace: torch.Tensor,
+        shared_rs_flags: torch.Tensor,
+        shared_rs_peer_ptrs: torch.Tensor,
+        sym_buffer: SymmBuffer,
+        cumulative_local_expert_recv_stats: Optional[torch.Tensor] = None,
+        recipe: Tuple[int, int, int] = (1, 1, 32),
+        activation: str = 'situ',
+        fast_math: bool = True,
+        situ_beta: Optional[float] = None,
+        situ_linear_beta: Optional[float] = None):
+    """Publish BF16 shared outputs into a symmetric ReduceScatter buffer."""
+    assert sym_buffer.shared_bf16_l2_acts is not None, \
+        'SymmBuffer was not initialized with a BF16 shared intermediate'
+    _C.fp8_fp4_mega_moe_bf16_shared(
+        y, None,
+        l1_weights, l2_weights,
+        shared_x, sym_buffer.shared_bf16_l2_acts,
+        shared_l1_weights, shared_l2_weights,
+        rms_weight, rms_epsilon,
+        cumulative_local_expert_recv_stats,
+        sym_buffer.buffer,
+        sym_buffer.handle.buffer_ptrs, sym_buffer.group.rank(),
+        sym_buffer.num_max_tokens_per_rank,
+        sym_buffer.num_experts, sym_buffer.num_topk,
+        recipe, activation, fast_math,
+        situ_beta, situ_linear_beta,
+        shared_rs_workspace, shared_rs_flags, shared_rs_peer_ptrs
     )
 
 

--- a/deep_gemm/mega/__init__.py
+++ b/deep_gemm/mega/__init__.py
@@ -257,9 +257,9 @@ def fp4_fp4_mega_moe(y: torch.Tensor,
     )
 
 
-def fp8_fp4_mega_moe_bf16_shared(
+def _fp8_fp4_mega_moe_bf16_shared(
         y: torch.Tensor,
-        shared_y: torch.Tensor,
+        shared_y: Optional[torch.Tensor],
         l1_weights: Tuple[torch.Tensor, torch.Tensor],
         l2_weights: Tuple[torch.Tensor, torch.Tensor],
         shared_x: torch.Tensor,
@@ -268,6 +268,9 @@ def fp8_fp4_mega_moe_bf16_shared(
         rms_weight: torch.Tensor,
         rms_epsilon: float,
         sym_buffer: SymmBuffer,
+        shared_rs_workspace: Optional[torch.Tensor],
+        shared_rs_flags: Optional[torch.Tensor],
+        shared_rs_peer_ptrs: Optional[torch.Tensor],
         cumulative_local_expert_recv_stats: Optional[torch.Tensor] = None,
         recipe: Tuple[int, int, int] = (1, 1, 32),
         activation: str = 'situ',
@@ -293,7 +296,37 @@ def fp8_fp4_mega_moe_bf16_shared(
         sym_buffer.num_experts, sym_buffer.num_topk,
         recipe, activation, fast_math,
         situ_beta, situ_linear_beta,
-        None, None, None
+        shared_rs_workspace, shared_rs_flags, shared_rs_peer_ptrs
+    )
+
+
+def fp8_fp4_mega_moe_bf16_shared(
+        y: torch.Tensor,
+        shared_y: torch.Tensor,
+        l1_weights: Tuple[torch.Tensor, torch.Tensor],
+        l2_weights: Tuple[torch.Tensor, torch.Tensor],
+        shared_x: torch.Tensor,
+        shared_l1_weights: torch.Tensor,
+        shared_l2_weights: torch.Tensor,
+        rms_weight: torch.Tensor,
+        rms_epsilon: float,
+        sym_buffer: SymmBuffer,
+        cumulative_local_expert_recv_stats: Optional[torch.Tensor] = None,
+        recipe: Tuple[int, int, int] = (1, 1, 32),
+        activation: str = 'situ',
+        fast_math: bool = True,
+        situ_beta: Optional[float] = None,
+        situ_linear_beta: Optional[float] = None):
+    _fp8_fp4_mega_moe_bf16_shared(
+        y, shared_y,
+        l1_weights, l2_weights,
+        shared_x, shared_l1_weights, shared_l2_weights,
+        rms_weight, rms_epsilon,
+        sym_buffer,
+        None, None, None,
+        cumulative_local_expert_recv_stats,
+        recipe, activation, fast_math,
+        situ_beta, situ_linear_beta
     )
 
 
@@ -323,26 +356,16 @@ def fp8_fp4_mega_moe_bf16_shared_rs(
     kernel only writes the selected generation; the caller must make remote
     stores visible and publish its own completion signal before consuming it.
     """
-    if sym_buffer.num_shared_experts != 0:
-        raise ValueError(
-            'BF16 shared MegaMoE requires num_shared_experts=0 because its '
-            'intermediate is stored outside the symmetric routed buffer')
-    assert sym_buffer.shared_bf16_l2_acts is not None, \
-        'SymmBuffer was not initialized with a BF16 shared intermediate'
-    _C.fp8_fp4_mega_moe_bf16_shared(
+    _fp8_fp4_mega_moe_bf16_shared(
         y, None,
         l1_weights, l2_weights,
-        shared_x, sym_buffer.shared_bf16_l2_acts,
-        shared_l1_weights, shared_l2_weights,
+        shared_x, shared_l1_weights, shared_l2_weights,
         rms_weight, rms_epsilon,
+        sym_buffer,
+        shared_rs_workspace, shared_rs_flags, shared_rs_peer_ptrs,
         cumulative_local_expert_recv_stats,
-        sym_buffer.buffer,
-        sym_buffer.handle.buffer_ptrs, sym_buffer.group.rank(),
-        sym_buffer.num_max_tokens_per_rank,
-        sym_buffer.num_experts, sym_buffer.num_topk,
         recipe, activation, fast_math,
-        situ_beta, situ_linear_beta,
-        shared_rs_workspace, shared_rs_flags, shared_rs_peer_ptrs
+        situ_beta, situ_linear_beta
     )
 
 

--- a/deep_gemm/mega/__init__.py
+++ b/deep_gemm/mega/__init__.py
@@ -22,7 +22,8 @@ class SymmBuffer:
                  hidden: int, intermediate_hidden: int,
                  num_shared_experts: int = 0,
                  mma_type: str = 'fp8xfp4',
-                 activation: str = 'swiglu'):
+                 activation: str = 'swiglu',
+                 bf16_shared_intermediate_hidden: int = 0):
         assert activation == 'swiglu' or (mma_type == 'fp8xfp4' and activation == 'situ'), \
             f'Only FP8xFP4 MegaMoE supports `situ`, got mma_type={mma_type!r}, activation={activation!r}'
         self.group = group
@@ -34,6 +35,7 @@ class SymmBuffer:
         self.num_shared_experts = num_shared_experts
         self.mma_type = mma_type
         self.activation = activation
+        self.bf16_shared_intermediate_hidden = bf16_shared_intermediate_hidden
 
         # Allocate a symmetric buffer
         num_bytes, slice_input_buffers = _C.get_symm_buffer_size_for_mega_moe(
@@ -61,6 +63,13 @@ class SymmBuffer:
          self.shared_l2_acts, self.shared_l2_acts_sf,
          self.l1_acts, self.l1_acts_sf,
          self.l2_acts, self.l2_acts_sf) = slice_input_buffers(self.buffer)
+        self.shared_bf16_l2_acts = (
+            torch.empty(
+                (num_max_tokens_per_rank, bf16_shared_intermediate_hidden),
+                dtype=torch.bfloat16,
+                device='cuda')
+            if bf16_shared_intermediate_hidden > 0 else None
+        )
 
     def destroy(self):
         self.handle = None
@@ -68,6 +77,7 @@ class SymmBuffer:
         self.group = None
         self.x = None
         self.x_sf = None
+        self.shared_bf16_l2_acts = None
 
 
 def get_symm_buffer_for_mega_moe(group: dist.ProcessGroup,
@@ -77,7 +87,8 @@ def get_symm_buffer_for_mega_moe(group: dist.ProcessGroup,
                                  num_shared_experts: int = 0,
                                  use_fp8_dispatch: Union[bool, None] = None,
                                  mma_type: str = 'fp8xfp4',
-                                 activation: str = 'swiglu') -> SymmBuffer:
+                                 activation: str = 'swiglu',
+                                 bf16_shared_intermediate_hidden: int = 0) -> SymmBuffer:
     # Align token count
     num_max_tokens_per_rank = align(num_max_tokens_per_rank, _C.get_token_alignment_for_mega_moe())
 
@@ -94,7 +105,8 @@ def get_symm_buffer_for_mega_moe(group: dist.ProcessGroup,
         num_max_tokens_per_rank, num_topk,
         hidden, intermediate_hidden,
         num_shared_experts,
-        mma_type=mma_type, activation=activation
+        mma_type=mma_type, activation=activation,
+        bf16_shared_intermediate_hidden=bf16_shared_intermediate_hidden
     )
 
 
@@ -139,8 +151,10 @@ def transform_weights_for_mega_moe(
 ) -> Tuple[Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]],
            Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]]:
     assert activation in ('swiglu', 'situ'), f'Unsupported activation: {activation!r}'
-    assert activation != 'situ' or (isinstance(l1_weights, tuple) and isinstance(l2_weights, tuple)), \
-        '`situ` requires FP8xFP4 `(weight, sf)` tuples for both L1 and L2 weights'
+    assert activation != 'situ' or (
+        (isinstance(l1_weights, tuple) and isinstance(l2_weights, tuple))
+        or (isinstance(l1_weights, torch.Tensor) and isinstance(l2_weights, torch.Tensor))
+    ), '`situ` requires matching tensor or `(weight, sf)` weight pairs'
     if isinstance(l1_weights, tuple):
         # Scaled FP8xFP4/NVFP4: both formats use the same MN-major SF layout.
         # Interleave gate/up for weight and SF, then transpose L1 SF for UTCCP.
@@ -241,6 +255,42 @@ def fp4_fp4_mega_moe(y: torch.Tensor,
         fast_math,
         l1_alphas, l2_alphas, a2_scales, routed_scaling_factor
     )
+
+
+def fp8_fp4_mega_moe_bf16_shared(
+        y: torch.Tensor,
+        shared_y: torch.Tensor,
+        l1_weights: Tuple[torch.Tensor, torch.Tensor],
+        l2_weights: Tuple[torch.Tensor, torch.Tensor],
+        shared_x: torch.Tensor,
+        shared_l1_weights: torch.Tensor,
+        shared_l2_weights: torch.Tensor,
+        rms_weight: torch.Tensor,
+        rms_epsilon: float,
+        sym_buffer: SymmBuffer,
+        cumulative_local_expert_recv_stats: Optional[torch.Tensor] = None,
+        recipe: Tuple[int, int, int] = (1, 1, 32),
+        activation: str = 'situ',
+        fast_math: bool = True,
+        situ_beta: Optional[float] = None,
+        situ_linear_beta: Optional[float] = None):
+    assert sym_buffer.shared_bf16_l2_acts is not None, \
+        'SymmBuffer was not initialized with a BF16 shared intermediate'
+    _C.fp8_fp4_mega_moe_bf16_shared(
+        y, shared_y,
+        l1_weights, l2_weights,
+        shared_x, sym_buffer.shared_bf16_l2_acts,
+        shared_l1_weights, shared_l2_weights,
+        rms_weight, rms_epsilon,
+        cumulative_local_expert_recv_stats,
+        sym_buffer.buffer,
+        sym_buffer.handle.buffer_ptrs, sym_buffer.group.rank(),
+        sym_buffer.num_max_tokens_per_rank,
+        sym_buffer.num_experts, sym_buffer.num_topk,
+        recipe, activation, fast_math,
+        situ_beta, situ_linear_beta
+    )
+
 
 def bf16_mega_moe(y: torch.Tensor,
                   l1_weights: torch.Tensor,

--- a/deep_gemm/mega/__init__.py
+++ b/deep_gemm/mega/__init__.py
@@ -15,6 +15,11 @@ except Exception as exception:
 from .. import _C
 
 
+def supports_bf16_shared_independent_tokens() -> bool:
+    """Return whether BF16 shared and routed work may use different M."""
+    return True
+
+
 class SymmBuffer:
     def __init__(self, group: dist.ProcessGroup,
                  num_experts: int,
@@ -271,6 +276,7 @@ def _fp8_fp4_mega_moe_bf16_shared(
         shared_rs_workspace: Optional[torch.Tensor],
         shared_rs_flags: Optional[torch.Tensor],
         shared_rs_peer_ptrs: Optional[torch.Tensor],
+        publish_shared_sp_rs: bool,
         cumulative_local_expert_recv_stats: Optional[torch.Tensor] = None,
         recipe: Tuple[int, int, int] = (1, 1, 32),
         activation: str = 'situ',
@@ -296,7 +302,8 @@ def _fp8_fp4_mega_moe_bf16_shared(
         sym_buffer.num_experts, sym_buffer.num_topk,
         recipe, activation, fast_math,
         situ_beta, situ_linear_beta,
-        shared_rs_workspace, shared_rs_flags, shared_rs_peer_ptrs
+        shared_rs_workspace, shared_rs_flags, shared_rs_peer_ptrs,
+        publish_shared_sp_rs
     )
 
 
@@ -323,7 +330,7 @@ def fp8_fp4_mega_moe_bf16_shared(
         shared_x, shared_l1_weights, shared_l2_weights,
         rms_weight, rms_epsilon,
         sym_buffer,
-        None, None, None,
+        None, None, None, False,
         cumulative_local_expert_recv_stats,
         recipe, activation, fast_math,
         situ_beta, situ_linear_beta
@@ -362,7 +369,40 @@ def fp8_fp4_mega_moe_bf16_shared_rs(
         shared_x, shared_l1_weights, shared_l2_weights,
         rms_weight, rms_epsilon,
         sym_buffer,
-        shared_rs_workspace, shared_rs_flags, shared_rs_peer_ptrs,
+        shared_rs_workspace, shared_rs_flags, shared_rs_peer_ptrs, False,
+        cumulative_local_expert_recv_stats,
+        recipe, activation, fast_math,
+        situ_beta, situ_linear_beta
+    )
+
+
+def fp8_fp4_mega_moe_bf16_shared_sp_rs(
+        y: torch.Tensor,
+        l1_weights: Tuple[torch.Tensor, torch.Tensor],
+        l2_weights: Tuple[torch.Tensor, torch.Tensor],
+        shared_x: torch.Tensor,
+        shared_l1_weights: torch.Tensor,
+        shared_l2_weights: torch.Tensor,
+        rms_weight: torch.Tensor,
+        rms_epsilon: float,
+        shared_rs_workspace: torch.Tensor,
+        shared_rs_flags: torch.Tensor,
+        shared_rs_peer_ptrs: torch.Tensor,
+        sym_buffer: SymmBuffer,
+        cumulative_local_expert_recv_stats: Optional[torch.Tensor] = None,
+        recipe: Tuple[int, int, int] = (1, 1, 32),
+        activation: str = 'situ',
+        fast_math: bool = True,
+        situ_beta: Optional[float] = None,
+        situ_linear_beta: Optional[float] = None):
+    """Publish TP partials to the owning sequence-parallel token rank."""
+    _fp8_fp4_mega_moe_bf16_shared(
+        y, None,
+        l1_weights, l2_weights,
+        shared_x, shared_l1_weights, shared_l2_weights,
+        rms_weight, rms_epsilon,
+        sym_buffer,
+        shared_rs_workspace, shared_rs_flags, shared_rs_peer_ptrs, True,
         cumulative_local_expert_recv_stats,
         recipe, activation, fast_math,
         situ_beta, situ_linear_beta

--- a/tests/test_mega_moe_situ.py
+++ b/tests/test_mega_moe_situ.py
@@ -11,6 +11,7 @@ sys.path.insert(
 
 import torch
 import torch.distributed as dist
+import torch.nn.functional as F
 
 import deep_gemm
 from deep_gemm.utils import per_token_cast_to_fp4, per_token_cast_to_fp8
@@ -23,6 +24,8 @@ NUM_TOPK = 1
 NUM_TOKENS = 64
 HIDDEN = 1024
 INTERMEDIATE = 512
+SHARED_HIDDEN = 2048
+SHARED_INTERMEDIATE = 1024
 
 
 class Case(NamedTuple):
@@ -199,6 +202,145 @@ def _worker(local_rank: int, master_port: int) -> None:
             dist.destroy_process_group()
 
 
+def _bf16_shared_worker(local_rank: int, master_port: int) -> None:
+    os.environ['MASTER_ADDR'] = '127.0.0.1'
+    os.environ['MASTER_PORT'] = str(master_port)
+    os.environ['WORLD_SIZE'] = '1'
+    os.environ['RANK'] = '0'
+
+    buffer = None
+    try:
+        _, _, group = init_dist(local_rank, NUM_RANKS)
+        generator = torch.Generator(device='cuda')
+        generator.manual_seed(20260823)
+
+        def randn(shape: Tuple[int, ...], scale: float) -> torch.Tensor:
+            return torch.randn(
+                shape,
+                dtype=torch.bfloat16,
+                device='cuda',
+                generator=generator).mul_(scale)
+
+        routed_x = randn((NUM_TOKENS, HIDDEN), 0.5)
+        routed_l1 = randn(
+            (NUM_EXPERTS, INTERMEDIATE * 2, HIDDEN), 0.04)
+        routed_l2 = randn(
+            (NUM_EXPERTS, HIDDEN, INTERMEDIATE), 0.04)
+        shared_x = randn((NUM_TOKENS, SHARED_HIDDEN), 0.25)
+        shared_l1 = randn(
+            (SHARED_INTERMEDIATE * 2, SHARED_HIDDEN), 0.02)
+        shared_l2 = randn(
+            (SHARED_HIDDEN, SHARED_INTERMEDIATE), 0.02)
+        rms_weight = randn((HIDDEN,), 0.1).add_(1.0)
+        rms_epsilon = 1e-6
+        situ_beta = 1.25
+        situ_linear_beta = 1.5
+
+        routed_x_fp8, routed_x_sf = per_token_cast_to_fp8(
+            routed_x,
+            use_ue8m0=True,
+            gran_k=32,
+            use_packed_ue8m0=True)
+        transformed_routed_l1, transformed_routed_l2 = (
+            deep_gemm.transform_weights_for_mega_moe(
+                _cast_weights_to_fp4(routed_l1),
+                _cast_weights_to_fp4(routed_l2),
+                activation='situ'))
+        transformed_shared_l1, transformed_shared_l2 = (
+            deep_gemm.transform_weights_for_mega_moe(
+                shared_l1, shared_l2, activation='situ'))
+        topk_idx = (
+            torch.arange(NUM_TOKENS, device='cuda', dtype=torch.long)
+            % NUM_EXPERTS
+        ).view(NUM_TOKENS, NUM_TOPK)
+        topk_weights = torch.ones(
+            (NUM_TOKENS, NUM_TOPK), device='cuda', dtype=torch.float)
+
+        buffer = deep_gemm.get_symm_buffer_for_mega_moe(
+            group,
+            NUM_EXPERTS,
+            NUM_TOKENS,
+            NUM_TOPK,
+            HIDDEN,
+            INTERMEDIATE,
+            mma_type='fp8xfp4',
+            activation='situ',
+            bf16_shared_intermediate_hidden=SHARED_INTERMEDIATE)
+
+        def prepare_inputs() -> None:
+            buffer.buffer.zero_()
+            buffer.x[:NUM_TOKENS].copy_(routed_x_fp8)
+            buffer.x_sf[:NUM_TOKENS].copy_(routed_x_sf)
+            buffer.topk_idx[:NUM_TOKENS].copy_(topk_idx)
+            buffer.topk_weights[:NUM_TOKENS].copy_(topk_weights)
+
+        # Reference routed output: existing routed-only kernel followed by the
+        # BF16-input RMSNorm contract used by Kimi K3.
+        prepare_inputs()
+        routed_unnormalized = torch.empty(
+            (NUM_TOKENS, HIDDEN), dtype=torch.bfloat16, device='cuda')
+        deep_gemm.fp8_fp4_mega_moe(
+            routed_unnormalized,
+            transformed_routed_l1,
+            transformed_routed_l2,
+            buffer,
+            activation='situ',
+            situ_beta=situ_beta,
+            situ_linear_beta=situ_linear_beta)
+        routed_fp32 = routed_unnormalized.float()
+        routed_reference = (
+            routed_fp32
+            * torch.rsqrt(routed_fp32.square().mean(-1, keepdim=True)
+                          + rms_epsilon)
+            * rms_weight.float()).to(torch.bfloat16)
+
+        prepare_inputs()
+        routed_actual = torch.empty_like(routed_unnormalized)
+        shared_actual = torch.empty(
+            (NUM_TOKENS, SHARED_HIDDEN),
+            dtype=torch.bfloat16,
+            device='cuda')
+        deep_gemm.fp8_fp4_mega_moe_bf16_shared(
+            routed_actual,
+            shared_actual,
+            transformed_routed_l1,
+            transformed_routed_l2,
+            shared_x,
+            transformed_shared_l1,
+            transformed_shared_l2,
+            rms_weight,
+            rms_epsilon,
+            buffer,
+            activation='situ',
+            situ_beta=situ_beta,
+            situ_linear_beta=situ_linear_beta)
+        torch.cuda.synchronize()
+
+        gate, up = F.linear(shared_x, shared_l1).chunk(2, dim=-1)
+        gate_fp32, up_fp32 = gate.float(), up.float()
+        shared_intermediate = (
+            torch.sigmoid(gate_fp32)
+            * (situ_beta * torch.tanh(gate_fp32 / situ_beta))
+            * (situ_linear_beta
+               * torch.tanh(up_fp32 / situ_linear_beta))).to(torch.bfloat16)
+        shared_reference = F.linear(
+            shared_intermediate, shared_l2).to(torch.bfloat16)
+
+        routed_error = _relative_l2(routed_actual, routed_reference)
+        shared_error = _relative_l2(shared_actual, shared_reference)
+        if routed_error >= 2e-3:
+            raise AssertionError(
+                f'fused RMSNorm relative L2 too high: {routed_error:.6f}')
+        if shared_error >= 1e-2:
+            raise AssertionError(
+                f'BF16 shared expert relative L2 too high: {shared_error:.6f}')
+    finally:
+        if buffer is not None:
+            buffer.destroy()
+        if dist.is_initialized():
+            dist.destroy_process_group()
+
+
 def _find_free_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.bind(('127.0.0.1', 0))
@@ -217,5 +359,18 @@ def test_situ_metamorphic() -> None:
         join=True)
 
 
+def test_bf16_shared_and_rms_norm() -> None:
+    if torch.cuda.device_count() < NUM_RANKS:
+        raise unittest.SkipTest('requires one CUDA device')
+    if torch.cuda.get_device_capability(0)[0] != 10:
+        raise unittest.SkipTest('requires an SM100 CUDA device')
+    torch.multiprocessing.spawn(
+        _bf16_shared_worker,
+        args=(_find_free_port(),),
+        nprocs=NUM_RANKS,
+        join=True)
+
+
 if __name__ == '__main__':
     test_situ_metamorphic()
+    test_bf16_shared_and_rms_norm()

--- a/tests/test_mega_moe_situ.py
+++ b/tests/test_mega_moe_situ.py
@@ -334,6 +334,45 @@ def _bf16_shared_worker(local_rank: int, master_port: int) -> None:
         if shared_error >= 1e-2:
             raise AssertionError(
                 f'BF16 shared expert relative L2 too high: {shared_error:.6f}')
+
+        shared_rs_workspace = torch.full(
+            (3, NUM_TOKENS, NUM_RANKS, SHARED_HIDDEN),
+            float('nan'),
+            dtype=torch.bfloat16,
+            device='cuda')
+        shared_rs_flags = torch.zeros(9, dtype=torch.int, device='cuda')
+        shared_rs_flags[2] = shared_rs_workspace[0].nbytes
+        shared_rs_peer_ptrs = torch.tensor(
+            [shared_rs_workspace.data_ptr()], dtype=torch.long, device='cuda')
+        for generation in range(3):
+            prepare_inputs()
+            routed_rs = torch.empty_like(routed_unnormalized)
+            shared_rs_flags[0] = generation
+            deep_gemm.fp8_fp4_mega_moe_bf16_shared_rs(
+                routed_rs,
+                transformed_routed_l1,
+                transformed_routed_l2,
+                shared_x,
+                transformed_shared_l1,
+                transformed_shared_l2,
+                rms_weight,
+                rms_epsilon,
+                shared_rs_workspace,
+                shared_rs_flags,
+                shared_rs_peer_ptrs,
+                buffer,
+                activation='situ',
+                situ_beta=situ_beta,
+                situ_linear_beta=situ_linear_beta)
+            torch.cuda.synchronize()
+            published = shared_rs_workspace[generation, :, 0]
+            if not torch.equal(published, shared_actual):
+                mismatch = torch.count_nonzero(
+                    published.view(torch.int16)
+                    != shared_actual.view(torch.int16)).item()
+                raise AssertionError(
+                    f'generation {generation} RS publication differs from '
+                    f'dense output in {mismatch} BF16 values')
     finally:
         if buffer is not None:
             buffer.destroy()

--- a/tests/test_mega_moe_situ.py
+++ b/tests/test_mega_moe_situ.py
@@ -21,7 +21,9 @@ from deep_gemm.utils.dist import init_dist
 NUM_RANKS = 1
 NUM_EXPERTS = 4
 NUM_TOPK = 1
+NUM_MAX_TOKENS = 96
 NUM_TOKENS = 64
+NUM_SHARED_TOKENS = 72
 HIDDEN = 1024
 INTERMEDIATE = 512
 SHARED_HIDDEN = 2048
@@ -154,7 +156,7 @@ def _worker(local_rank: int, master_port: int) -> None:
         buffer = deep_gemm.get_symm_buffer_for_mega_moe(
             group,
             NUM_EXPERTS,
-            NUM_TOKENS,
+            NUM_MAX_TOKENS,
             NUM_TOPK,
             HIDDEN,
             INTERMEDIATE,
@@ -226,7 +228,7 @@ def _bf16_shared_worker(local_rank: int, master_port: int) -> None:
             (NUM_EXPERTS, INTERMEDIATE * 2, HIDDEN), 0.04)
         routed_l2 = randn(
             (NUM_EXPERTS, HIDDEN, INTERMEDIATE), 0.04)
-        shared_x = randn((NUM_TOKENS, SHARED_HIDDEN), 0.25)
+        shared_x = randn((NUM_SHARED_TOKENS, SHARED_HIDDEN), 0.25)
         shared_l1 = randn(
             (SHARED_INTERMEDIATE * 2, SHARED_HIDDEN), 0.02)
         shared_l2 = randn(
@@ -297,7 +299,7 @@ def _bf16_shared_worker(local_rank: int, master_port: int) -> None:
         prepare_inputs()
         routed_actual = torch.empty_like(routed_unnormalized)
         shared_actual = torch.empty(
-            (NUM_TOKENS, SHARED_HIDDEN),
+            (NUM_SHARED_TOKENS, SHARED_HIDDEN),
             dtype=torch.bfloat16,
             device='cuda')
         deep_gemm.fp8_fp4_mega_moe_bf16_shared(
@@ -336,7 +338,7 @@ def _bf16_shared_worker(local_rank: int, master_port: int) -> None:
                 f'BF16 shared expert relative L2 too high: {shared_error:.6f}')
 
         shared_rs_workspace = torch.full(
-            (3, NUM_TOKENS, NUM_RANKS, SHARED_HIDDEN),
+            (3, NUM_SHARED_TOKENS, NUM_RANKS, SHARED_HIDDEN),
             float('nan'),
             dtype=torch.bfloat16,
             device='cuda')
@@ -372,6 +374,47 @@ def _bf16_shared_worker(local_rank: int, master_port: int) -> None:
                     != shared_actual.view(torch.int16)).item()
                 raise AssertionError(
                     f'generation {generation} RS publication differs from '
+                    f'dense output in {mismatch} BF16 values')
+
+        shared_sp_rs_workspace = torch.full(
+            (1, NUM_SHARED_TOKENS // NUM_RANKS, NUM_RANKS, SHARED_HIDDEN),
+            float('nan'),
+            dtype=torch.bfloat16,
+            device='cuda')
+        shared_sp_rs_flags = torch.zeros(9, dtype=torch.int, device='cuda')
+        shared_sp_rs_flags[2] = shared_sp_rs_workspace[0].nbytes
+        shared_sp_rs_peer_ptrs = torch.tensor(
+            [shared_sp_rs_workspace.data_ptr()],
+            dtype=torch.long,
+            device='cuda')
+        for generation in range(1):
+            prepare_inputs()
+            routed_sp_rs = torch.empty_like(routed_unnormalized)
+            shared_sp_rs_flags[0] = generation
+            deep_gemm.fp8_fp4_mega_moe_bf16_shared_sp_rs(
+                routed_sp_rs,
+                transformed_routed_l1,
+                transformed_routed_l2,
+                shared_x,
+                transformed_shared_l1,
+                transformed_shared_l2,
+                rms_weight,
+                rms_epsilon,
+                shared_sp_rs_workspace,
+                shared_sp_rs_flags,
+                shared_sp_rs_peer_ptrs,
+                buffer,
+                activation='situ',
+                situ_beta=situ_beta,
+                situ_linear_beta=situ_linear_beta)
+            torch.cuda.synchronize()
+            published = shared_sp_rs_workspace[generation].sum(dim=1)
+            if not torch.equal(published, shared_actual):
+                mismatch = torch.count_nonzero(
+                    published.view(torch.int16)
+                    != shared_actual.view(torch.int16)).item()
+                raise AssertionError(
+                    f'generation {generation} SP RS publication differs from '
                     f'dense output in {mismatch} BF16 values')
     finally:
         if buffer is not None:


### PR DESCRIPTION
## Summary

This PR extends the SM100 FP8/FP4 MegaMoE path with an optional BF16 shared expert for latent-MoE models such as Kimi K3. It schedules routed FP8/FP4 experts and BF16 shared L1/L2 together, applies the routed RMSNorm contract, and can publish each TP-sharded shared partial directly to a downstream symmetric workspace.

Kimi K3's routed output is latent-width (3584), while its shared output is hidden-width (7168). The final `3584 -> 7168` projection and residual combination therefore remain in the dependent vLLM tail rather than in this kernel.

This update adds sequence-parallel token publication. The routed branch still processes SP-local tokens, while the shared branch may process a different, gathered token count. Each shared partial is written directly to the rank that owns the corresponding output token.

## Implementation

- Thread `num_shared_tokens` independently from routed `num_tokens` through host validation, tensor-map creation, kernel arguments, and the MegaMoE scheduler. Shared L1/L2 task generation now uses the shared token count; routed dispatch remains unchanged.
- Add `fp8_fp4_mega_moe_bf16_shared_sp_rs` as an explicit opt-in wrapper. Existing dense shared output and hidden-dimension ReduceScatter publication APIs retain their behavior.
- In SP publication mode, shared epilogue stores use:
  - `tokens_per_rank = num_shared_tokens / num_ranks`;
  - `destination_rank = global_token / tokens_per_rank`;
  - `destination_token = global_token % tokens_per_rank`;
  - workspace layout `[generation, destination_token, source_rank, shared_hidden]`.
- The destination receives the complete hidden vector from every TP source rank. The downstream consumer reduces the source-rank dimension locally and combines it with the routed up-projection.
- Validate that the global shared token count is rank-divisible, workspace dimensions match the selected publication mode, peer pointers cover every rank, and the generation/byte-stride metadata satisfies the cross-repository ABI.
- Preserve the existing hidden-sharded publication path, including the generalized `vector_n - destination_rank * shard` column offset that avoids underflow when a shard boundary crosses a 128-column store tile.

The new behavior is compile-time specialized and optional. Calls that do not request BF16 shared work or publication instantiate the existing kernel behavior.

## Integration dependencies

The consumer is [vllm-project/vllm#53556](https://github.com/vllm-project/vllm/pull/53556). The TP8 x PP2 sequence-parallel benchmark temporarily stacked that PR on [vllm-project/vllm#54347](https://github.com/vllm-project/vllm/pull/54347); #54347 is not merged into #53556 and is not a DeepGEMM dependency.

## Test Plan

### Repository regression

`tests/test_mega_moe_situ.py` validates independent routed/shared token counts, fused RMSNorm, dense BF16 shared output, the existing published output, and the new SP publication API. Published BF16 values are compared bitwise with dense output.

```bash
python3 tests/test_mega_moe_situ.py
```

### TP8 remote-publication regression

An 8-GPU B200 harness gives each TP rank different shared weights, gathers every dense partial as the reference, calls `fp8_fp4_mega_moe_bf16_shared_sp_rs`, and compares every destination workspace value in `[local_token, source_rank, hidden]` order. The test passed twice with Kimi K3 matrix widths.

### End-to-end setup

The dependent vLLM integration used two 8xB200 nodes, TP8 x PP2 x EP8, `VLLM_KIMI_K3_SHARD_SP_SHARED_EXPERT=1`, `VLLM_KIMI_K3_GEMM_RS=1`, `max_num_seqs=128`, and `max_num_batched_tokens=32768`. Baseline and fused runs used identical nodes, image, model, scheduler settings, exact request lengths, four warmups, and `seed=2026`.

## Test Results

### TP8 producer microbenchmark

The benchmark uses Kimi K3 matrix widths (`routed H/I=3584/3072`, `shared H/I per TP rank=7168/768`), local routed M=8, global shared M=64, one routed expert per rank for the isolated replay, and 100 measured iterations. Reported latency is the maximum rank time.

Run | Dense shared output | SP token-owner publication | Change
---: | ---: | ---: | ---:
1 | 42.487 us | 42.944 us | +1.08%
2 | 42.368 us | 43.002 us | +1.50%
Mean | 42.428 us | 42.973 us | **+1.29%**

The remote token-owner publication adds about `0.55 us` to the producer kernel and replaces downstream full shared-output materialization plus SP reduction.

The original non-SP destination-scatter replay remains neutral at its measured shapes:

M | Existing shared output | Published shared output | Change
---: | ---: | ---: | ---:
32 | 0.2032 ms | 0.2030 ms | -0.09%
64 | 0.2664 ms | 0.2666 ms | +0.04%

### Downstream SP-sharded prefill

Workload: 8192 input / 1 output, concurrency 8, 128 requests.

Run | SHARD=1 baseline total tok/s | Fused + SP publication total tok/s | Change
---: | ---: | ---: | ---:
1 | 53,543.40 | 54,523.92 | +1.83%
2 | 53,084.73 | 54,776.67 | +3.19%
Mean | 53,314.06 | 54,650.29 | **+2.51%**

Mean median TTFT improves by **3.55%** (`1230.43 -> 1186.76 ms`). These end-to-end results include the dependent vLLM targeted gather and local projection tail; they are not a standalone claim for the DeepGEMM producer.

### Downstream decode

For 128 input / 1024 output at concurrency 32, the fused runs measured `773.91`, `799.72`, and `800.06 output tok/s`; the SHARD=1 baseline measured `780.46` and `783.86 tok/s`. Including the first cold fused run gives **+1.16%**; steady-state second-run comparison gives **+2.02%**.

## Accuracy

The original fused non-SP integration was evaluated on the complete GSM8K v3 test split with `lm-eval 0.4.12`, 5-shot chat-template evaluation, and greedy decoding. All 1,319 samples were retained. The SP-token extension is covered by the TP8 bitwise and serving regressions above; this full-dataset run was not repeated for the temporary #54347 benchmark stack.

|Tasks|Version|Filter|n-shot|Metric| |Value| |Stderr|
|---|---:|---|---:|---|:---:|---:|:---:|---:|
|gsm8k|3|flexible-extract|5|exact_match|↑|0.9682|±|0.0048|
|||strict-match|5|exact_match|↑|0.9689|±|0.0048|

The routed output passed the real-checkpoint comparison, and TP8 SP-published shared fragments were bit-exact against dense output.

## Compatibility

- Existing FP8/FP4 MegaMoE calls are unchanged.
- BF16 shared work, hidden-sharded publication, and SP token publication are independent opt-in modes.
- Host checks reject incompatible token counts, workspace shapes, dtypes, peer metadata, and devices before launch.
- The dependent vLLM integration retains its native fallback when the new API or supported topology is unavailable.

## Contribution notes

AI assistance was used during implementation, debugging, validation, benchmark analysis, and preparation of this PR description.
