### PR TITLE
fix: port the #343 tensormap drain to the SM120 k_grouped NT contiguous kernel

### DIFF
--- a/deep_gemm/include/deep_gemm/impls/sm120_fp8_fp4_gemm_1d1d.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm120_fp8_fp4_gemm_1d1d.cuh
@@ -273,6 +273,13 @@ sm120_fp8_fp4_gemm_1d1d_impl(cd_dtype_t* gmem_d, const cd_dtype_t* gmem_c,
                                 smem_tm_b, scheduler.current_shape_k, b_new_stride);
                         }
 
+                        // Make sure the tensor maps are not used by in-flight TMA loads before updating GMEM
+                        cute::tma_desc_commit_group();
+                        cute::tma_desc_wait_group();
+                        // Only used to prevent `ptxas` from moving the following GMEM stores before `cute::tma_desc_wait_group()`.
+                        // Shouldn't be needed otherwise, since we only use one thread
+                        __syncwarp(1u << lane_idx);
+
                         *gmem_tm_a = *smem_tm_a;
                         *gmem_tm_b = *smem_tm_b;
                         ptx::tensor_map_release_gpu();


### PR DESCRIPTION
Fixes #430.

The SM120 1D1D kernel (`sm120_fp8_fp4_gemm_1d1d.cuh`, introduced in #324) was copied from `sm90_fp8_gemm_1d1d.cuh` twelve days before #343 fixed the in-flight tensormap race there. Since the copy lives at a different file path, the #343 fix never reached it. This ports the same drain to the SM120 group-switch path so that in-flight TMA loads complete before the grouped tensormaps are published to GMEM.

Validation on RTX 5090 D (SM120, CUDA 13.0, PyTorch 2.11.0+cu130, nv_dev @ 2642b32):

- Before: `test_k_grouped_gemm_contiguous` fails at the first shape in 13/14 runs; diff 0.0015–0.006, non-deterministic on identical inputs
- After: diff **0.000105, bit-identical across runs**; full k_grouped + m_grouped suites pass; 100× soak clean
- Perf A/B (same seeds/data): +0.9% on the sentinel shape (worst-case group-switch density), +0.26% on typical EP shapes — the same trade-off SM90 accepted in #343

Note on `__syncwarp`: same construct as the merged SM90 fix — for the prior discussion of its validity see #343.

`sm120_bf16_gemm.cuh` has the same un-drained pattern, but we could not reproduce failures there (full suite + 50 targeted stress runs pass), so this PR leaves it alone — details in the linked issue.

Evidence and raw logs: https://gist.github.com/aganhui/3b374ffb3d6d13b52d5688780fafac28
