### PR TITLE
fix: derive the SM120 fp8 mqa_logits swizzle mode from head_dim

### DIFF
--- a/deep_gemm/include/deep_gemm/impls/sm120_fp8_mqa_logits.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm120_fp8_mqa_logits.cuh
@@ -58,7 +58,12 @@ void sm120_fp8_mqa_logits(const uint32_t seq_len, const uint32_t seq_len_kv,
     DG_STATIC_ASSERT(BLOCK_KV == kNumMathWarps * MMA_M, "BLOCK_KV = warps × MMA_M");
     DG_STATIC_ASSERT(kHeadDim % MMA_K == 0 and kNumHeads % MMA_N == 0, "Alignment");
 
-    static constexpr uint32_t kSwizzleMode = 128;
+    // Must match the host-side TMA descriptors (swizzle_mode = head_dim bytes) and
+    // the `tma::copy<..., kHeadDim>` smem layout: the fp8 row is head_dim bytes, so
+    // the TMA writes are swizzled in head_dim-byte atoms (32B/64B/128B for D=32/64/128).
+    // A hardcoded 128 here only matches D=128; for D=32/64 the readers would un-swizzle
+    // with the wrong pattern and consume out-of-tile shared memory.
+    static constexpr uint32_t kSwizzleMode = kHeadDim;
     static constexpr uint32_t kSwizzleAlignment = kHeadDim * 8;
     static constexpr uint32_t kSMEMKBytes = kHeadDim;
 

--- a/deep_gemm/include/deep_gemm/impls/sm120_fp8_mqa_logits.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm120_fp8_mqa_logits.cuh
@@ -64,6 +64,8 @@ void sm120_fp8_mqa_logits(const uint32_t seq_len, const uint32_t seq_len_kv,
     // A hardcoded 128 here only matches D=128; for D=32/64 the readers would un-swizzle
     // with the wrong pattern and consume out-of-tile shared memory.
     static constexpr uint32_t kSwizzleMode = kHeadDim;
+    DG_STATIC_ASSERT(kHeadDim == 32 or kHeadDim == 64 or kHeadDim == 128,
+                     "kSwizzleMode must stay within the hardware swizzle modes");
     static constexpr uint32_t kSwizzleAlignment = kHeadDim * 8;
     static constexpr uint32_t kSMEMKBytes = kHeadDim;
 

--- a/deep_gemm/include/deep_gemm/impls/sm120_fp8_paged_mqa_logits.cuh
+++ b/deep_gemm/include/deep_gemm/impls/sm120_fp8_paged_mqa_logits.cuh
@@ -53,7 +53,12 @@ void sm120_fp8_paged_mqa_logits(const uint32_t batch_size,
     static constexpr uint32_t kNumMathWarps = kNumMathThreads / 32;
     static constexpr uint32_t kWarpsPerGroup = BLOCK_KV / MMA_M;
     static constexpr uint32_t kNumGroups = kNumMathWarps / kWarpsPerGroup;
-    static constexpr uint32_t kSwizzleMode = 128;
+    // Must match the host-side TMA descriptors (swizzle_mode = head_dim bytes) and the
+    // `tma::copy<..., kHeadDim>` smem layout: the fp8 row is head_dim bytes, so the TMA
+    // writes are swizzled in head_dim-byte atoms (32B/64B/128B for D=32/64/128).
+    static constexpr uint32_t kSwizzleMode = kHeadDim;
+    DG_STATIC_ASSERT(kHeadDim == 32 or kHeadDim == 64 or kHeadDim == 128,
+                     "kSwizzleMode must stay within the hardware swizzle modes");
     static constexpr uint32_t kSMEMKBytes = kHeadDim;
 
     DG_STATIC_ASSERT(kNumTMAThreads == 128, "Expected 128 TMA threads");


### PR DESCRIPTION
Fixes #433.

The SM120 fp8 MQA-logits readers un-swizzle shared memory with a hardcoded 128-byte pattern, while the host TMA descriptors and the `tma::copy` sites swizzle in head_dim-byte atoms (32B/64B/128B for D=32/64/128 — the fp8 row is head_dim bytes). For head_dim 32/64 the XOR bits don't match the write pattern, fragment loads address outside their row, and the kernel returns in-window logits that are silently wrong. D=128 is the only head_dim where the hardcoded value matches, which is why the main DSA path works.

This derives the mode from `kHeadDim`, matching the sibling kernels: SM90 (`to_swizzle_cute_type<kHeadDim>()`) and SM100 (`kHeadDim / kPackFactor`).

**Both fp8 variants are fixed** (second commit, addressing the review finding): the fp8 paged dispatch has no `head_dim == 128` restriction — only its fp4 sibling does — so the paged kernel had the same mismatch. Notably, in the paged variant the resulting garbage is *deterministic* (misreads land on deterministically-stale shared memory), so self-consistency passes and only the accuracy comparison against the reference exposes it.

Validation on RTX 5090 D (CUDA 13.0, PyTorch 2.11.0+cu130, nv_dev @ 2642b32):

- Dense, 384-config self-consistency scan: **189 failures → 0** (all failures were fp8 with D ∈ {32, 64}; zero at D=128, zero mxfp4)
- Dense, full `test_mqa_logits` (20x bitwise + accuracy vs reference + bench): **PASSED**, all 384 configs, fp8 up to 411 TFLOPS
- Paged, targeted fp8 repro (small configs; the full paged suite does not fit in 32 GB): accuracy diff vs reference **D=32: 0.83 → 0.0008, D=64: 0.72 → 0.001**, D=128 unchanged (~0.001)
- Dense regression after adding the static asserts: fp8 D=32 accuracy diff 0.0006 (< 1e-3)

Also adds `DG_STATIC_ASSERT(kHeadDim ∈ {32, 64, 128})` next to the derived constants (per review suggestion), so a future dispatch widening cannot silently instantiate an invalid `CuTeSwizzle`.

Unaffected kernels (verified): dense fp4 and both fp4 paged variants are head_dim-128-only (`DG_HOST_ASSERT`/`DG_STATIC_ASSERT`), where their constants already match. Dense fp8 and fp8 paged are the only instantiations whose dispatches allow multiple row widths, and both are now derived.

Scan script and raw logs: https://gist.github.com/aganhui/f783450b212217284c062c3b46300649
