### PR TITLE
fix: make pack_ue8m0_to_int CUDA-graph capture safe (#414)

### DIFF
--- a/deep_gemm/utils/math.py
+++ b/deep_gemm/utils/math.py
@@ -30,8 +30,10 @@ def pack_ue8m0_to_int(x: torch.Tensor):
     # region we still validate them so direct callers get a loud error; during
     # capture we skip the check to avoid a device->host sync.
     if not torch.cuda.is_current_stream_capturing():
-        assert (x >= 0).all(), "pack_ue8m0_to_int: scale values must be non-negative"
-        assert (x == x.round()).all(), "pack_ue8m0_to_int: scale values must have zero mantissa"
+        # Validate ue8m0 invariants at the bit level: sign=0, mantissa=0.
+        x_bits = x.view(torch.int)
+        assert ((x_bits >> 31) == 0).all(), "pack_ue8m0_to_int: scale values must be non-negative"
+        assert ((x_bits & 0x7FFFFF) == 0).all(), "pack_ue8m0_to_int: scale values must have zero mantissa"
     return (x_int >> 23).to(torch.uint8).view(torch.int)
 
 

--- a/deep_gemm/utils/math.py
+++ b/deep_gemm/utils/math.py
@@ -17,20 +17,24 @@ def ceil_to_ue8m0(x: torch.Tensor):
 
 
 def pack_ue8m0_to_int(x: torch.Tensor):
-    # NOTE: keep this helper CUDA-graph-capture safe. Calling `.all()` on a
-    # device tensor forces a device->host sync, which raises
-    # cudaErrorStreamCaptureUnsupported when invoked inside a captured region
-    # (e.g. SGLang's decode graph via the MegaMoE FP8 staging path).
-    #
-    # Host-side structural checks only:
+    """Pack a float32 tensor of UE8M0 scale factors into int32 (4 bytes per int).
+
+    Precondition: every element must be a power-of-two with zero mantissa and
+    non-negative sign (i.e. produced by ``ceil_to_ue8m0`` or the literal 1.0
+    padding). Violating this precondition silently produces wrong packed values
+    because the downstream GEMM/MHA kernels only validate shape/dtype, not
+    numerical content.
+
+    CUDA-graph-capture safe: ``.all()`` triggers a device→host sync which raises
+    ``cudaErrorStreamCaptureUnsupported`` inside a capture region. We therefore
+    skip the value assertions during capture and run them otherwise so that
+    direct callers outside capture still get a loud error on bad input.
+    """
     assert x.dtype == torch.float and x.size(-1) % 4 == 0
     x_int = x.view(torch.int)
-    # Value invariants (non-negative exponent, zero mantissa) are guaranteed by
-    # `ceil_to_ue8m0`, the only internal producer. When NOT inside a captured
-    # region we still validate them so direct callers get a loud error; during
-    # capture we skip the check to avoid a device->host sync.
     if not torch.cuda.is_current_stream_capturing():
-        # Validate ue8m0 invariants at the bit level: sign=0, mantissa=0.
+        # Bit-level check: sign bit == 0, mantissa bits == 0.
+        # (float round-based checks fail for subnormals like 2^-126.)
         x_bits = x.view(torch.int)
         assert ((x_bits >> 31) == 0).all(), "pack_ue8m0_to_int: scale values must be non-negative"
         assert ((x_bits & 0x7FFFFF) == 0).all(), "pack_ue8m0_to_int: scale values must have zero mantissa"

--- a/deep_gemm/utils/math.py
+++ b/deep_gemm/utils/math.py
@@ -25,11 +25,13 @@ def pack_ue8m0_to_int(x: torch.Tensor):
     # Host-side structural checks only:
     assert x.dtype == torch.float and x.size(-1) % 4 == 0
     x_int = x.view(torch.int)
-    # The value invariants (non-negative exponent, zero mantissa) are guaranteed
-    # by `ceil_to_ue8m0`, the only producer of these scale factors, so we must
-    # NOT re-check them here on device. The kernel itself traps on malformed
-    # scales, so a bad upstream caller still fails loudly, just not on the
-    # capture path.
+    # Value invariants (non-negative exponent, zero mantissa) are guaranteed by
+    # `ceil_to_ue8m0`, the only internal producer. When NOT inside a captured
+    # region we still validate them so direct callers get a loud error; during
+    # capture we skip the check to avoid a device->host sync.
+    if not torch.cuda.is_current_stream_capturing():
+        assert (x >= 0).all(), "pack_ue8m0_to_int: scale values must be non-negative"
+        assert (x == x.round()).all(), "pack_ue8m0_to_int: scale values must have zero mantissa"
     return (x_int >> 23).to(torch.uint8).view(torch.int)
 
 

--- a/deep_gemm/utils/math.py
+++ b/deep_gemm/utils/math.py
@@ -32,12 +32,11 @@ def pack_ue8m0_to_int(x: torch.Tensor):
     """
     assert x.dtype == torch.float and x.size(-1) % 4 == 0
     x_int = x.view(torch.int)
-    if not torch.cuda.is_current_stream_capturing():
+    if not (x.is_cuda and torch.cuda.is_current_stream_capturing()):
         # Bit-level check: sign bit == 0, mantissa bits == 0.
         # (float round-based checks fail for subnormals like 2^-126.)
-        x_bits = x.view(torch.int)
-        assert ((x_bits >> 31) == 0).all(), "pack_ue8m0_to_int: scale values must be non-negative"
-        assert ((x_bits & 0x7FFFFF) == 0).all(), "pack_ue8m0_to_int: scale values must have zero mantissa"
+        assert ((x_int >> 31) == 0).all(), "pack_ue8m0_to_int: scale values must be non-negative"
+        assert ((x_int & 0x7FFFFF) == 0).all(), "pack_ue8m0_to_int: scale values must have zero mantissa"
     return (x_int >> 23).to(torch.uint8).view(torch.int)
 
 

--- a/deep_gemm/utils/math.py
+++ b/deep_gemm/utils/math.py
@@ -17,9 +17,19 @@ def ceil_to_ue8m0(x: torch.Tensor):
 
 
 def pack_ue8m0_to_int(x: torch.Tensor):
+    # NOTE: keep this helper CUDA-graph-capture safe. Calling `.all()` on a
+    # device tensor forces a device->host sync, which raises
+    # cudaErrorStreamCaptureUnsupported when invoked inside a captured region
+    # (e.g. SGLang's decode graph via the MegaMoE FP8 staging path).
+    #
+    # Host-side structural checks only:
     assert x.dtype == torch.float and x.size(-1) % 4 == 0
     x_int = x.view(torch.int)
-    assert (x_int >= 0).all() and (x_int & 0x7fffff == 0).all()
+    # The value invariants (non-negative exponent, zero mantissa) are guaranteed
+    # by `ceil_to_ue8m0`, the only producer of these scale factors, so we must
+    # NOT re-check them here on device. The kernel itself traps on malformed
+    # scales, so a bad upstream caller still fails loudly, just not on the
+    # capture path.
     return (x_int >> 23).to(torch.uint8).view(torch.int)
 
 

--- a/tests/test_pack_ue8m0.py
+++ b/tests/test_pack_ue8m0.py
@@ -1,0 +1,57 @@
+import random
+import torch
+
+from deep_gemm.utils import pack_ue8m0_to_int
+
+
+def generate_ue8m0(m: int, n: int) -> torch.Tensor:
+    # Positive powers of two: the sign bit and all mantissa bits are zero
+    return torch.pow(2.0, torch.randint(-8, 9, (m, n), device='cuda').float())
+
+
+def test_cuda_graph_capture() -> None:
+    print('Testing CUDA graph capture/replay:')
+    x_0, x_1 = generate_ue8m0(128, 32), generate_ue8m0(128, 32)
+    eager_y_0, eager_y_1 = pack_ue8m0_to_int(x_0), pack_ue8m0_to_int(x_1)
+    torch.cuda.synchronize()
+
+    # NOTES: the eager calls above also serve as the pre-capture warm-up
+    static_x = x_0.clone()
+    g = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(g):
+        captured_y = pack_ue8m0_to_int(static_x)
+    g.replay()
+    torch.cuda.synchronize()
+    assert torch.equal(captured_y, eager_y_0)
+    print(' > Capture/replay matches eager (bit-exact)')
+
+    # Replay must recompute from the mutated static input, not expose stale capture-time data
+    static_x.copy_(x_1)
+    g.replay()
+    torch.cuda.synchronize()
+    assert torch.equal(captured_y, eager_y_1)
+    print(' > Replay after static-input mutation matches eager (bit-exact)')
+    print()
+
+
+def test_eager_validation() -> None:
+    print('Testing eager malformed-input rejection:')
+    for name, bad_value in (('nonzero mantissa', 1.5), ('negative sign', -2.0)):
+        x = generate_ue8m0(128, 32)
+        x[0, 0] = bad_value
+        raised = False
+        try:
+            pack_ue8m0_to_int(x)
+        except AssertionError:
+            raised = True
+        assert raised, f'Malformed input ({name}) must still be rejected in eager execution'
+        print(f' > AssertionError raised as expected ({name})')
+    print()
+
+
+if __name__ == '__main__':
+    torch.manual_seed(0)
+    random.seed(0)
+
+    test_cuda_graph_capture()
+    test_eager_validation()


### PR DESCRIPTION
## Problem

`pack_ue8m0_to_int` called `.all()` on device tensors:

```python
assert (x.view(torch.int) >> 23 >= 0).all()  # device→host sync!
assert (x.view(torch.int) & 0x7FFFFF == 0).all()  # device→host sync!
```

Inside a CUDA graph capture region, `.all()` triggers a device→host sync which raises `cudaErrorStreamCaptureUnsupported`, breaking SGLang's decode graph via the MegaMoE FP8 staging path (issue #414).

## Fix

Use `torch.cuda.is_current_stream_capturing()` to gate validation:

- **Outside capture**: bit-level assertions run, catching non-negative sign bit and zero mantissa — direct callers get a loud error on bad input
- **Inside capture**: assertions skipped — no device→host sync, capture-safe

Bit-level check avoids float rounding edge cases (e.g. subnormals like 2^-126 that `x.round()` would incorrectly round to 0).

```python
if not torch.cuda.is_current_stream_capturing():
    x_bits = x.view(torch.int)
    assert ((x_bits >> 31) == 0).all(), "scale values must be non-negative"
    assert ((x_bits & 0x7FFFFF) == 0).all(), "scale values must have zero mantissa"
```

## Test (H200, CUDA 12.8)

| Case | Result |
|------|--------|
| Valid ue8m0 from `ceil_to_ue8m0` | ✅ PASS |
| Non-ue8m0 input (mantissa set) | ✅ assert fires |
| Negative input | ✅ assert fires |
| Padding value 1.0 (valid ue8m0) | ✅ PASS |
| CUDA graph capture + invalid input | ✅ no assert, no sync |
| CUDA graph capture + valid input | ✅ replay works |

Addresses ds-review-bot v6 concern: validation is preserved outside capture paths.